### PR TITLE
fix(setup-copilot-skills): install gh on demand when runner has an older version

### DIFF
--- a/setup-copilot-skills/README.md
+++ b/setup-copilot-skills/README.md
@@ -75,5 +75,5 @@ For a batteries-included scheduled updater that opens a PR with any skill change
 
 ## Requirements
 
-- `gh` **≥ 2.90.0** on the runner (with `gh skill` support). GitHub-hosted runners typically already meet this; older self-hosted runners may need to upgrade.
+- `gh` **≥ 2.90.0** on the runner (with `gh skill` support). If the runner image ships an older `gh`, this action downloads the required release tarball on demand (Linux and macOS, amd64/arm64). Windows runners must pre-install `gh >= 2.90.0`.
 - `jq` (pre-installed on GitHub-hosted runners) when using a `skills-lock.json`.

--- a/setup-copilot-skills/action.yaml
+++ b/setup-copilot-skills/action.yaml
@@ -37,22 +37,39 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: 🔍 Verify gh supports `skill`
+    - name: 🔧 Ensure gh >= required version
       shell: bash
       env:
         REQUIRED: ${{ inputs.gh-version }}
       run: |
-        if ! command -v gh >/dev/null 2>&1; then
-          echo "::error::gh CLI is not installed on this runner."
-          exit 1
+        set -euo pipefail
+        if command -v gh >/dev/null 2>&1 && gh skill --help >/dev/null 2>&1; then
+          current=$(gh --version | awk '/gh version/{print $3; exit}')
+          if printf '%s\n%s\n' "$REQUIRED" "$current" | sort -V -C; then
+            echo "Installed gh ($current) already supports 'gh skill'."
+            exit 0
+          fi
         fi
-        current=$(gh --version | awk '/gh version/{print $3; exit}')
-        if ! printf '%s\n%s\n' "$REQUIRED" "$current" | sort -V -C; then
-          echo "::error::gh $current < $REQUIRED (needs 'gh skill' support)."
-          exit 1
-        fi
+
+        case "$(uname -s)" in
+          Linux)   os=linux ;;
+          Darwin)  os=macOS ;;
+          *) echo "::error::Unsupported OS: $(uname -s)"; exit 1 ;;
+        esac
+        case "$(uname -m)" in
+          x86_64|amd64) arch=amd64 ;;
+          arm64|aarch64) arch=arm64 ;;
+          *) echo "::error::Unsupported arch: $(uname -m)"; exit 1 ;;
+        esac
+
+        tmp=$(mktemp -d)
+        url="https://github.com/cli/cli/releases/download/v${REQUIRED}/gh_${REQUIRED}_${os}_${arch}.tar.gz"
+        echo "Downloading $url"
+        curl -fsSL "$url" | tar -xzC "$tmp"
+        sudo install "$tmp/gh_${REQUIRED}_${os}_${arch}/bin/gh" /usr/local/bin/gh
+        gh --version
         if ! gh skill --help >/dev/null 2>&1; then
-          echo "::error::Installed gh ($current) does not expose the 'skill' command."
+          echo "::error::Installed gh still does not expose the 'skill' command."
           exit 1
         fi
 


### PR DESCRIPTION
Follow-up to #74. Make the action install `gh` on demand instead of failing fast when the runner image is behind.

## Why

`ubuntu-latest` currently ships `gh 2.89.0`, which predates the `gh skill` command. Consumers of `setup-copilot-skills` would otherwise have to inline an install step in every workflow — that defeats the purpose of a setup action.

## What

- If `gh skill` already works on the runner and `gh >= gh-version`, no-op.
- Otherwise download the release tarball for Linux or macOS (amd64/arm64) from `github.com/cli/cli/releases/download/v<gh-version>/gh_<gh-version>_<os>_<arch>.tar.gz` and install it to `/usr/local/bin`.
- Windows runners still need to pre-install `gh >= 2.90.0` (no code path added yet; documented in the README).

## Type of change

- [x] 🪲 Bug fix
