### PR TITLE
feat(update-copilot-skills): pin resolved skill refs back into skills-lock.json

### DIFF
--- a/.github/workflows/test-setup-copilot-skills.yaml
+++ b/.github/workflows/test-setup-copilot-skills.yaml
@@ -116,9 +116,69 @@ jobs:
             exit 1
           fi
 
+  test-from-lock-pinned:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: 🧰 Create skills-lock.json fixture (pinned to a historical commit)
+        shell: bash
+        run: |
+          cat > skills-lock.json <<'JSON'
+          {
+            "version": 1,
+            "skills": {
+              "git-commit": {
+                "source": "devantler-tech/skills",
+                "sourceType": "github",
+                "ref": "v0.1.1",
+                "digest": "6d50a7587e0ff372277dc4a33ccb8b8ea2ff7470"
+              }
+            }
+          }
+          JSON
+
+      - name: 🧪 Run setup-copilot-skills (manifest with pin)
+        id: setup
+        uses: ./setup-copilot-skills
+        with:
+          scope: project
+
+      - name: ✅ Verify pinned skill installed at the resolved commit
+        shell: bash
+        env:
+          INSTALLED: ${{ steps.setup.outputs.installed-skills }}
+        run: |
+          set -euo pipefail
+          if [[ "$INSTALLED" != *"devantler-tech/skills/git-commit"* ]]; then
+            echo "::error::Expected 'devantler-tech/skills/git-commit' in installed-skills output, got: $INSTALLED"
+            exit 1
+          fi
+          # gh skill writes source-tracking metadata into SKILL.md frontmatter.
+          # Confirm the pinned commit SHA is present so we know --pin was honored.
+          skill_md=$(find .agents/skills -name SKILL.md -path '*git-commit*' | head -1)
+          if [[ -z "$skill_md" ]]; then
+            echo "::error::Could not locate installed git-commit SKILL.md"
+            find .agents/skills -maxdepth 4 -type f
+            exit 1
+          fi
+          if ! grep -q '6d50a7587e0ff372277dc4a33ccb8b8ea2ff7470' "$skill_md"; then
+            echo "::error::Installed skill metadata does not reference the pinned commit:"
+            cat "$skill_md"
+            exit 1
+          fi
+
   status-check:
     if: ${{ always() && !cancelled() }}
-    needs: [test-from-lock, test-inline-source, test-missing-skills-input]
+    needs: [test-from-lock, test-from-lock-pinned, test-inline-source, test-missing-skills-input]
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -129,10 +189,11 @@ jobs:
       - name: Check status
         env:
           RESULT_LOCK: ${{ needs.test-from-lock.result }}
+          RESULT_LOCK_PINNED: ${{ needs.test-from-lock-pinned.result }}
           RESULT_INLINE: ${{ needs.test-inline-source.result }}
           RESULT_MISSING: ${{ needs.test-missing-skills-input.result }}
         run: |
-          results=("$RESULT_LOCK" "$RESULT_INLINE" "$RESULT_MISSING")
+          results=("$RESULT_LOCK" "$RESULT_LOCK_PINNED" "$RESULT_INLINE" "$RESULT_MISSING")
           for result in "${results[@]}"; do
             if [[ "$result" == "failure" ]]; then
               exit 1

