### PR TITLE
feat: add upsert-issue composite action

### DIFF
--- a/.github/workflows/test-upsert-issue.yaml
+++ b/.github/workflows/test-upsert-issue.yaml
@@ -1,0 +1,87 @@
+name: 🧪 upsert-issue
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  test-upsert-issue-create:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: 🧪 Create or update an issue
+        id: upsert
+        uses: ./upsert-issue
+        with:
+          title: "[test] upsert-issue smoke test"
+          body: |
+            This issue is created by the `upsert-issue` test workflow.
+            Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify outputs
+        env:
+          ISSUE_NUMBER: ${{ steps.upsert.outputs.issue-number }}
+          ISSUE_URL: ${{ steps.upsert.outputs.issue-url }}
+        run: |
+          if [ -z "$ISSUE_NUMBER" ]; then
+            echo "::error::issue-number output is empty"
+            exit 1
+          fi
+          echo "Issue: $ISSUE_URL"
+
+  test-upsert-issue-close:
+    needs: [test-upsert-issue-create]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: 🧪 Close the issue
+        uses: ./upsert-issue
+        with:
+          title: "[test] upsert-issue smoke test"
+          body: "Closed by test."
+          open: "false"
+          close-comment: "🧪 Closed by test workflow."
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  status-check:
+    if: ${{ !cancelled() }}
+    needs: [test-upsert-issue-create, test-upsert-issue-close]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+
+      - name: Check status
+        env:
+          CREATE_RESULT: ${{ needs.test-upsert-issue-create.result }}
+          CLOSE_RESULT: ${{ needs.test-upsert-issue-close.result }}
+        run: |
+          if [[ "$CREATE_RESULT" == "failure" || "$CLOSE_RESULT" == "failure" ]]; then
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ flowchart TD
 | [setup-go-toolchain](setup-go-toolchain/README.md) | Setup Go with optional private module support |
 | [setup-ksail-cli](setup-ksail-cli/README.md) | Install KSail CLI via Homebrew |
 | [sync-github-labels](sync-github-labels/README.md) | Sync GitHub labels from a configuration file |
+| [upsert-issue](upsert-issue/README.md) | Create, update, reopen, or close a GitHub issue by title |
 
 ## Contributing
 

--- a/upsert-issue/README.md
+++ b/upsert-issue/README.md
@@ -1,0 +1,61 @@
+# Upsert Issue
+
+Create, update, reopen, or close a GitHub issue by title. Finds an existing issue with the same title and updates it, or creates a new one. Supports controlling the issue state (`open` / `closed`) to manage issue lifecycle — e.g., auto-closing when a report has no violations and reopening when violations recur.
+
+## Inputs
+
+| Name | Description | Required | Default |
+|------|-------------|----------|---------|
+| `title` | Title of the issue to create or update | ✅ | — |
+| `body` | Body content of the issue | ❌ | — |
+| `body-file` | Path to a file containing the body content (takes precedence over `body`) | ❌ | — |
+| `labels` | Comma-separated list of labels to assign | ❌ | — |
+| `open` | Whether the issue should be open (`true`) or closed (`false`) | ❌ | `true` |
+| `close-comment` | Comment to post when closing the issue | ❌ | `✅ Resolved — closing this issue.` |
+| `repository` | Target repository (`owner/repo`) | ❌ | `${{ github.repository }}` |
+| `github-token` | GitHub token with `issues: write` permission | ❌ | `${{ github.token }}` |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `issue-number` | The number of the created or updated issue |
+| `issue-url` | The URL of the created or updated issue |
+
+## Usage
+
+### Create or update an issue
+
+```yaml
+steps:
+  - uses: devantler-tech/actions/upsert-issue@main
+    with:
+      title: "[report] My Report"
+      body-file: report.md
+```
+
+### Close an issue when resolved
+
+```yaml
+steps:
+  - uses: devantler-tech/actions/upsert-issue@main
+    with:
+      title: "[report] My Report"
+      body: "No violations found."
+      open: "false"
+      close-comment: "✅ All violations have been resolved."
+```
+
+### Conditional open/close based on a previous step
+
+```yaml
+steps:
+  - id: report
+    run: bun run report:my-report
+
+  - uses: devantler-tech/actions/upsert-issue@main
+    with:
+      title: "[report] My Report"
+      body-file: ${{ steps.report.outputs.report-path }}
+      open: ${{ steps.report.outputs.has-violations }}
+```

