### PR TITLE
refactor: rename secret inputs to kebab-case

### DIFF
--- a/.github/workflows/active-release.yaml
+++ b/.github/workflows/active-release.yaml
@@ -10,6 +10,6 @@ permissions: {}
 
 jobs:
   release:
-    uses: devantler-tech/reusable-workflows/.github/workflows/create-release.yaml@main
+    uses: devantler-tech/reusable-workflows/.github/workflows/create-release.yaml@9ec9792d6c140612f6b5bafa5dc786e751b5ff1a # v2.2.0
     secrets:
-      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      app-private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/test-login-to-ghcr.yaml
+++ b/.github/workflows/test-login-to-ghcr.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: 🧪 Run login-to-ghcr
         uses: ./login-to-ghcr
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: ✅ Verify GHCR login
         run: cat ~/.docker/config.json | grep -q "ghcr.io"

--- a/.github/workflows/test-setup-go-toolchain.yaml
+++ b/.github/workflows/test-setup-go-toolchain.yaml
@@ -62,7 +62,7 @@ jobs:
       - name: 🧪 Run setup-go-toolchain with token
         uses: ./setup-go-toolchain
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: ✅ Verify GOPRIVATE is set
         shell: bash

--- a/login-to-ghcr/README.md
+++ b/login-to-ghcr/README.md
@@ -6,7 +6,7 @@ Login to GitHub Container Registry (GHCR) for pulling or pushing container image
 
 | Name | Description | Required | Default |
 |------|-------------|----------|---------|
-| `token` | GitHub token with `packages:read` (or `packages:write`) scope | ✅ | - |
+| `github-token` | GitHub token with `packages:read` (or `packages:write`) scope | ✅ | - |
 
 ## Usage
 
@@ -15,5 +15,5 @@ steps:
   - name: Login to GHCR
     uses: devantler-tech/actions/login-to-ghcr@main
     with:
-      token: ${{ secrets.GITHUB_TOKEN }}
+      github-token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/login-to-ghcr/action.yaml
+++ b/login-to-ghcr/action.yaml
@@ -2,7 +2,7 @@ name: Login to GHCR
 description: Login to GitHub Container Registry (GHCR)
 author: devantler-tech
 inputs:
-  token:
+  github-token:
     description: GitHub token with packages:read (or packages:write) scope
     required: true
 runs:
@@ -13,4 +13,4 @@ runs:
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ inputs.token }}
+        password: ${{ inputs.github-token }}

--- a/setup-go-toolchain/README.md
+++ b/setup-go-toolchain/README.md
@@ -7,7 +7,7 @@ Setup Go with optional private module support for devantler-tech repositories.
 | Name | Description | Required | Default |
 |------|-------------|----------|---------|
 | `go-version` | Go version to install | ❌ | `stable` |
-| `token` | GitHub token for private module access | ❌ | - |
+| `github-token` | GitHub token for private module access | ❌ | - |
 
 ## Outputs
 
@@ -42,5 +42,5 @@ steps:
   - name: Setup Go
     uses: devantler-tech/actions/setup-go-toolchain@main
     with:
-      token: ${{ secrets.GITHUB_TOKEN }}
+      github-token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/setup-go-toolchain/action.yaml
+++ b/setup-go-toolchain/action.yaml
@@ -6,7 +6,7 @@ inputs:
     description: Go version to install
     required: false
     default: stable
-  token:
+  github-token:
     description: GitHub token for private module access
     required: false
 outputs:
@@ -23,10 +23,10 @@ runs:
         go-version: ${{ inputs.go-version }}
 
     - name: 🔑 Configure private modules
-      if: inputs.token != ''
+      if: inputs.github-token != ''
       shell: bash
       env:
-        TOKEN: ${{ inputs.token }}
+        TOKEN: ${{ inputs.github-token }}
       run: |
         go env -w GOPRIVATE=github.com/devantler-tech/*
         git config --global url."https://x-access-token:${TOKEN}@github.com/devantler-tech/".insteadOf "https://github.com/devantler-tech/"


### PR DESCRIPTION
Renames secret inputs that were not following the kebab-case convention established in [CONTRIBUTING.md](./CONTRIBUTING.md). Specifically:

- Renames `token` to `github-token` in `setup-go-toolchain` and `login-to-ghcr` for consistency with other actions (e.g. `run-dotnet-tests`, `upsert-issue`).
- Renames the `APP_PRIVATE_KEY` secret parameter to `app-private-key` in the `active-release` workflow, and pins the reusable workflow ref to `@9ec9792 # v2.2.0`.
- Updates test workflows and READMEs accordingly.

## Type of change

- [x] 🧹 Refactor
- [x] ⛓️‍💥 Breaking change