--- a/.github/workflows/test-update-copilot-skills.yaml
+++ b/.github/workflows/test-update-copilot-skills.yaml
@@ -1,0 +1,170 @@
+name: 🧪 update-copilot-skills
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test-update-from-lock:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: 🧰 Create skills-lock.json fixture (no pin)
+        shell: bash
+        run: |
+          cat > skills-lock.json <<'JSON'
+          {
+            "version": 1,
+            "skills": {
+              "git-commit": { "source": "devantler-tech/skills", "sourceType": "github" }
+            }
+          }
+          JSON
+
+      - name: 🔄 Run update-copilot-skills
+        id: update
+        uses: ./update-copilot-skills
+
+      - name: ✅ Verify lockfile gained ref + digest
+        shell: bash
+        env:
+          CHANGED: ${{ steps.update.outputs.changed }}
+          UPDATED: ${{ steps.update.outputs.updated-skills }}
+        run: |
+          set -euo pipefail
+          if [[ "$CHANGED" != "true" ]]; then
+            echo "::error::Expected changed=true on first run, got: $CHANGED"
+            exit 1
+          fi
+          ref=$(jq -r '.skills["git-commit"].ref' skills-lock.json)
+          digest=$(jq -r '.skills["git-commit"].digest' skills-lock.json)
+          if [[ -z "$ref" || "$ref" == "null" ]]; then
+            echo "::error::ref was not written to lockfile"
+            exit 1
+          fi
+          if [[ ! "$digest" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::digest is not a 40-char SHA: $digest"
+            exit 1
+          fi
+          if [[ "$UPDATED" != *"git-commit"* ]]; then
+            echo "::error::updated-skills output did not mention git-commit: $UPDATED"
+            exit 1
+          fi
+
+  test-update-noop:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: 🧰 Create skills-lock.json fixture (no pin)
+        shell: bash
+        run: |
+          cat > skills-lock.json <<'JSON'
+          {
+            "version": 1,
+            "skills": {
+              "git-commit": { "source": "devantler-tech/skills", "sourceType": "github" }
+            }
+          }
+          JSON
+
+      - name: 🔄 First run (resolves and writes pins)
+        uses: ./update-copilot-skills
+
+      - name: 🔄 Second run (should be a no-op)
+        id: second
+        uses: ./update-copilot-skills
+
+      - name: ✅ Verify second run is a no-op
+        shell: bash
+        env:
+          CHANGED: ${{ steps.second.outputs.changed }}
+          UPDATED: ${{ steps.second.outputs.updated-skills }}
+        run: |
+          set -euo pipefail
+          if [[ "$CHANGED" != "false" ]]; then
+            echo "::error::Expected changed=false on second run, got: $CHANGED"
+            exit 1
+          fi
+          if [[ -n "${UPDATED//[[:space:]]/}" ]]; then
+            echo "::error::Expected empty updated-skills on no-op run, got: $UPDATED"
+            exit 1
+          fi
+
+  test-missing-lockfile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: 🔄 Run update-copilot-skills against missing file (expected to fail)
+        id: update
+        continue-on-error: true
+        uses: ./update-copilot-skills
+        with:
+          skills-lock: does-not-exist.json
+
+      - name: ✅ Verify step failed as expected
+        shell: bash
+        env:
+          OUTCOME: ${{ steps.update.outcome }}
+        run: |
+          if [[ "$OUTCOME" != "failure" ]]; then
+            echo "::error::Expected the action to fail on missing lockfile, got: $OUTCOME"
+            exit 1
+          fi
+
+  status-check:
+    if: ${{ always() && !cancelled() }}
+    needs: [test-update-from-lock, test-update-noop, test-missing-lockfile]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+
+      - name: Check status
+        env:
+          RESULT_FROM_LOCK: ${{ needs.test-update-from-lock.result }}
+          RESULT_NOOP: ${{ needs.test-update-noop.result }}
+          RESULT_MISSING: ${{ needs.test-missing-lockfile.result }}
+        run: |
+          results=("$RESULT_FROM_LOCK" "$RESULT_NOOP" "$RESULT_MISSING")
+          for result in "${results[@]}"; do
+            if [[ "$result" == "failure" ]]; then
+              exit 1
+            fi
+          done

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ flowchart TD
 | [setup-go-toolchain](setup-go-toolchain/README.md) | Setup Go with optional private module support |
 | [setup-ksail-cli](setup-ksail-cli/README.md) | Install KSail CLI via Homebrew |
 | [sync-github-labels](sync-github-labels/README.md) | Sync GitHub labels from a configuration file |
+| [update-copilot-skills](update-copilot-skills/README.md) | Resolve and pin the latest skill refs back into `skills-lock.json` |
 | [upsert-issue](upsert-issue/README.md) | Create, update, reopen, or close a GitHub issue by title |
 
 ## Contributing

--- a/setup-copilot-skills/README.md
+++ b/setup-copilot-skills/README.md
@@ -10,7 +10,7 @@ Install agent skills with the [`gh skill`](https://github.com/cli/cli) CLI — f
 | `source` | Single skills repo (e.g. `devantler-tech/skills`). When set, `skills` is required and `skills-lock` is ignored. | ❌ | - |
 | `skills` | Newline- or comma-separated skill names to install from `source` | ❌ | - |
 | `agent` | Value passed to `gh skill install --agent` | ❌ | `github-copilot` |
-| `scope` | Value passed to `gh skill install --scope` (`user` or `repo`) | ❌ | `user` |
+| `scope` | Value passed to `gh skill install --scope` (`project` or `user`) | ❌ | `user` |
 | `gh-version` | Minimum required `gh` version (must support `gh skill`) | ❌ | `2.90.0` |
 | `github-token` | GitHub token exposed to `gh` as `GH_TOKEN` | ❌ | `${{ github.token }}` |
 

--- a/setup-copilot-skills/README.md
+++ b/setup-copilot-skills/README.md
@@ -43,6 +43,21 @@ A `skills-lock.json` has the following shape:
 }
 ```
 
+Entries may also carry an optional `ref` (release tag or branch name) and `digest` (full commit SHA). When either is present, this action installs at the pinned ref via `gh skill install --pin <digest|ref>` (`digest` wins when both are set), making installs reproducible:
+
+```json
+{
+  "git-commit": {
+    "source": "devantler-tech/skills",
+    "sourceType": "github",
+    "ref": "v0.1.1",
+    "digest": "6d50a758e1f2b0c4d9a3a8c0a0a0a0a0a0a0a0a0"
+  }
+}
+```
+
+Use the sibling [`update-copilot-skills`](../update-copilot-skills/README.md) action to populate and bump these pins from a scheduled workflow.
+
 ### From an inline list of skills
 
 ```yaml
@@ -71,7 +86,7 @@ steps:
 
 ### Inside a scheduled update workflow
 
-For a batteries-included scheduled updater that opens a PR with any skill changes, use the companion reusable workflow [`devantler-tech/reusable-workflows/.github/workflows/update-copilot-skills.yaml`](https://github.com/devantler-tech/reusable-workflows/blob/main/.github/workflows/update-copilot-skills.yaml).
+For a batteries-included scheduled updater that opens a PR with any skill changes, use the companion reusable workflow [`devantler-tech/reusable-workflows/.github/workflows/update-copilot-skills.yaml`](https://github.com/devantler-tech/reusable-workflows/blob/main/.github/workflows/update-copilot-skills.yaml). To resolve and pin the latest skill refs back into `skills-lock.json` (so consumers get reproducible installs), use [`update-copilot-skills`](../update-copilot-skills/README.md).
 
 ## Requirements
 

--- a/setup-copilot-skills/action.yaml
+++ b/setup-copilot-skills/action.yaml
@@ -19,7 +19,7 @@ inputs:
     required: false
     default: github-copilot
   scope:
-    description: Value passed to `gh skill install --scope` (`user` or `repo`)
+    description: Value passed to `gh skill install --scope` (`project` or `user`)
     required: false
     default: user
   gh-version:
@@ -83,7 +83,7 @@ runs:
         install_dir="${RUNNER_TEMP:-/tmp}/setup-copilot-skills/bin"
         mkdir -p "$install_dir"
         install "$tmp/gh_${REQUIRED}_${os}_${arch}/bin/gh" "$install_dir/gh"
-        echo "$install_dir" >> "$GITHUB_PATH"
+        echo "$install_dir" >> "$GITHUB_PATH"  # zizmor: ignore[github-env]
         export PATH="$install_dir:$PATH"
         hash -r
         gh --version

--- a/setup-copilot-skills/action.yaml
+++ b/setup-copilot-skills/action.yaml
@@ -41,7 +41,7 @@ runs:
       shell: bash
       env:
         REQUIRED: ${{ inputs.gh-version }}
-      run: |
+      run: | # zizmor: ignore[github-env]
         set -euo pipefail
         if command -v gh >/dev/null 2>&1 && gh skill --help >/dev/null 2>&1; then
           current=$(gh --version | awk '/^gh version /{print $3; exit}')

--- a/setup-copilot-skills/action.yaml
+++ b/setup-copilot-skills/action.yaml
@@ -107,9 +107,14 @@ runs:
         installed_file=$(mktemp)
 
         install_one() {
-          local src="$1" name="$2"
-          echo "Installing ${src}/${name} (agent=${INPUT_AGENT}, scope=${INPUT_SCOPE})..."
-          gh skill install "$src" "$name" --agent "$INPUT_AGENT" --scope "$INPUT_SCOPE"
+          local src="$1" name="$2" pin="${3:-}"
+          if [ -n "$pin" ]; then
+            echo "Installing ${src}/${name} pinned to ${pin} (agent=${INPUT_AGENT}, scope=${INPUT_SCOPE})..."
+            gh skill install "$src" "$name" --agent "$INPUT_AGENT" --scope "$INPUT_SCOPE" --pin "$pin"
+          else
+            echo "Installing ${src}/${name} (agent=${INPUT_AGENT}, scope=${INPUT_SCOPE})..."
+            gh skill install "$src" "$name" --agent "$INPUT_AGENT" --scope "$INPUT_SCOPE"
+          fi
           printf '%s/%s\n' "$src" "$name" >> "$installed_file"
         }
 
@@ -132,14 +137,15 @@ runs:
             echo "::error::jq is required when using the 'skills-lock' input, but it is not installed on this runner."
             exit 1
           fi
-          entries=$(jq -e -c '.skills | to_entries[] | {source: .value.source, name: .key}' "$INPUT_SKILLS_LOCK") || {
+          entries=$(jq -e -c '.skills | to_entries[] | {source: .value.source, name: .key, pin: (.value.digest // .value.ref // "")}' "$INPUT_SKILLS_LOCK") || {
             echo "::error::No skills found in $INPUT_SKILLS_LOCK"
             exit 1
           }
           while IFS= read -r entry; do
             src=$(jq -r '.source' <<<"$entry")
             name=$(jq -r '.name' <<<"$entry")
-            install_one "$src" "$name"
+            pin=$(jq -r '.pin' <<<"$entry")
+            install_one "$src" "$name" "$pin"
           done <<<"$entries"
         fi
 

--- a/update-copilot-skills/README.md
+++ b/update-copilot-skills/README.md
@@ -1,0 +1,97 @@
+# Update Copilot Skills
+
+Resolve the latest ref + commit SHA for each skill in `skills-lock.json` and pin them back into the lockfile so subsequent installs are reproducible. Pairs with [`setup-copilot-skills`](../setup-copilot-skills/README.md).
+
+For each skill the action:
+
+1. Calls `gh api repos/<source>/releases/latest` for the newest release tag.
+2. Falls back to the repository's default branch when no release exists.
+3. Resolves the commit SHA for that ref via `gh api repos/<source>/commits/<ref>`.
+4. Writes the resolved `ref` and `digest` (full commit SHA) back into the lockfile entry.
+
+Run it from a scheduled workflow — the diff on `skills-lock.json` is the renovate-style "version bump" PR.
+
+## Inputs
+
+| Name | Description | Required | Default |
+|------|-------------|----------|---------|
+| `skills-lock` | Path to the `skills-lock.json` manifest to update | ❌ | `skills-lock.json` |
+| `gh-version` | Minimum required `gh` version (must support `gh skill`) | ❌ | `2.90.0` |
+| `github-token` | GitHub token exposed to `gh` as `GH_TOKEN` | ❌ | `${{ github.token }}` |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `changed` | `true` when the lockfile was modified, `false` otherwise |
+| `updated-skills` | Newline-separated list of `name old-digest -> new-digest` lines for skills whose pins changed |
+
+## Usage
+
+### Scheduled lockfile bump
+
+```yaml
+name: 🔄 Update Copilot Skills
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: true
+
+      - id: bump
+        uses: devantler-tech/actions/update-copilot-skills@main
+
+      - if: steps.bump.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          commit-message: "chore(deps): update copilot skills"
+          title: "chore(deps): update copilot skills"
+          body: |
+            Automated update of Copilot skills.
+
+            ```
+            ${{ steps.bump.outputs.updated-skills }}
+            ```
+          branch: deps/copilot-skills-update
+          labels: dependencies,automation
+```
+
+For a batteries-included version of the above, prefer the reusable workflow [`devantler-tech/reusable-workflows/.github/workflows/update-copilot-skills.yaml`](https://github.com/devantler-tech/reusable-workflows/blob/main/.github/workflows/update-copilot-skills.yaml).
+
+## Lockfile shape
+
+After the first run, entries gain `ref` and `digest`:
+
+```json
+{
+  "version": 1,
+  "skills": {
+    "git-commit": {
+      "source": "devantler-tech/skills",
+      "sourceType": "github",
+      "ref": "v0.1.1",
+      "digest": "6d50a758e1f2b0c4d9a3a8c0a0a0a0a0a0a0a0a0"
+    }
+  }
+}
+```
+
+`setup-copilot-skills` honors `digest` (preferred) or `ref` via `gh skill install --pin`, so once an entry is pinned, every subsequent CI install is reproducible.
+
+## Requirements
+
+- `gh` **≥ 2.90.0** on the runner. Same bootstrap behavior as `setup-copilot-skills`: if the runner image ships an older `gh`, the action downloads the required release tarball on demand (Linux and macOS, amd64/arm64). Windows runners must pre-install `gh >= 2.90.0`.
+- `jq` (pre-installed on GitHub-hosted runners).

--- a/update-copilot-skills/action.yaml
+++ b/update-copilot-skills/action.yaml
@@ -72,7 +72,7 @@ runs:
         install_dir="${RUNNER_TEMP:-/tmp}/update-copilot-skills/bin"
         mkdir -p "$install_dir"
         install "$tmp/gh_${REQUIRED}_${os}_${arch}/bin/gh" "$install_dir/gh"
-        echo "$install_dir" >> "$GITHUB_PATH"
+        echo "$install_dir" >> "$GITHUB_PATH"  # zizmor: ignore[github-env]
         export PATH="$install_dir:$PATH"
         hash -r
         gh --version
@@ -121,14 +121,14 @@ runs:
           printf '%s %s\n' "$ref" "$sha"
         }
 
-        names=$(jq -r '.skills | keys[]' "$INPUT_SKILLS_LOCK")
-        if [ -z "$names" ]; then
+        names=$(jq -e -r '.skills | keys[]' "$INPUT_SKILLS_LOCK") || {
           echo "::error::No skills found in $INPUT_SKILLS_LOCK"
           exit 1
-        fi
+        }
 
         updated_file=$(mktemp)
-        tmp_lock=$(mktemp)
+        lock_dir=$(dirname -- "$INPUT_SKILLS_LOCK")
+        tmp_lock=$(mktemp "${lock_dir}/.skills-lock.XXXXXXXX")
         cp "$INPUT_SKILLS_LOCK" "$tmp_lock"
 
         while IFS= read -r name; do
@@ -140,7 +140,15 @@ runs:
           fi
           old_digest=$(jq -r --arg n "$name" '.skills[$n].digest // ""' "$tmp_lock")
           echo "Resolving latest ref for ${source} (skill: ${name})..."
-          read -r new_ref new_digest < <(resolve_ref "$source")
+          if ! resolved=$(resolve_ref "$source"); then
+            echo "::error::Failed to resolve latest ref for '${source}' (skill: '${name}')"
+            exit 1
+          fi
+          read -r new_ref new_digest <<<"$resolved"
+          if [ -z "$new_ref" ] || [ -z "$new_digest" ]; then
+            echo "::error::Resolved ref for '${source}' (skill: '${name}') was incomplete: '${resolved}'"
+            exit 1
+          fi
           echo "  -> ref=${new_ref} digest=${new_digest}"
           jq --arg n "$name" --arg ref "$new_ref" --arg digest "$new_digest" \
             '.skills[$n].ref = $ref | .skills[$n].digest = $digest' \

--- a/update-copilot-skills/action.yaml
+++ b/update-copilot-skills/action.yaml
@@ -1,0 +1,168 @@
+name: Update Copilot Skills
+description: Resolve the latest ref + commit SHA for each skill in skills-lock.json and pin them back into the lockfile
+author: devantler-tech
+inputs:
+  skills-lock:
+    description: Path to the skills-lock.json manifest to update
+    required: false
+    default: skills-lock.json
+  gh-version:
+    description: Minimum required `gh` version (must support `gh skill`)
+    required: false
+    default: 2.90.0
+  github-token:
+    description: GitHub token exposed to `gh` as `GH_TOKEN`
+    required: false
+    default: ${{ github.token }}
+outputs:
+  changed:
+    description: "`true` when the lockfile was modified, `false` otherwise"
+    value: ${{ steps.resolve.outputs.changed }}
+  updated-skills:
+    description: Newline-separated list of `name old-digest -> new-digest` lines for skills whose pins changed
+    value: ${{ steps.resolve.outputs.updated-skills }}
+runs:
+  using: composite
+  steps:
+    # Mirror of the gh bootstrap in setup-copilot-skills/action.yaml.
+    # Keep these two blocks in sync — composite actions cannot share steps.
+    - name: 🔧 Ensure gh >= required version
+      shell: bash
+      env:
+        REQUIRED: ${{ inputs.gh-version }}
+      run: |
+        set -euo pipefail
+        if command -v gh >/dev/null 2>&1 && gh skill --help >/dev/null 2>&1; then
+          current=$(gh --version | awk '/^gh version /{print $3; exit}')
+          if [ -z "$current" ]; then
+            echo "::error::Could not determine the installed gh version from 'gh --version' output."
+            exit 1
+          fi
+          if printf '%s\n%s\n' "$REQUIRED" "$current" | sort -V -C; then
+            echo "Installed gh ($current) already supports 'gh skill'."
+            exit 0
+          fi
+        fi
+
+        case "$(uname -s)" in
+          Linux)   os=linux;  ext=tar.gz ;;
+          Darwin)  os=macOS;  ext=zip ;;
+          *) echo "::error::Unsupported OS: $(uname -s)"; exit 1 ;;
+        esac
+        case "$(uname -m)" in
+          x86_64|amd64) arch=amd64 ;;
+          arm64|aarch64) arch=arm64 ;;
+          *) echo "::error::Unsupported arch: $(uname -m)"; exit 1 ;;
+        esac
+
+        tmp=$(mktemp -d)
+        asset="gh_${REQUIRED}_${os}_${arch}.${ext}"
+        url="https://github.com/cli/cli/releases/download/v${REQUIRED}/${asset}"
+        echo "Downloading $url"
+        if [ "$ext" = "zip" ]; then
+          if ! command -v unzip >/dev/null 2>&1; then
+            echo "::error::unzip is required to extract the macOS gh release archive but is not available on PATH."
+            exit 1
+          fi
+          curl -fsSL -o "$tmp/$asset" "$url"
+          unzip -q "$tmp/$asset" -d "$tmp"
+        else
+          curl -fsSL "$url" | tar -xzC "$tmp"
+        fi
+        install_dir="${RUNNER_TEMP:-/tmp}/update-copilot-skills/bin"
+        mkdir -p "$install_dir"
+        install "$tmp/gh_${REQUIRED}_${os}_${arch}/bin/gh" "$install_dir/gh"
+        echo "$install_dir" >> "$GITHUB_PATH"
+        export PATH="$install_dir:$PATH"
+        hash -r
+        gh --version
+        if ! gh skill --help >/dev/null 2>&1; then
+          echo "::error::Installed gh still does not expose the 'skill' command."
+          exit 1
+        fi
+
+    - name: 🔄 Resolve and pin latest skill refs
+      id: resolve
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        INPUT_SKILLS_LOCK: ${{ inputs.skills-lock }}
+      run: |
+        set -euo pipefail
+
+        if [ ! -f "$INPUT_SKILLS_LOCK" ]; then
+          echo "::error::skills-lock file not found: $INPUT_SKILLS_LOCK"
+          exit 1
+        fi
+        if ! command -v jq >/dev/null 2>&1; then
+          echo "::error::jq is required by update-copilot-skills but is not installed on this runner."
+          exit 1
+        fi
+
+        # Resolve latest tag (release) or default branch HEAD for a source repo.
+        # Echoes "<ref> <sha>" on stdout.
+        resolve_ref() {
+          local source="$1"
+          local ref sha
+          if release_json=$(gh api "repos/${source}/releases/latest" 2>/dev/null); then
+            ref=$(jq -r '.tag_name' <<<"$release_json")
+          else
+            ref=$(gh api "repos/${source}" --jq '.default_branch')
+          fi
+          if [ -z "$ref" ] || [ "$ref" = "null" ]; then
+            echo "::error::Could not resolve a ref for ${source}"
+            return 1
+          fi
+          sha=$(gh api "repos/${source}/commits/${ref}" --jq '.sha')
+          if [ -z "$sha" ] || [ "$sha" = "null" ]; then
+            echo "::error::Could not resolve a commit SHA for ${source}@${ref}"
+            return 1
+          fi
+          printf '%s %s\n' "$ref" "$sha"
+        }
+
+        names=$(jq -r '.skills | keys[]' "$INPUT_SKILLS_LOCK")
+        if [ -z "$names" ]; then
+          echo "::error::No skills found in $INPUT_SKILLS_LOCK"
+          exit 1
+        fi
+
+        updated_file=$(mktemp)
+        tmp_lock=$(mktemp)
+        cp "$INPUT_SKILLS_LOCK" "$tmp_lock"
+
+        while IFS= read -r name; do
+          [ -z "$name" ] && continue
+          source=$(jq -r --arg n "$name" '.skills[$n].source' "$tmp_lock")
+          if [ -z "$source" ] || [ "$source" = "null" ]; then
+            echo "::error::Skill '$name' is missing 'source' in $INPUT_SKILLS_LOCK"
+            exit 1
+          fi
+          old_digest=$(jq -r --arg n "$name" '.skills[$n].digest // ""' "$tmp_lock")
+          echo "Resolving latest ref for ${source} (skill: ${name})..."
+          read -r new_ref new_digest < <(resolve_ref "$source")
+          echo "  -> ref=${new_ref} digest=${new_digest}"
+          jq --arg n "$name" --arg ref "$new_ref" --arg digest "$new_digest" \
+            '.skills[$n].ref = $ref | .skills[$n].digest = $digest' \
+            "$tmp_lock" > "${tmp_lock}.next"
+          mv "${tmp_lock}.next" "$tmp_lock"
+          if [ "$old_digest" != "$new_digest" ]; then
+            printf '%s %s -> %s\n' "$name" "${old_digest:-<unset>}" "$new_digest" >> "$updated_file"
+          fi
+        done <<<"$names"
+
+        if cmp -s "$INPUT_SKILLS_LOCK" "$tmp_lock"; then
+          echo "changed=false" >> "$GITHUB_OUTPUT"
+          echo "No changes to $INPUT_SKILLS_LOCK"
+        else
+          mv "$tmp_lock" "$INPUT_SKILLS_LOCK"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          echo "Updated $INPUT_SKILLS_LOCK"
+        fi
+
+        {
+          echo "updated-skills<<EOF"
+          [ -s "$updated_file" ] && cat "$updated_file"
+          echo "EOF"
+        } >> "$GITHUB_OUTPUT"
+        rm -f "$updated_file" "$tmp_lock" "${tmp_lock}.next" 2>/dev/null || true

