### PR TITLE
fix: pass skills directory to gh skill update to fix write path

### DIFF
--- a/update-copilot-skills/README.md
+++ b/update-copilot-skills/README.md
@@ -8,7 +8,7 @@ The `github-*` frontmatter that `gh skill install` injects into each `SKILL.md` 
 
 | Name | Description | Required | Default |
 |------|-------------|----------|---------|
-| `dir` | Directory to scan for installed skills. The action discovers all skill root directories under this path and runs `gh skill update --all --dir <root>` for each one. A skill root is any directory containing a `skills/*/SKILL.md` pattern. This supports both the standard layout (`.agents/skills/`) and nested layouts like `plugins/<plugin>/skills/<skill>/`. | ❌ | `.` |
+| `dir` | Directory to scan for installed skills. The action finds every `SKILL.md` under this path, uses its immediate parent (the directory containing individual skill subdirectories, e.g. `skills/`) as the `--dir` argument, and runs `gh skill update --all --dir <skills-dir>` for each unique `<skills-dir>`. This supports both the standard layout (`.agents/skills/`) and nested layouts like `plugins/<plugin>/skills/<skill>/`. | ❌ | `.` |
 | `dry-run` | When `true`, pass `--dry-run` (report without modifying files) | ❌ | `false` |
 | `unpin` | When `true`, pass `--unpin` (clear pinned versions and include pinned skills) | ❌ | `false` |
 | `gh-version` | Minimum required `gh` version (must support `gh skill`) | ❌ | `2.90.0` |
@@ -79,7 +79,7 @@ For repositories that organise skills into subdirectories (e.g. copilot-plugins)
 - id: update
   uses: devantler-tech/actions/update-copilot-skills@v2
   with:
-    dir: plugins   # discovers plugins/go, plugins/github, … and updates each
+    dir: plugins   # discovers plugins/go/skills, plugins/github/skills, … and updates each
 ```
 
 ## Migrating from v1

--- a/update-copilot-skills/action.yaml
+++ b/update-copilot-skills/action.yaml
@@ -116,10 +116,10 @@ runs:
           | sort -z \
           | xargs -0 -r shasum -a 256 >"$before"
 
-        # Discover all skill root directories under INPUT_DIR.
-        # gh skill update --dir X expects X/skills/*/SKILL.md (one level).
-        # To support nested layouts like plugins/<plugin>/skills/<skill>/SKILL.md,
-        # we find every SKILL.md and derive the root each one belongs to.
+        # Discover all parent directories of skill subdirectories under INPUT_DIR.
+        # gh skill update --dir X discovers X/*/SKILL.md and writes back to X/<skill>/SKILL.md.
+        # Passing the immediate parent of each skill dir (e.g. .agents/skills or plugins/<p>/skills)
+        # ensures discovery and writes land in the same place.
         # Use a while-read loop instead of mapfile for bash 3.2 compatibility (macOS).
         roots=()
         while IFS= read -r root; do
@@ -129,11 +129,7 @@ runs:
             | while IFS= read -r -d '' md; do
                 skill_dir=$(dirname "$md")
                 parent_dir=$(dirname "$skill_dir")
-                if [[ "$(basename "$parent_dir")" == "skills" ]]; then
-                  dirname "$parent_dir"
-                else
-                  echo "$parent_dir"
-                fi
+                echo "$parent_dir"
               done \
             | sort -u
         )


### PR DESCRIPTION
## Problem

`gh skill update --dir X` discovers skills at both `X/skills/*/SKILL.md` and `X/*/SKILL.md`, but **always writes** updated files to `X/<skill>/SKILL.md`. The old auto-discovery logic climbed up past `skills/` and passed the plugin directory as `--dir`, so for a skill at `plugins/github/skills/gh-stack/SKILL.md` it passed `--dir plugins/github` — causing `gh` to write the update to `plugins/github/gh-stack/SKILL.md` (a duplicate) instead of the original path.

## Fix

Remove the `if basename == "skills"` branch and always pass `parent_dir` (the immediate parent of the skill subdirectory) as `--dir`:

| Layout | `--dir` before | `--dir` after |
|--------|---------------|--------------|
| `.agents/skills/gh-stack/SKILL.md` | `.agents` | `.agents/skills` ✅ |
| `plugins/github/skills/gh-stack/SKILL.md` | `plugins/github` | `plugins/github/skills` ✅ |
| `.agents/gh-stack/SKILL.md` | `.agents` | `.agents` ✅ |

## Changes

- **`update-copilot-skills/action.yaml`** — simplify discovery loop to emit `parent_dir` unconditionally; update inline comments
- **`update-copilot-skills/README.md`** — update `dir` input description and plugin layout example comment to reflect the corrected behaviour