### PR TITLE
feat(setup-copilot-skills): add composite action to install gh skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ flowchart TD
 | [enable-auto-merge-on-pr](enable-auto-merge-on-pr/README.md) | Enable auto-merge on a pull request |
 | [login-to-ghcr](login-to-ghcr/README.md) | Login to GitHub Container Registry |
 | [run-dotnet-tests](run-dotnet-tests/README.md) | Test .NET solution or project with coverage |
+| [setup-copilot-skills](setup-copilot-skills/README.md) | Install agent skills via `gh skill` from a manifest or inline list |
 | [setup-go-toolchain](setup-go-toolchain/README.md) | Setup Go with optional private module support |
 | [setup-ksail-cli](setup-ksail-cli/README.md) | Install KSail CLI via Homebrew |
 | [sync-github-labels](sync-github-labels/README.md) | Sync GitHub labels from a configuration file |

--- a/setup-copilot-skills/README.md
+++ b/setup-copilot-skills/README.md
@@ -1,0 +1,79 @@
+# Setup Copilot Skills
+
+Install agent skills with the [`gh skill`](https://github.com/cli/cli) CLI — from a `skills-lock.json` manifest or an inline source/skills list. Works with any `gh skill`-compatible skills repository (e.g. [`devantler-tech/skills`](https://github.com/devantler-tech/skills)).
+
+## Inputs
+
+| Name | Description | Required | Default |
+|------|-------------|----------|---------|
+| `skills-lock` | Path to a `skills-lock.json` manifest (used when `source` is empty) | ❌ | `skills-lock.json` |
+| `source` | Single skills repo (e.g. `devantler-tech/skills`). When set, `skills` is required and `skills-lock` is ignored. | ❌ | - |
+| `skills` | Newline- or comma-separated skill names to install from `source` | ❌ | - |
+| `agent` | Value passed to `gh skill install --agent` | ❌ | `github-copilot` |
+| `scope` | Value passed to `gh skill install --scope` (`user` or `repo`) | ❌ | `user` |
+| `gh-version` | Minimum required `gh` version (must support `gh skill`) | ❌ | `2.90.0` |
+| `github-token` | GitHub token exposed to `gh` as `GH_TOKEN` | ❌ | `${{ github.token }}` |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `installed-skills` | Newline-separated list of `source/skill-name` pairs that were installed |
+
+## Usage
+
+### From a `skills-lock.json` manifest (recommended)
+
+```yaml
+steps:
+  - uses: actions/checkout@v5
+  - name: Install Copilot skills
+    uses: devantler-tech/actions/setup-copilot-skills@main
+```
+
+A `skills-lock.json` has the following shape:
+
+```json
+{
+  "version": 1,
+  "skills": {
+    "git-commit": { "source": "devantler-tech/skills", "sourceType": "github" },
+    "gh-cli":     { "source": "devantler-tech/skills", "sourceType": "github" }
+  }
+}
+```
+
+### From an inline list of skills
+
+```yaml
+steps:
+  - name: Install specific skills
+    uses: devantler-tech/actions/setup-copilot-skills@main
+    with:
+      source: devantler-tech/skills
+      skills: |
+        git-commit
+        gh-cli
+        refactor
+```
+
+### Customising agent and scope
+
+```yaml
+steps:
+  - uses: devantler-tech/actions/setup-copilot-skills@main
+    with:
+      source: devantler-tech/skills
+      skills: git-commit
+      agent: github-copilot
+      scope: repo
+```
+
+### Inside a scheduled update workflow
+
+For a batteries-included scheduled updater that opens a PR with any skill changes, use the companion reusable workflow [`devantler-tech/reusable-workflows/.github/workflows/update-copilot-skills.yaml`](https://github.com/devantler-tech/reusable-workflows/blob/main/.github/workflows/update-copilot-skills.yaml).
+
+## Requirements
+
+- `gh` **≥ 2.90.0** on the runner (with `gh skill` support). GitHub-hosted runners typically already meet this; older self-hosted runners may need to upgrade.
+- `jq` (pre-installed on GitHub-hosted runners) when using a `skills-lock.json`.

--- a/setup-copilot-skills/action.yaml
+++ b/setup-copilot-skills/action.yaml
@@ -1,0 +1,111 @@
+name: Setup Copilot Skills
+description: Install agent skills with the gh skill CLI, from a skills-lock.json manifest or an inline source/skills list
+author: devantler-tech
+inputs:
+  skills-lock:
+    description: Path to a skills-lock.json manifest (used when `source` is empty)
+    required: false
+    default: skills-lock.json
+  source:
+    description: Single skills repo (e.g. `devantler-tech/skills`). When set, `skills` is required and `skills-lock` is ignored.
+    required: false
+    default: ""
+  skills:
+    description: Newline- or comma-separated skill names to install from `source`. Ignored when `source` is empty.
+    required: false
+    default: ""
+  agent:
+    description: Value passed to `gh skill install --agent`
+    required: false
+    default: github-copilot
+  scope:
+    description: Value passed to `gh skill install --scope` (`user` or `repo`)
+    required: false
+    default: user
+  gh-version:
+    description: Minimum required `gh` version (must support `gh skill`)
+    required: false
+    default: 2.90.0
+  github-token:
+    description: GitHub token exposed to `gh` as `GH_TOKEN`
+    required: false
+    default: ${{ github.token }}
+outputs:
+  installed-skills:
+    description: Newline-separated list of `source/skill-name` pairs that were installed
+    value: ${{ steps.install.outputs.installed-skills }}
+runs:
+  using: composite
+  steps:
+    - name: 🔍 Verify gh supports `skill`
+      shell: bash
+      env:
+        REQUIRED: ${{ inputs.gh-version }}
+      run: |
+        if ! command -v gh >/dev/null 2>&1; then
+          echo "::error::gh CLI is not installed on this runner."
+          exit 1
+        fi
+        current=$(gh --version | awk '/gh version/{print $3; exit}')
+        if ! printf '%s\n%s\n' "$REQUIRED" "$current" | sort -V -C; then
+          echo "::error::gh $current < $REQUIRED (needs 'gh skill' support)."
+          exit 1
+        fi
+        if ! gh skill --help >/dev/null 2>&1; then
+          echo "::error::Installed gh ($current) does not expose the 'skill' command."
+          exit 1
+        fi
+
+    - name: 📦 Install skills
+      id: install
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        INPUT_SOURCE: ${{ inputs.source }}
+        INPUT_SKILLS: ${{ inputs.skills }}
+        INPUT_SKILLS_LOCK: ${{ inputs.skills-lock }}
+        INPUT_AGENT: ${{ inputs.agent }}
+        INPUT_SCOPE: ${{ inputs.scope }}
+      run: |
+        set -euo pipefail
+        installed_file=$(mktemp)
+
+        install_one() {
+          local src="$1" name="$2"
+          echo "Installing ${src}/${name} (agent=${INPUT_AGENT}, scope=${INPUT_SCOPE})..."
+          gh skill install "$src" "$name" --agent "$INPUT_AGENT" --scope "$INPUT_SCOPE"
+          printf '%s/%s\n' "$src" "$name" >> "$installed_file"
+        }
+
+        if [ -n "$INPUT_SOURCE" ]; then
+          if [ -z "$INPUT_SKILLS" ]; then
+            echo "::error::'skills' input is required when 'source' is set."
+            exit 1
+          fi
+          printf '%s' "$INPUT_SKILLS" | tr ',' '\n' | while IFS= read -r name; do
+            name=$(printf '%s' "$name" | awk '{$1=$1;print}')
+            [ -z "$name" ] && continue
+            install_one "$INPUT_SOURCE" "$name"
+          done
+        else
+          if [ ! -f "$INPUT_SKILLS_LOCK" ]; then
+            echo "::error::skills-lock file not found: $INPUT_SKILLS_LOCK"
+            exit 1
+          fi
+          entries=$(jq -e -c '.skills | to_entries[] | {source: .value.source, name: .key}' "$INPUT_SKILLS_LOCK") || {
+            echo "::error::No skills found in $INPUT_SKILLS_LOCK"
+            exit 1
+          }
+          while IFS= read -r entry; do
+            src=$(jq -r '.source' <<<"$entry")
+            name=$(jq -r '.name' <<<"$entry")
+            install_one "$src" "$name"
+          done <<<"$entries"
+        fi
+
+        {
+          echo "installed-skills<<EOF"
+          cat "$installed_file"
+          echo "EOF"
+        } >> "$GITHUB_OUTPUT"
+        rm -f "$installed_file"


### PR DESCRIPTION
Add a `setup-copilot-skills` composite action that installs agent skills with the [`gh skill`](https://github.com/cli/cli) CLI.

## What has changed and why?

Currently, repositories that want to use `gh skill` have to hand-roll a shell loop (see [devantler-tech/ksail#4105](https://github.com/devantler-tech/ksail/pull/4105) for an example). This action packages that loop so consumers can install skills with one step.

### Features

- Accepts either a **`skills-lock.json` manifest** (recommended) or an **inline `source` + `skills` list**.
- Generic — works with any `gh skill`-compatible skills repository, not just [`devantler-tech/skills`](https://github.com/devantler-tech/skills).
- Configurable `agent`, `scope`, minimum `gh` version, and token.
- Verifies `gh >= 2.90.0` (the first release with `gh skill` support) before running, with a clear error on older runners.
- Emits an `installed-skills` output for downstream steps.

## Related

- Companion skills registry: [devantler-tech/skills#1](https://github.com/devantler-tech/skills/pull/1)
- Companion reusable workflow (scheduled updater): [devantler-tech/reusable-workflows#<pending>](https://github.com/devantler-tech/reusable-workflows/pulls)

## Type of change

- [x] 🚀 New feature
