### PR TITLE
fix: rename secret key to match reusable workflow definition

### DIFF
--- a/.github/workflows/active-release.yaml
+++ b/.github/workflows/active-release.yaml
@@ -12,4 +12,4 @@ jobs:
   release:
     uses: devantler-tech/reusable-workflows/.github/workflows/create-release.yaml@main
     secrets:
-      app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Description

The caller workflow passed the secret as `app-private-key` (kebab-case), but the reusable workflow [`create-release.yaml`](https://github.com/devantler-tech/reusable-workflows/blob/main/.github/workflows/create-release.yaml) defines it as `APP_PRIVATE_KEY` (uppercase with underscores). The key in the `secrets:` block must match exactly.

## Changes

- Renamed `app-private-key` → `APP_PRIVATE_KEY` in `.github/workflows/active-release.yaml`