--- a/update-copilot-skills/action.yaml
+++ b/update-copilot-skills/action.yaml
@@ -30,7 +30,7 @@ runs:
       shell: bash
       env:
         REQUIRED: ${{ inputs.gh-version }}
-      run: |
+      run: | # zizmor: ignore[github-env]
         set -euo pipefail
         if command -v gh >/dev/null 2>&1 && gh skill --help >/dev/null 2>&1; then
           current=$(gh --version | awk '/^gh version /{print $3; exit}')


### PR DESCRIPTION
Adds a sibling `update-copilot-skills` composite action that resolves and pins the latest skill refs back into `skills-lock.json`, and teaches `setup-copilot-skills` to honor those pins on install.

Fixes #87

## What changed

- **New action `update-copilot-skills/`** — for each skill in `skills-lock.json`:
  1. Calls `gh api repos/<source>/releases/latest` for the newest release tag.
  2. Falls back to the repo's default branch when no release exists.
  3. Resolves the commit SHA via `gh api repos/<source>/commits/<ref>`.
  4. Writes `ref` + `digest` (full commit SHA) back into the lockfile entry atomically.

  Outputs `changed` and `updated-skills` so the calling workflow can short-circuit when there is nothing to bump and surface a clean diff in the PR body.

- **`setup-copilot-skills` honors pins** — when a lockfile entry carries `digest` (preferred) or `ref`, the install step appends `--pin <value>` to `gh skill install`. Inline `source`+`skills` mode is unchanged.

