### PR TITLE
ci: switch from Renovate to Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    cooldown:
+      default-days: 7

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
-}


### PR DESCRIPTION
Replace `renovate.json` with `dependabot.yaml` for GitHub Actions dependency updates.

- Adds `.github/dependabot.yaml` with `github-actions` ecosystem, daily schedule, 7-day cooldown
- Removes `.github/renovate.json`
- Matches the KSail Dependabot convention