### PR TITLE
fix: update active-release workflow to use kebab-case secret name

### DIFF
--- a/.github/workflows/active-release.yaml
+++ b/.github/workflows/active-release.yaml
@@ -10,6 +10,6 @@ permissions: {}
 
 jobs:
   release:
-    uses: devantler-tech/reusable-workflows/.github/workflows/create-release.yaml@main
+    uses: devantler-tech/reusable-workflows/.github/workflows/create-release.yaml@e195335519da551c6d74e12b197159ed5484ff15 # devantler/refactor-secrets-to-kebab-case
     secrets:
-      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      app-private-key: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Update the `active-release.yaml` workflow to pass `app-private-key` (kebab-case) instead of `APP_PRIVATE_KEY` to the reusable `create-release` workflow, and pin the SHA ref to the commit from devantler-tech/reusable-workflows#193 that introduces this change.

## Changes

- Renamed secret `APP_PRIVATE_KEY` → `app-private-key` in the reusable workflow call
- Pinned `devantler-tech/reusable-workflows` ref from `@main` to `@e195335519da551c6d74e12b197159ed5484ff15`

## Dependencies

> [!IMPORTANT]
> This PR depends on devantler-tech/reusable-workflows#193 being merged first. The SHA ref points to that PR's head commit.