--- a/upsert-issue/action.yaml
+++ b/upsert-issue/action.yaml
@@ -1,0 +1,125 @@
+name: Upsert Issue
+description: Create, update, reopen, or close a GitHub issue by title. Useful for surfacing report data or recurring checks as issues.
+author: devantler-tech
+
+inputs:
+  title:
+    description: "Title of the issue to create or update"
+    required: true
+  body:
+    description: "Body content of the issue"
+    required: false
+  body-file:
+    description: "Path to a file containing the body content. Takes precedence over body."
+    required: false
+  labels:
+    description: "Comma-separated list of labels to assign to the issue"
+    required: false
+  open:
+    description: "Whether the issue should be open (true) or closed (false)"
+    required: false
+    default: "true"
+  close-comment:
+    description: "Comment to post when closing the issue. Only used when open is false."
+    required: false
+    default: "✅ Resolved — closing this issue."
+  repository:
+    description: "Repository to create/update the issue in (format: owner/repo). Defaults to the current repository."
+    required: false
+    default: ${{ github.repository }}
+  github-token:
+    description: "GitHub token with issues write permission"
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  issue-number:
+    description: "The number of the created or updated issue"
+    value: ${{ steps.upsert.outputs.issue-number }}
+  issue-url:
+    description: "The URL of the created or updated issue"
+    value: ${{ steps.upsert.outputs.issue-url }}
+
+runs:
+  using: composite
+  steps:
+    - id: upsert
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        TITLE: ${{ inputs.title }}
+        BODY: ${{ inputs.body }}
+        BODY_FILE: ${{ inputs.body-file }}
+        LABELS: ${{ inputs.labels }}
+        OPEN: ${{ inputs.open }}
+        CLOSE_COMMENT: ${{ inputs.close-comment }}
+        REPO: ${{ inputs.repository }}
+      run: |
+        set -euo pipefail
+
+        # Resolve body content
+        if [ -n "$BODY_FILE" ]; then
+          BODY=$(cat "$BODY_FILE")
+        fi
+
+        if [ -z "${BODY:-}" ]; then
+          echo "::error::Either 'body' or 'body-file' input must be provided"
+          exit 1
+        fi
+
+        # Search for existing issue by exact title (any state).
+        # Prefer an open issue; fall back to the most recent closed one.
+        ISSUE_NUMBER=$(
+          gh issue list \
+            --repo "$REPO" \
+            --state all \
+            --search "in:title \"${TITLE}\"" \
+            --json number,title,state \
+            --jq "
+              [ .[] | select(.title == \"${TITLE}\") ] |
+              ([ .[] | select(.state == \"OPEN\") ] | first // empty) as \$open |
+              if \$open then \$open.number
+              else (last // empty | .number)
+              end
+            "
+        )
+
+        if [ "$OPEN" = "true" ]; then
+          if [ -n "$ISSUE_NUMBER" ]; then
+            echo "Updating issue #${ISSUE_NUMBER} and ensuring it is open"
+            gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --body "$BODY"
+            if [ -n "$LABELS" ]; then
+              gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "$LABELS"
+            fi
+            gh issue reopen "$ISSUE_NUMBER" --repo "$REPO" 2>/dev/null || true
+          else
+            echo "Creating new issue"
+            CREATE_ARGS=(--repo "$REPO" --title "$TITLE" --body "$BODY")
+            if [ -n "$LABELS" ]; then
+              CREATE_ARGS+=(--label "$LABELS")
+            fi
+            ISSUE_URL=$(gh issue create "${CREATE_ARGS[@]}")
+            ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')
+          fi
+        else
+          if [ -n "$ISSUE_NUMBER" ]; then
+            ISSUE_STATE=$(
+              gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json state --jq .state
+            )
+            if [ "$ISSUE_STATE" = "OPEN" ]; then
+              echo "Closing issue #${ISSUE_NUMBER}"
+              gh issue close "$ISSUE_NUMBER" --repo "$REPO" --comment "$CLOSE_COMMENT"
+            else
+              echo "Issue #${ISSUE_NUMBER} is already closed — nothing to do"
+            fi
+          else
+            echo "No existing issue found — nothing to do"
+          fi
+        fi
+
+        if [ -n "${ISSUE_NUMBER:-}" ]; then
+          ISSUE_URL="https://github.com/${REPO}/issues/${ISSUE_NUMBER}"
+          echo "issue-number=${ISSUE_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "issue-url=${ISSUE_URL}" >> "$GITHUB_OUTPUT"
+          echo "Result: ${ISSUE_URL}"
+        fi


### PR DESCRIPTION
## Summary

Adds a reusable `upsert-issue` composite action that manages the full lifecycle of a GitHub issue by title:

- **`open=true`**: Creates a new issue or updates + reopens an existing one
- **`open=false`**: Closes an existing open issue with a comment, or does nothing

### Files

- `upsert-issue/action. Composite action using `gh` CLIyaml` 
- `upsert-issue/README. Documentation with usage examplesmd` 
- `.github/workflows/test-upsert-issue. Test workflow (create + close)yaml` 
- `README. Updated actions tablemd` 

### Motivation

The `devantler-tech/maintenance` repo needs to manage report issues based on whether violations were found. This generic action can be used by any workflow that needs to create-or-update issues based on dynamic conditions.

Inspired by [dvt-engineering's upsert-issue](https://github.com/dvt-engineering/github/tree/main/actions/actions/upsert-issue), implemented as a composite action per [CONTRIBUTING.md](https://github.com/devantler-tech/actions/blob/main/CONTRIBUTING.md) conventions.