### PR TITLE
fix(setup-copilot-skills): default scope to repo for CI use

### DIFF
--- a/setup-copilot-skills/README.md
+++ b/setup-copilot-skills/README.md
@@ -10,7 +10,7 @@ Install agent skills with the [`gh skill`](https://github.com/cli/cli) CLI — f
 | `source` | Single skills repo (e.g. `devantler-tech/skills`). When set, `skills` is required and `skills-lock` is ignored. | ❌ | - |
 | `skills` | Newline- or comma-separated skill names to install from `source` | ❌ | - |
 | `agent` | Value passed to `gh skill install --agent` | ❌ | `github-copilot` |
-| `scope` | Value passed to `gh skill install --scope` (`project` or `user`) | ❌ | `user` |
+| `scope` | Value passed to `gh skill install --scope` (`project` or `user`) | ❌ | `project` |
 | `gh-version` | Minimum required `gh` version (must support `gh skill`) | ❌ | `2.90.0` |
 | `github-token` | GitHub token exposed to `gh` as `GH_TOKEN` | ❌ | `${{ github.token }}` |
 
@@ -81,6 +81,9 @@ steps:
       source: devantler-tech/skills
       skills: git-commit
       agent: github-copilot
+      # Default is `project` (writes inside the checkout, suitable for CI and
+      # scheduled-update workflows). Use `user` for local dev installs that
+      # should land in the runner's home directory.
       scope: user
 ```
 

--- a/setup-copilot-skills/action.yaml
+++ b/setup-copilot-skills/action.yaml
@@ -21,7 +21,7 @@ inputs:
   scope:
     description: Value passed to `gh skill install --scope` (`project` or `user`)
     required: false
-    default: user
+    default: project
   gh-version:
     description: Minimum required `gh` version (must support `gh skill`)
     required: false


### PR DESCRIPTION
The default `scope` is `user`, which makes `gh skill install` write to `~/.copilot/skills` on the runner — outside `GITHUB_WORKSPACE`. In CI and scheduled-update workflows (the documented primary use case for this action) the working tree therefore never changes, so follow-up steps like `peter-evans/create-pull-request` open no PR.

Concrete failure example: [`devantler-tech/ksail` run 24609491046](https://github.com/devantler-tech/ksail/actions/runs/24609491046) succeeds but produces no PR. The PR-creation step logs:

```
No local changes to save
Branch 'deps/copilot-skills-update' is not ahead of base 'main' and will not be created
```

Default to `scope: repo` so installs land inside the checkout. Users who explicitly want host-level installs can still pass `scope: user`. README updated to flip which scope is shown as the override example.

A stacked PR will follow against `devantler-tech/reusable-workflows` to flip the default in `update-copilot-skills.yaml` and bump the action pin to the release that includes this change.

## Type of change

- [x] 🪲 Bug fix
- [x] ⛓️‍💥 Breaking change (default behaviour changes for existing consumers; opt back in with `scope: user`)