### PR TITLE
fix: normalize action input names

### DIFF
--- a/.github/workflows/test-approve-pr.yaml
+++ b/.github/workflows/test-approve-pr.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: ./approve-pr
         with:
           app-id: ${{ vars.APP_ID }}
-          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+          app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
           pr-number: ${{ github.event.pull_request.number }}
 
   status-check:

--- a/.github/workflows/test-create-issues-from-todos.yaml
+++ b/.github/workflows/test-create-issues-from-todos.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: ./create-issues-from-todos
         with:
           app-id: ${{ vars.APP_ID }}
-          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+          app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
           project: organization/devantler-tech/5
 
   status-check:

--- a/.github/workflows/test-login-to-ghcr.yaml
+++ b/.github/workflows/test-login-to-ghcr.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: 🧪 Run login-to-ghcr
         uses: ./login-to-ghcr
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: ✅ Verify GHCR login
         run: cat ~/.docker/config.json | grep -q "ghcr.io"

--- a/.github/workflows/test-run-dotnet-tests.yaml
+++ b/.github/workflows/test-run-dotnet-tests.yaml
@@ -28,8 +28,8 @@ jobs:
         uses: ./run-dotnet-tests
         with:
           app-id: ${{ vars.APP_ID }}
-          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           working-directory: .github/fixtures/run-dotnet-tests
 
   status-check:

--- a/.github/workflows/test-setup-go-toolchain.yaml
+++ b/.github/workflows/test-setup-go-toolchain.yaml
@@ -62,7 +62,7 @@ jobs:
       - name: 🧪 Run setup-go-toolchain with token
         uses: ./setup-go-toolchain
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: ✅ Verify GOPRIVATE is set
         shell: bash

--- a/.github/workflows/test-upsert-issue.yaml
+++ b/.github/workflows/test-upsert-issue.yaml
@@ -31,7 +31,7 @@ jobs:
           body: |
             This issue is created by the `upsert-issue` test workflow.
             Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify outputs
         env:
@@ -65,7 +65,7 @@ jobs:
           body: "Closed by test."
           open: "false"
           close-comment: "🧪 Closed by test workflow."
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   status-check:
     if: ${{ !cancelled() }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,10 +11,10 @@ Use the `<active-verb>-<purpose>` pattern:
 
 ### Inputs and Outputs
 
-Use **kebab-case** for non-secret inputs, and **UPPER_SNAKE_CASE** for secret inputs:
+Use **kebab-case** for all action inputs, including secret-backed ones. Workflow inputs can keep their own conventions:
 
-- ✅ `app-id`, `go-version` (non-secret), `GITHUB_TOKEN`, `APP_PRIVATE_KEY` (secret)
-- ❌ `app_id`, `goVersion`, `github-token` (secret in kebab-case)
+- ✅ `app-id`, `go-version`, `github-token`, `app-private-key`
+- ❌ `app_id`, `goVersion`, `GITHUB_TOKEN`, `APP_PRIVATE_KEY`
 
 ## Action Structure
 

--- a/approve-pr/README.md
+++ b/approve-pr/README.md
@@ -7,7 +7,7 @@ Approve a pull request using a GitHub App identity. This is needed because `GITH
 | Name | Description | Required | Default |
 |------|-------------|----------|---------|
 | `app-id` | GitHub App ID | ✅ | - |
-| `APP_PRIVATE_KEY` | GitHub App Private Key | ✅ | - |
+| `app-private-key` | GitHub App Private Key | ✅ | - |
 | `pr-number` | Pull request number to approve | ✅ | - |
 | `dry-run` | Validate only; do not approve the pull request | - | `false` |
 
@@ -21,7 +21,7 @@ steps:
     uses: devantler-tech/actions/approve-pr@main
     with:
       app-id: ${{ vars.APP_ID }}
-      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
       pr-number: ${{ github.event.pull_request.number }}
 ```
 
@@ -33,7 +33,7 @@ steps:
     uses: devantler-tech/actions/approve-pr@main
     with:
       app-id: ${{ vars.APP_ID }}
-      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
       pr-number: ${{ github.event.pull_request.number }}
 
   - name: Enable auto-merge

--- a/approve-pr/action.yaml
+++ b/approve-pr/action.yaml
@@ -6,7 +6,7 @@ inputs:
   app-id:
     description: GitHub App ID
     required: true
-  APP_PRIVATE_KEY:
+  app-private-key:
     description: GitHub App Private Key
     required: true
   pr-number:
@@ -26,7 +26,7 @@ runs:
       id: app-token
       with:
         app-id: ${{ inputs.app-id }}
-        private-key: ${{ inputs.APP_PRIVATE_KEY }}
+        private-key: ${{ inputs.app-private-key }}
 
     - name: ✅ Approve pull request
       if: inputs.dry-run != 'true'

--- a/create-issues-from-todos/README.md
+++ b/create-issues-from-todos/README.md
@@ -7,7 +7,7 @@ Scan code for TODO comments and automatically create corresponding GitHub issues
 | Name | Description | Required | Default |
 |------|-------------|----------|---------|
 | `app-id` | GitHub App ID | ✅ | - |
-| `APP_PRIVATE_KEY` | GitHub App Private Key | ✅ | - |
+| `app-private-key` | GitHub App Private Key | ✅ | - |
 | `project` | GitHub Project to add issues to | ❌ | - |
 
 ## Usage
@@ -20,7 +20,7 @@ steps:
     uses: devantler-tech/actions/create-issues-from-todos@main
     with:
       app-id: ${{ vars.APP_ID }}
-      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
 ```
 
 ### With project integration
@@ -31,6 +31,6 @@ steps:
     uses: devantler-tech/actions/create-issues-from-todos@main
     with:
       app-id: ${{ vars.APP_ID }}
-      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
       project: "organization/devantler-tech/1"
 ```

--- a/create-issues-from-todos/action.yaml
+++ b/create-issues-from-todos/action.yaml
@@ -5,7 +5,7 @@ inputs:
   app-id:
     description: GitHub App ID
     required: true
-  APP_PRIVATE_KEY:
+  app-private-key:
     description: GitHub App Private Key
     required: true
   project:
@@ -19,7 +19,7 @@ runs:
       id: app-token
       with:
         app-id: ${{ inputs.app-id }}
-        private-key: ${{ inputs.APP_PRIVATE_KEY }}
+        private-key: ${{ inputs.app-private-key }}
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false

--- a/login-to-ghcr/README.md
+++ b/login-to-ghcr/README.md
@@ -6,7 +6,7 @@ Login to GitHub Container Registry (GHCR) for pulling or pushing container image
 
 | Name | Description | Required | Default |
 |------|-------------|----------|---------|
-| `GITHUB_TOKEN` | GitHub token with `packages:read` (or `packages:write`) scope | ✅ | - |
+| `github-token` | GitHub token with `packages:read` (or `packages:write`) scope | ✅ | - |
 
 ## Usage
 
@@ -15,5 +15,5 @@ steps:
   - name: Login to GHCR
     uses: devantler-tech/actions/login-to-ghcr@main
     with:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      github-token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/login-to-ghcr/action.yaml
+++ b/login-to-ghcr/action.yaml
@@ -2,7 +2,7 @@ name: Login to GHCR
 description: Login to GitHub Container Registry (GHCR)
 author: devantler-tech
 inputs:
-  GITHUB_TOKEN:
+  github-token:
     description: GitHub token with packages:read (or packages:write) scope
     required: true
 runs:
@@ -13,4 +13,4 @@ runs:
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ inputs.GITHUB_TOKEN }}
+        password: ${{ inputs.github-token }}

--- a/run-dotnet-tests/README.md
+++ b/run-dotnet-tests/README.md
@@ -7,9 +7,9 @@ Test .NET solutions or projects across multiple platforms with code coverage rep
 | Name | Description | Required | Default |
 |------|-------------|----------|---------|
 | `app-id` | GitHub App ID to generate a token | ✅ | - |