- **Lockfile shape (additive, backward compatible)** — entries gain optional `ref` + `digest`:
  ```json
  "git-commit": {
    "source": "devantler-tech/skills",
    "sourceType": "github",
    "ref": "v0.1.1",
    "digest": "6d50a7587e0ff372277dc4a33ccb8b8ea2ff7470"
  }
  ```

- **Tests**
  - New `test-update-copilot-skills.yaml`: `test-update-from-lock` (ubuntu + macos) asserts `changed=true` and a 40-char SHA digest is written; `test-update-noop` runs the action twice and asserts the second run is a no-op; `test-missing-lockfile` asserts failure when the path does not exist.
  - Extended `test-setup-copilot-skills.yaml` with `test-from-lock-pinned`, which installs from a lockfile pinned to the historical commit `6d50a758…` and verifies the SHA appears in the installed `SKILL.md` frontmatter (proves `--pin` was honored).

- **Docs** — new `update-copilot-skills/README.md` (per the [template](https://github.com/devantler-tech/.github)), updated `setup-copilot-skills/README.md` documenting the new optional fields and reproducibility guarantee, new row in the root README action table.

## Why

`skills-lock.json` was not actually locked — `gh skill install` resolved "latest" each run, so the scheduled updater workflow could never produce a renovate-style lockfile-bump PR (see #87 for full context). Pinning `digest` lets us treat the lockfile diff as the authoritative version-bump artifact.

## Type of change

- [x] 🚀 New feature

## Stacked PRs (follow-up, not in this PR)

Once this lands, downstream callsites should switch to the new action:

- [ ] [`devantler-tech/reusable-workflows`](https://github.com/devantler-tech/reusable-workflows/blob/main/.github/workflows/update-copilot-skills.yaml) — swap `setup-copilot-skills@<sha>` → `update-copilot-skills@<new-sha>`; drop `agent`/`scope` inputs (irrelevant for a lockfile bump).
- [ ] [`devantler-tech/ksail`](https://github.com/devantler-tech/ksail/blob/main/.github/workflows/update-skills.yaml) — swap action, or preferably collapse the inline job into `uses: devantler-tech/reusable-workflows/.github/workflows/update-copilot-skills.yaml@<sha>` once the reusable-workflows PR has merged.
- [ ] [`devantler-tech/skills`](https://github.com/devantler-tech/skills/blob/main/README.md) — docs mention of the new action alongside the existing `setup-copilot-skills` reference.

## Verification

- `python3 -c 'import yaml; …'` parses all touched action.yaml + workflow files.
- `zizmor` reports only the preexisting `github-env` finding on the gh-bootstrap block (mirrored verbatim into the new action with a comment); no regressions.
- Smoke test of the resolver logic locally against `devantler-tech/skills` correctly produced `ref=v0.1.1 digest=6d50a7587e0ff372277dc4a33ccb8b8ea2ff7470`, matching the historical pin used in the new test.