### PR TITLE
refactor: split enable-auto-merge-on-pr into approve-pr and enable-auto-merge-on-pr

### DIFF
--- a/.github/workflows/test-approve-pr.yaml
+++ b/.github/workflows/test-approve-pr.yaml
@@ -1,4 +1,4 @@
-name: 🧪 enable-auto-merge-on-pr
+name: 🧪 approve-pr
 on:
   pull_request:
 
@@ -7,7 +7,7 @@ permissions:
   contents: write
 
 jobs:
-  test-enable-auto-merge-on-pr:
+  test-approve-pr:
     runs-on: ubuntu-latest
     if: startsWith(github.event_name, 'pull_request') && (github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'botantler[bot]' || github.event.pull_request.user.login == 'devantler')
     steps:
@@ -21,14 +21,16 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: 🧪 Run enable-auto-merge-on-pr
-        uses: ./enable-auto-merge-on-pr
+      - name: 🧪 Run approve-pr
+        uses: ./approve-pr
         with:
+          app-id: ${{ vars.APP_ID }}
+          app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
           pr-number: ${{ github.event.pull_request.number }}
 
   status-check:
     if: ${{ !cancelled() }}
-    needs: [test-enable-auto-merge-on-pr]
+    needs: [test-approve-pr]
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -38,7 +40,7 @@ jobs:
 
       - name: Check status
         env:
-          RESULT: ${{ needs.test-enable-auto-merge-on-pr.result }}
+          RESULT: ${{ needs.test-approve-pr.result }}
         run: |
           if [[ "$RESULT" == "failure" ]]; then
             exit 1

--- a/README.md
+++ b/README.md
@@ -26,9 +26,10 @@ flowchart TD
 
 | Action | Description |
 |--------|-------------|
+| [approve-pr](approve-pr/README.md) | Approve a PR using a GitHub App identity |
 | [cleanup-ghcr-packages](cleanup-ghcr-packages/README.md) | Clean up old GHCR packages |
 | [create-issues-from-todos](create-issues-from-todos/README.md) | Create GitHub issues from TODO comments |
-| [enable-auto-merge-on-pr](enable-auto-merge-on-pr/README.md) | Approve and auto-merge PRs from trusted bots/users |
+| [enable-auto-merge-on-pr](enable-auto-merge-on-pr/README.md) | Enable auto-merge on a pull request |
 | [login-to-ghcr](login-to-ghcr/README.md) | Login to GitHub Container Registry |
 | [run-dotnet-tests](run-dotnet-tests/README.md) | Test .NET solution or project with coverage |
 | [setup-go-toolchain](setup-go-toolchain/README.md) | Setup Go with optional private module support |

--- a/approve-pr/README.md
+++ b/approve-pr/README.md
@@ -1,0 +1,43 @@
+# Approve PR
+
+Approve a pull request using a GitHub App identity. This is needed because `GITHUB_TOKEN` cannot provide independent approvals that satisfy branch protection rules requiring multiple reviewers.
+
+## Inputs
+
+| Name | Description | Required | Default |
+|------|-------------|----------|---------|
+| `app-id` | GitHub App ID | ✅ | - |
+| `app-private-key` | GitHub App Private Key | ✅ | - |
+| `pr-number` | Pull request number to approve | ✅ | - |
+| `dry-run` | Validate only; do not approve the pull request | - | `false` |
+
+## Usage
+
+### Approve a PR from a trusted bot
+
+```yaml
+steps:
+  - name: Approve PR
+    uses: devantler-tech/actions/approve-pr@main
+    with:
+      app-id: ${{ vars.APP_ID }}
+      app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      pr-number: ${{ github.event.pull_request.number }}
+```
+
+### Combined with auto-merge
+
+```yaml
+steps:
+  - name: Approve PR
+    uses: devantler-tech/actions/approve-pr@main
+    with:
+      app-id: ${{ vars.APP_ID }}
+      app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      pr-number: ${{ github.event.pull_request.number }}
+
+  - name: Enable auto-merge
+    uses: devantler-tech/actions/enable-auto-merge-on-pr@main
+    with:
+      pr-number: ${{ github.event.pull_request.number }}
+```

--- a/approve-pr/action.yaml
+++ b/approve-pr/action.yaml
@@ -1,0 +1,48 @@
+name: Approve PR
+description: Approve a pull request using a GitHub App identity
+author: devantler-tech
+
+inputs:
+  app-id:
+    description: GitHub App ID
+    required: true
+  app-private-key:
+    description: GitHub App Private Key
+    required: true
+  pr-number:
+    description: Pull request number to approve
+    required: true
+  dry-run:
+    description: Validate only; do not approve the pull request
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: 🔑 Generate GitHub App Token
+      if: inputs.dry-run != 'true'
+      uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+      id: app-token
+      with:
+        app-id: ${{ inputs.app-id }}
+        private-key: ${{ inputs.app-private-key }}
+
+    - name: ✅ Approve pull request
+      if: inputs.dry-run != 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+        REPOSITORY: ${{ github.repository }}
+      run: |
+        gh pr review "$PR_NUMBER" --approve --repo "$REPOSITORY"
+        echo "✅ PR #${PR_NUMBER} approved"
+
+    - name: 🔎 Dry-run notice
+      if: inputs.dry-run == 'true'
+      shell: bash
+      env:
+        PR_NUMBER: ${{ inputs.pr-number }}
+      run: |
+        echo "::notice::Dry-run enabled — PR #${PR_NUMBER} was not approved"