-| `APP_PRIVATE_KEY` | Private key of the GitHub App | ✅ | - |
-| `GITHUB_TOKEN` | GitHub token to access the repository | ✅ | - |
-| `CODECOV_TOKEN` | Token to upload code coverage to CodeCov | ❌ | - |
+| `app-private-key` | Private key of the GitHub App | ✅ | - |
+| `github-token` | GitHub token to access the repository | ✅ | - |
+| `codecov-token` | Token to upload code coverage to CodeCov | ❌ | - |
 | `working-directory` | Directory to run the tests in | ❌ | `.` |
 
 ## Usage
@@ -22,9 +22,9 @@ steps:
     uses: devantler-tech/actions/run-dotnet-tests@main
     with:
       app-id: ${{ vars.APP_ID }}
-      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      codecov-token: ${{ secrets.CODECOV_TOKEN }}
 ```
 
 ### Custom working directory
@@ -35,8 +35,8 @@ steps:
     uses: devantler-tech/actions/run-dotnet-tests@main
     with:
       app-id: ${{ vars.APP_ID }}
-      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      github-token: ${{ secrets.GITHUB_TOKEN }}
       working-directory: src/MyProject
 ```
 
@@ -48,6 +48,6 @@ steps:
     uses: devantler-tech/actions/run-dotnet-tests@main
     with:
       app-id: ${{ vars.APP_ID }}
-      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      github-token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/run-dotnet-tests/action.yaml
+++ b/run-dotnet-tests/action.yaml
@@ -5,13 +5,13 @@ inputs:
   app-id:
     description: GitHub App ID to generate a token
     required: true
-  APP_PRIVATE_KEY:
+  app-private-key:
     description: Private key of the GitHub App to generate a token
     required: true
-  GITHUB_TOKEN:
+  github-token:
     description: GitHub token to access the repository
     required: true
-  CODECOV_TOKEN:
+  codecov-token:
     description: Token to upload code coverage to CodeCov
   working-directory:
     description: Directory to run the tests in
@@ -34,7 +34,7 @@ runs:
           "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
       env:
         GITHUB_ACTOR: ${{ github.actor }}
-        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
       shell: bash
     - name: 🧪 Test
       run: dotnet test --collect:"XPlat Code Coverage" --logger "console;verbosity=detailed"
@@ -42,7 +42,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
     - name: 📄 Get Coverage Files
       id: get_coverage_files
-      if: matrix.os != 'windows-latest' && inputs.CODECOV_TOKEN != ''
+      if: matrix.os != 'windows-latest' && inputs.codecov-token != ''
       run: |
         coverage_files=$(find . -name 'coverage.cobertura.xml' -print0 | tr '\0' ',' | sed 's/,$//')
         echo "COVERAGE_FILES=$coverage_files" >> "$GITHUB_OUTPUT"
@@ -50,7 +50,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
     - name: 📄 Get Coverage Files on Windows
       id: get_coverage_files_windows
-      if: matrix.os == 'windows-latest' && inputs.CODECOV_TOKEN != ''
+      if: matrix.os == 'windows-latest' && inputs.codecov-token != ''
       run: |
         $coverage_files = Get-ChildItem -Path . -Recurse -Filter coverage.cobertura.xml -ErrorAction SilentlyContinue | ForEach-Object { $_.FullName }
         $coverage_files = $coverage_files -join ','
@@ -58,10 +58,10 @@ runs:
       shell: pwsh
       working-directory: ${{ inputs.working-directory }}
     - name: 📄 Upload Code Coverage to CodeCov
-      if: inputs.CODECOV_TOKEN != ''
+      if: inputs.codecov-token != ''
       uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
       with:
         files: ${{ steps.get_coverage_files.outputs.COVERAGE_FILES }}
         fail_ci_if_error: true
       env:
-        CODECOV_TOKEN: ${{ inputs.CODECOV_TOKEN }}
+        CODECOV_TOKEN: ${{ inputs.codecov-token }}

--- a/setup-go-toolchain/README.md
+++ b/setup-go-toolchain/README.md
@@ -7,7 +7,7 @@ Setup Go with optional private module support for devantler-tech repositories.
 | Name | Description | Required | Default |
 |------|-------------|----------|---------|
 | `go-version` | Go version to install | ❌ | `stable` |
-| `GITHUB_TOKEN` | GitHub token for private module access | ❌ | - |
+| `github-token` | GitHub token for private module access | ❌ | - |
 
 ## Outputs
 
@@ -42,5 +42,5 @@ steps:
   - name: Setup Go
     uses: devantler-tech/actions/setup-go-toolchain@main
     with:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      github-token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/setup-go-toolchain/action.yaml
+++ b/setup-go-toolchain/action.yaml
@@ -6,7 +6,7 @@ inputs:
     description: Go version to install
     required: false
     default: stable
-  GITHUB_TOKEN:
+  github-token:
     description: GitHub token for private module access
     required: false
 outputs:
@@ -23,10 +23,10 @@ runs:
         go-version: ${{ inputs.go-version }}
 
     - name: 🔑 Configure private modules
-      if: inputs.GITHUB_TOKEN != ''
+      if: inputs.github-token != ''
       shell: bash
       env:
-        TOKEN: ${{ inputs.GITHUB_TOKEN }}
+        TOKEN: ${{ inputs.github-token }}
       run: |
         go env -w GOPRIVATE=github.com/devantler-tech/*
         git config --global url."https://x-access-token:${TOKEN}@github.com/devantler-tech/".insteadOf "https://github.com/devantler-tech/"

--- a/upsert-issue/README.md
+++ b/upsert-issue/README.md
@@ -13,7 +13,7 @@ Create, update, reopen, or close a GitHub issue by title. Finds an existing issu
 | `open` | Whether the issue should be open (`true`) or closed (`false`) | ❌ | `true` |
 | `close-comment` | Comment to post when closing the issue | ❌ | `✅ Resolved — closing this issue.` |
 | `repository` | Target repository (`owner/repo`) | ❌ | `${{ github.repository }}` |
-| `GITHUB_TOKEN` | GitHub token with `issues: write` permission | ❌ | `${{ github.token }}` |
+| `github-token` | GitHub token with `issues: write` permission | ❌ | `${{ github.token }}` |
 
 ## Outputs
 

--- a/upsert-issue/action.yaml
+++ b/upsert-issue/action.yaml
@@ -27,7 +27,7 @@ inputs:
     description: "Repository to create/update the issue in (format: owner/repo). Defaults to the current repository."
     required: false
     default: ${{ github.repository }}
-  GITHUB_TOKEN:
+  github-token:
     description: "GitHub token with issues write permission"
     required: false
     default: ${{ github.token }}
@@ -46,7 +46,7 @@ runs:
     - id: upsert
       shell: bash
       env:
-        GH_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ inputs.github-token }}
         TITLE: ${{ inputs.title }}
         BODY: ${{ inputs.body }}
         BODY_FILE: ${{ inputs.body-file }}


### PR DESCRIPTION
## Why
Several actions exposed a mix of kebab-case and uppercase env-style input names. That made the action interfaces inconsistent and conflicted with the repo's naming guidance.

## What changed
This PR normalizes action inputs to kebab-case for the affected actions, including secret-backed inputs such as `app-private-key`, `github-token`, and `codecov-token`. It updates the action metadata, internal `inputs.*` references, the in-repo test workflows that call those actions, and the corresponding READMEs so the documented interface matches the implemented one.

## Notes
Reusable workflow boundaries were left unchanged on purpose. For example, `.github/workflows/active-release.yaml` still uses `APP_PRIVATE_KEY` because that is a workflow secret interface, not an action input.

`CONTRIBUTING.md` now makes that distinction explicit.