### PR TITLE
fix: use UPPER_SNAKE_CASE for secret input keys

### DIFF
--- a/.github/workflows/test-approve-pr.yaml
+++ b/.github/workflows/test-approve-pr.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: ./approve-pr
         with:
           app-id: ${{ vars.APP_ID }}
-          app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
           pr-number: ${{ github.event.pull_request.number }}
 
   status-check:

--- a/.github/workflows/test-create-issues-from-todos.yaml
+++ b/.github/workflows/test-create-issues-from-todos.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: ./create-issues-from-todos
         with:
           app-id: ${{ vars.APP_ID }}
-          app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
           project: organization/devantler-tech/5
 
   status-check:

--- a/.github/workflows/test-login-to-ghcr.yaml
+++ b/.github/workflows/test-login-to-ghcr.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: 🧪 Run login-to-ghcr
         uses: ./login-to-ghcr
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: ✅ Verify GHCR login
         run: cat ~/.docker/config.json | grep -q "ghcr.io"

--- a/.github/workflows/test-run-dotnet-tests.yaml
+++ b/.github/workflows/test-run-dotnet-tests.yaml
@@ -28,8 +28,8 @@ jobs:
         uses: ./run-dotnet-tests
         with:
           app-id: ${{ vars.APP_ID }}
-          app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           working-directory: .github/fixtures/run-dotnet-tests
 
   status-check:

--- a/.github/workflows/test-setup-go-toolchain.yaml
+++ b/.github/workflows/test-setup-go-toolchain.yaml
@@ -62,7 +62,7 @@ jobs:
       - name: 🧪 Run setup-go-toolchain with token
         uses: ./setup-go-toolchain
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: ✅ Verify GOPRIVATE is set
         shell: bash

--- a/.github/workflows/test-upsert-issue.yaml
+++ b/.github/workflows/test-upsert-issue.yaml
@@ -31,7 +31,7 @@ jobs:
           body: |
             This issue is created by the `upsert-issue` test workflow.
             Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify outputs
         env:
@@ -65,7 +65,7 @@ jobs:
           body: "Closed by test."
           open: "false"
           close-comment: "🧪 Closed by test workflow."
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   status-check:
     if: ${{ !cancelled() }}

--- a/approve-pr/action.yaml
+++ b/approve-pr/action.yaml
@@ -6,7 +6,7 @@ inputs:
   app-id:
     description: GitHub App ID
     required: true
-  app-private-key:
+  APP_PRIVATE_KEY:
     description: GitHub App Private Key
     required: true
   pr-number:
@@ -26,7 +26,7 @@ runs:
       id: app-token
       with:
         app-id: ${{ inputs.app-id }}
-        private-key: ${{ inputs.app-private-key }}
+        private-key: ${{ inputs.APP_PRIVATE_KEY }}
 
     - name: ✅ Approve pull request
       if: inputs.dry-run != 'true'

--- a/create-issues-from-todos/action.yaml
+++ b/create-issues-from-todos/action.yaml
@@ -5,7 +5,7 @@ inputs:
   app-id:
     description: GitHub App ID
     required: true
-  app-private-key:
+  APP_PRIVATE_KEY:
     description: GitHub App Private Key
     required: true
   project:
@@ -19,7 +19,7 @@ runs:
       id: app-token
       with:
         app-id: ${{ inputs.app-id }}
-        private-key: ${{ inputs.app-private-key }}
+        private-key: ${{ inputs.APP_PRIVATE_KEY }}
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false

--- a/login-to-ghcr/action.yaml
+++ b/login-to-ghcr/action.yaml
@@ -2,7 +2,7 @@ name: Login to GHCR
 description: Login to GitHub Container Registry (GHCR)
 author: devantler-tech
 inputs:
-  github-token:
+  GITHUB_TOKEN:
     description: GitHub token with packages:read (or packages:write) scope
     required: true
 runs:
@@ -13,4 +13,4 @@ runs:
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ inputs.github-token }}
+        password: ${{ inputs.GITHUB_TOKEN }}

--- a/run-dotnet-tests/action.yaml
+++ b/run-dotnet-tests/action.yaml
@@ -5,13 +5,13 @@ inputs:
   app-id:
     description: GitHub App ID to generate a token
     required: true
-  app-private-key:
+  APP_PRIVATE_KEY:
     description: Private key of the GitHub App to generate a token
     required: true
-  github-token:
+  GITHUB_TOKEN:
     description: GitHub token to access the repository
     required: true
-  codecov-token:
+  CODECOV_TOKEN:
     description: Token to upload code coverage to CodeCov
   working-directory:
     description: Directory to run the tests in
