### PR TITLE
fix(update-copilot-skills): address post-merge review comments

### DIFF
--- a/setup-copilot-skills/README.md
+++ b/setup-copilot-skills/README.md
@@ -81,7 +81,7 @@ steps:
       source: devantler-tech/skills
       skills: git-commit
       agent: github-copilot
-      scope: repo
+      scope: user
 ```
 
 ### Inside a scheduled update workflow

--- a/setup-copilot-skills/action.yaml
+++ b/setup-copilot-skills/action.yaml
@@ -58,7 +58,7 @@ runs:
         case "$(uname -s)" in
           Linux)   os=linux;  ext=tar.gz ;;
           Darwin)  os=macOS;  ext=zip ;;
-          *) echo "::error::Unsupported OS: $(uname -s)"; exit 1 ;;
+          *) echo "::error::Automatic gh install is only supported on Linux and macOS. On $(uname -s) (e.g. Windows), preinstall gh >= ${REQUIRED} on the runner before this step."; exit 1 ;;
         esac
         case "$(uname -m)" in
           x86_64|amd64) arch=amd64 ;;

--- a/update-copilot-skills/action.yaml
+++ b/update-copilot-skills/action.yaml
@@ -47,7 +47,7 @@ runs:
         case "$(uname -s)" in
           Linux)   os=linux;  ext=tar.gz ;;
           Darwin)  os=macOS;  ext=zip ;;
-          *) echo "::error::Unsupported OS: $(uname -s)"; exit 1 ;;
+          *) echo "::error::Automatic gh install is only supported on Linux and macOS. On $(uname -s) (e.g. Windows), preinstall gh >= ${REQUIRED} on the runner before this step."; exit 1 ;;
         esac
         case "$(uname -m)" in
           x86_64|amd64) arch=amd64 ;;
@@ -103,12 +103,21 @@ runs:
         # Echoes "<ref> <sha>" on stdout.
         resolve_ref() {
           local source="$1"
-          local ref sha
-          if release_json=$(gh api "repos/${source}/releases/latest" 2>/dev/null); then
+          local ref sha release_json release_error_file release_error_message
+          release_error_file=$(mktemp)
+          if release_json=$(gh api "repos/${source}/releases/latest" 2>"$release_error_file"); then
             ref=$(jq -r '.tag_name' <<<"$release_json")
           else
-            ref=$(gh api "repos/${source}" --jq '.default_branch')
+            release_error_message=$(tr '\n' ' ' <"$release_error_file")
+            if grep -qiE '404|Not Found' "$release_error_file"; then
+              ref=$(gh api "repos/${source}" --jq '.default_branch')
+            else
+              rm -f "$release_error_file"
+              echo "::error::Failed to resolve latest release for ${source}: ${release_error_message}"
+              return 1
+            fi
           fi
+          rm -f "$release_error_file"
           if [ -z "$ref" ] || [ "$ref" = "null" ]; then
             echo "::error::Could not resolve a ref for ${source}"
             return 1


### PR DESCRIPTION
Follow-up to #88 addressing the three copilot-pull-request-reviewer comments that landed after merge.

## Changes

- **`resolve_ref` fails loud on non-404 API errors.** Previously any failure from `gh api repos/<source>/releases/latest` (rate limit, auth, transient network) was treated as 'no release exists' and fell back to the default branch, silently drifting pins. Now only an actual 404/Not Found triggers the branch fallback; every other exit surfaces the gh error message and aborts the action. Applied from the reviewer's suggestion on [#88 (comment)](https://github.com/devantler-tech/actions/pull/88#discussion_r3105608803).
- **Clearer bootstrap error on unsupported runners.** The `Unsupported OS` path now states that auto-install is Linux/macOS only and that Windows needs a preinstalled `gh >= ${REQUIRED}`. Mirrored on `setup-copilot-skills` to stay in sync.
- **Fix stale `scope: repo` example in setup-copilot-skills README** so the documented input (`project | user`) and the code sample agree.

## Context

- All three items were raised by `copilot-pull-request-reviewer` on #88 after auto-merge landed.
- Follows the repo's contributing guide (https://github.com/devantler-tech/.github PR template).