--- a/enable-auto-merge-on-pr/README.md
+++ b/enable-auto-merge-on-pr/README.md
@@ -1,14 +1,17 @@
 # Enable Auto Merge on PR
 
-Approve and auto-merge PRs from specific bots/users. Generates an authenticated token using GitHub App credentials, approves the pull request, and enables auto-merge with squash strategy.
+Enable auto-merge on a pull request using GitHub CLI. The PR will only merge automatically once all required status checks pass and branch protection rules are satisfied.
+
+- **Auto-merge must be enabled** on the repository (Settings > Pull Requests > Allow auto-merge). If not enabled, a warning is displayed but the action does not fail.
+- Supports `merge`, `squash`, and `rebase` merge methods.
 
 ## Inputs
 
 | Name | Description | Required | Default |
 |------|-------------|----------|---------|
-| `app-id` | GitHub App ID | ✅ | - |
-| `app-private-key` | GitHub App Private Key | ✅ | - |
-| `github-token` | GitHub Token | ✅ | - |
+| `pr-number` | Pull request number to enable auto-merge on | ✅ | - |
+| `merge-method` | Merge method to use: `merge`, `squash`, or `rebase` | - | `squash` |
+| `dry-run` | Validate only; do not enable auto-merge | - | `false` |
 
 ## Usage
 
@@ -17,7 +20,8 @@ steps:
   - name: Enable auto-merge
     uses: devantler-tech/actions/enable-auto-merge-on-pr@main
     with:
-      app-id: ${{ vars.APP_ID }}
-      app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
-      github-token: ${{ secrets.GITHUB_TOKEN }}
+      pr-number: ${{ github.event.pull_request.number }}
+      merge-method: squash
 ```
+
+> **Note:** This action uses `github.token` from context for authentication. Ensure the job has `contents: write` and `pull-requests: write` permissions.

--- a/enable-auto-merge-on-pr/action.yaml
+++ b/enable-auto-merge-on-pr/action.yaml
@@ -1,34 +1,58 @@
 name: Enable Auto Merge on PR
-description: Approve and auto-merge PRs from specific bots/users
+description: Enable auto-merge on a pull request using GitHub CLI
 author: devantler-tech
+
 inputs:
-  app-id:
-    description: GitHub App ID
+  pr-number:
+    description: Pull request number to enable auto-merge on
     required: true
-  app-private-key:
-    description: GitHub App Private Key
-    required: true
-  github-token:
-    description: GitHub Token
-    required: true
+  merge-method:
+    description: "Merge method to use: merge, squash, or rebase"
+    required: false
+    default: "squash"
+  dry-run:
+    description: Validate only; do not enable auto-merge
+    required: false
+    default: "false"
 
 runs:
   using: composite
   steps:
-    - name: 🔑 Generate GitHub App Token
-      uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
-      id: app-token
-      with:
-        app-id: ${{ inputs.app-id }}
-        private-key: ${{ inputs.app-private-key }}
+    - name: 🔍 Check if auto-merge is enabled on repository
+      id: check-auto-merge
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        REPOSITORY: ${{ github.repository }}
+      run: |
+        REPO_INFO=$(gh api "repos/$REPOSITORY" --jq '.allow_auto_merge')
+        echo "auto-merge-enabled=${REPO_INFO}" >> "$GITHUB_OUTPUT"
 
-    - name: ✅ Approve pull request
-      uses: step-security/auto-approve-action@0c28339628c8e79ab2f6813291e7e6cd584b4d30 # v4.0.0
-      with:
-        github-token: ${{ inputs.github-token }}
+        if [[ "$REPO_INFO" != "true" ]]; then
+          echo "::warning::Auto-merge is not enabled on this repository. Contact a repository admin to enable it in Settings > Pull Requests > Allow auto-merge."
+        fi
 
     - name: 🤖 Enable auto-merge
+      if: steps.check-auto-merge.outputs.auto-merge-enabled == 'true' && inputs.dry-run != 'true'
       shell: bash
-      run: gh pr merge --auto --squash ${{ github.event.number }}
       env:
-        GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        GH_TOKEN: ${{ github.token }}
+        MERGE_METHOD: ${{ inputs.merge-method }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+        REPOSITORY: ${{ github.repository }}
+      run: |
+        if [[ ! "$MERGE_METHOD" =~ ^(merge|squash|rebase)$ ]]; then
+          echo "::error::Invalid merge method '${MERGE_METHOD}'. Must be 'merge', 'squash', or 'rebase'."
+          exit 1
+        fi
+
+        gh pr merge "$PR_NUMBER" --auto --"$MERGE_METHOD" --repo "$REPOSITORY"
+        echo "✅ Auto-merge enabled for PR #${PR_NUMBER} using ${MERGE_METHOD} method"
+
+    - name: 🔎 Dry-run notice
+      if: inputs.dry-run == 'true'
+      shell: bash
+      env:
+        PR_NUMBER: ${{ inputs.pr-number }}
+      run: |
+        echo "::notice::Dry-run enabled — auto-merge was not enabled on PR #${PR_NUMBER}"


### PR DESCRIPTION
Split the combined `enable-auto-merge-on-pr` action into two focused, single-responsibility actions:

- **`enable-auto-merge-on-pr`** — Only enables auto-merge. Uses `github.token` from context. Adds `pr-number`, `merge-method`, and `dry-run` inputs. Validates repo auto-merge settings.
- **`approve-pr`** — New action that approves a PR using a GitHub App identity via `actions/create-github-app-token` and `gh pr review --approve`.

## Type of change

- [x] 🧹 Refactor
- [x] 🚀 New feature
- [x] ⛓️‍💥 Breaking change