### PR TITLE
feat(update-copilot-skills): auto-discover skill root directories

### DIFF
--- a/update-copilot-skills/README.md
+++ b/update-copilot-skills/README.md
@@ -8,7 +8,7 @@ The `github-*` frontmatter that `gh skill install` injects into each `SKILL.md` 
 
 | Name | Description | Required | Default |
 |------|-------------|----------|---------|
-| `dir` | Directory to scan for installed skills (passed to `gh skill update --dir`) | ❌ | `.` |
+| `dir` | Directory to scan for installed skills. The action discovers all skill root directories under this path and runs `gh skill update --all --dir <root>` for each one. A skill root is any directory containing a `skills/*/SKILL.md` pattern. This supports both the standard layout (`.agents/skills/`) and nested layouts like `plugins/<plugin>/skills/<skill>/`. | ❌ | `.` |
 | `dry-run` | When `true`, pass `--dry-run` (report without modifying files) | ❌ | `false` |
 | `unpin` | When `true`, pass `--unpin` (clear pinned versions and include pinned skills) | ❌ | `false` |
 | `gh-version` | Minimum required `gh` version (must support `gh skill`) | ❌ | `2.90.0` |
@@ -65,6 +65,22 @@ jobs:
 ```
 
 For a batteries-included version of the above, use the reusable workflow [`devantler-tech/reusable-workflows/.github/workflows/update-copilot-skills.yaml`](https://github.com/devantler-tech/reusable-workflows/blob/main/.github/workflows/update-copilot-skills.yaml).
+
+### Plugin directory layout
+
+For repositories that organise skills into subdirectories (e.g. copilot-plugins):
+
+```yaml
+# plugins/
+#   go/skills/golang-pro/SKILL.md
+#   github/skills/gh-cli/SKILL.md
+#   ...
+
+- id: update
+  uses: devantler-tech/actions/update-copilot-skills@v2
+  with:
+    dir: plugins   # discovers plugins/go, plugins/github, … and updates each
+```
 
 ## Migrating from v1
 

--- a/update-copilot-skills/action.yaml
+++ b/update-copilot-skills/action.yaml
@@ -120,7 +120,11 @@ runs:
         # gh skill update --dir X expects X/skills/*/SKILL.md (one level).
         # To support nested layouts like plugins/<plugin>/skills/<skill>/SKILL.md,
         # we find every SKILL.md and derive the root each one belongs to.
-        mapfile -t roots < <(
+        # Use a while-read loop instead of mapfile for bash 3.2 compatibility (macOS).
+        roots=()
+        while IFS= read -r root; do
+          roots+=("$root")
+        done < <(
           find "$INPUT_DIR" -type f -name SKILL.md -print0 \
             | while IFS= read -r -d '' md; do
                 skill_dir=$(dirname "$md")

--- a/update-copilot-skills/action.yaml
+++ b/update-copilot-skills/action.yaml
@@ -105,14 +105,6 @@ runs:
           exit 1
         fi
 
-        flags=(--all --dir "$INPUT_DIR")
-        case "$INPUT_DRY_RUN" in
-          true|1|yes) flags+=(--dry-run) ;;
-        esac
-        case "$INPUT_UNPIN" in
-          true|1|yes) flags+=(--unpin) ;;
-        esac
-
         # Snapshot SKILL.md contents before running so we can detect modifications
         # without relying on git being present in the caller's environment.
         if ! command -v shasum >/dev/null 2>&1; then
@@ -124,12 +116,53 @@ runs:
           | sort -z \
           | xargs -0 -r shasum -a 256 >"$before"
 
-        out=$(mktemp)
-        if ! gh skill update "${flags[@]}" 2>&1 | tee "$out"; then
-          echo "::error::'gh skill update ${flags[*]}' failed."
-          rm -f "$before" "$out"
-          exit 1
+        # Discover all skill root directories under INPUT_DIR.
+        # gh skill update --dir X expects X/skills/*/SKILL.md (one level).
+        # To support nested layouts like plugins/<plugin>/skills/<skill>/SKILL.md,
+        # we find every SKILL.md and derive the root each one belongs to.
+        mapfile -t roots < <(
+          find "$INPUT_DIR" -type f -name SKILL.md -print0 \
+            | while IFS= read -r -d '' md; do
+                skill_dir=$(dirname "$md")
+                parent_dir=$(dirname "$skill_dir")
+                if [[ "$(basename "$parent_dir")" == "skills" ]]; then
+                  dirname "$parent_dir"
+                else
+                  echo "$parent_dir"
+                fi
+              done \
+            | sort -u
+        )
+
+        if [ ${#roots[@]} -eq 0 ]; then
+          echo "No installed skills found."
+          echo "changed=false" >> "$GITHUB_OUTPUT"
+          {
+            echo "updated-skills<<EOF"
+            echo "No installed skills found."
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          rm -f "$before"
+          exit 0
         fi
+
+        out=$(mktemp)
+        status=0
+        for root in "${roots[@]}"; do
+          root_flags=(--all --dir "$root")
+          case "$INPUT_DRY_RUN" in
+            true|1|yes) root_flags+=(--dry-run) ;;
+          esac
+          case "$INPUT_UNPIN" in
+            true|1|yes) root_flags+=(--unpin) ;;
+          esac
+          echo "::group::Updating skills in $root"
+          if ! gh skill update "${root_flags[@]}" 2>&1 | tee -a "$out"; then
+            echo "::error::'gh skill update ${root_flags[*]}' failed."
+            status=1
+          fi
+          echo "::endgroup::"
+        done
 
         after=$(mktemp)
         find "$INPUT_DIR" -type f -name SKILL.md -print0 \
@@ -153,3 +186,7 @@ runs:
         } >> "$GITHUB_OUTPUT"
 
         rm -f "$before" "$after" "$out"
+
+        if [ "$status" -ne 0 ]; then
+          exit 1
+        fi


### PR DESCRIPTION
The action now discovers all skill root directories under the input `dir` and runs `gh skill update --all --dir <root>` for each one. This supports nested layouts like `plugins/<plugin>/skills/<skill>/SKILL.md` in addition to the standard `.agents/skills/` layout.

### What changed

- **`update-copilot-skills/action.yaml`** — replaced the single `gh skill update --dir "$INPUT_DIR"` call with an auto-discovery loop: `find` all `SKILL.md` files, derive each one's skill root (the directory above the `skills/` sub-tree), deduplicate with `sort -u`, then iterate and call `gh skill update --all --dir <root>` per root. Per-root failures are accumulated and the step exits non-zero at the end, so all roots are always attempted. When no `SKILL.md` files are found the step exits cleanly with `changed=false`.
- **`update-copilot-skills/README.md`** — updated `dir` input description to explain the auto-discovery behaviour; added a "Plugin directory layout" usage example.

### `--dir` behaviour reference

| `--dir` value | What `gh skill update` searches |
|---|---|
| `.agents` | `.agents/skills/*/SKILL.md` ✅ |
| `.agents/skills` | `.agents/skills/*/SKILL.md` ✅ |
| `plugins/go` | `plugins/go/skills/*/SKILL.md` ✅ |
| `plugins` | `plugins/skills/*/SKILL.md` ❌ not found |
| `.` | `./skills/*/SKILL.md` ❌ not found |

The discovery loop resolves this by deriving the correct root for each installed skill regardless of nesting depth.