@@ -34,7 +34,7 @@ runs:
           "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
       env:
         GITHUB_ACTOR: ${{ github.actor }}
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
       shell: bash
     - name: 🧪 Test
       run: dotnet test --collect:"XPlat Code Coverage" --logger "console;verbosity=detailed"
@@ -42,7 +42,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
     - name: 📄 Get Coverage Files
       id: get_coverage_files
-      if: matrix.os != 'windows-latest' && inputs.codecov-token != ''
+      if: matrix.os != 'windows-latest' && inputs.CODECOV_TOKEN != ''
       run: |
         coverage_files=$(find . -name 'coverage.cobertura.xml' -print0 | tr '\0' ',' | sed 's/,$//')
         echo "COVERAGE_FILES=$coverage_files" >> "$GITHUB_OUTPUT"
@@ -50,7 +50,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
     - name: 📄 Get Coverage Files on Windows
       id: get_coverage_files_windows
-      if: matrix.os == 'windows-latest' && inputs.codecov-token != ''
+      if: matrix.os == 'windows-latest' && inputs.CODECOV_TOKEN != ''
       run: |
         $coverage_files = Get-ChildItem -Path . -Recurse -Filter coverage.cobertura.xml -ErrorAction SilentlyContinue | ForEach-Object { $_.FullName }
         $coverage_files = $coverage_files -join ','
@@ -58,10 +58,10 @@ runs:
       shell: pwsh
       working-directory: ${{ inputs.working-directory }}
     - name: 📄 Upload Code Coverage to CodeCov
-      if: inputs.codecov-token != ''
+      if: inputs.CODECOV_TOKEN != ''
       uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
       with:
         files: ${{ steps.get_coverage_files.outputs.COVERAGE_FILES }}
         fail_ci_if_error: true
       env:
-        CODECOV_TOKEN: ${{ inputs.codecov-token }}
+        CODECOV_TOKEN: ${{ inputs.CODECOV_TOKEN }}

--- a/setup-go-toolchain/action.yaml
+++ b/setup-go-toolchain/action.yaml
@@ -6,7 +6,7 @@ inputs:
     description: Go version to install
     required: false
     default: stable
-  github-token:
+  GITHUB_TOKEN:
     description: GitHub token for private module access
     required: false
 outputs:
@@ -23,10 +23,10 @@ runs:
         go-version: ${{ inputs.go-version }}
 
     - name: 🔑 Configure private modules
-      if: inputs.github-token != ''
+      if: inputs.GITHUB_TOKEN != ''
       shell: bash
       env:
-        TOKEN: ${{ inputs.github-token }}
+        TOKEN: ${{ inputs.GITHUB_TOKEN }}
       run: |
         go env -w GOPRIVATE=github.com/devantler-tech/*
         git config --global url."https://x-access-token:${TOKEN}@github.com/devantler-tech/".insteadOf "https://github.com/devantler-tech/"

--- a/upsert-issue/action.yaml
+++ b/upsert-issue/action.yaml
@@ -27,7 +27,7 @@ inputs:
     description: "Repository to create/update the issue in (format: owner/repo). Defaults to the current repository."
     required: false
     default: ${{ github.repository }}
-  github-token:
+  GITHUB_TOKEN:
     description: "GitHub token with issues write permission"
     required: false
     default: ${{ github.token }}
@@ -46,7 +46,7 @@ runs:
     - id: upsert
       shell: bash
       env:
-        GH_TOKEN: ${{ inputs.github-token }}
+        GH_TOKEN: ${{ inputs.GITHUB_TOKEN }}
         TITLE: ${{ inputs.title }}
         BODY: ${{ inputs.body }}
         BODY_FILE: ${{ inputs.body-file }}


### PR DESCRIPTION
GitHub Actions convention uses `${{ secrets.UPPER_SNAKE_CASE }}` for secret references, but the input keys accepting those secrets were kebab-case (e.g. `app-private-key`, `github-token`). This mismatch made it less obvious which inputs carry sensitive values and was inconsistent with how the secrets themselves are named.

This PR renames all secret-carrying input keys to UPPER_SNAKE_CASE across every action and its callers:

| Old key | New key | Actions |
|---|---|---|
| `app-private-key` | `APP_PRIVATE_KEY` | `approve-pr`, `create-issues-from-todos`, `run-dotnet-tests` |
| `github-token` | `GITHUB_TOKEN` | `login-to-ghcr`, `setup-go-toolchain`, `run-dotnet-tests`, `upsert-issue` |
| `codecov-token` | `CODECOV_TOKEN` | `run-dotnet-tests` |

Non-secret inputs (`app-id`, `pr-number`, `go-version`, etc.) remain kebab-case. All `inputs.*` references inside action files and the corresponding `with:` blocks in test workflows were updated to match.