### PR TITLE
ci: add enable-auto-merge workflow

### DIFF
--- a/.github/workflows/active-enable-auto-merge.yaml
+++ b/.github/workflows/active-enable-auto-merge.yaml
@@ -1,0 +1,13 @@
+name: 🔀 Enable Auto-Merge
+
+on:
+  pull_request:
+  merge_group:
+
+permissions: {}
+
+jobs:
+  auto-merge:
+    uses: devantler-tech/reusable-workflows/.github/workflows/enable-auto-merge.yaml@5a334687e73feec66012e62db518716a8618417a # v3.0.0
+    secrets:
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
Adds `.github/workflows/active-enable-auto-merge.yaml` — a caller workflow that triggers the reusable `enable-auto-merge` workflow from `devantler-tech/reusable-workflows`.

This is needed because PRs merged by `github-actions[bot]` (default token) don't trigger the release workflow — only merges by `botantler[bot]` (App token) do. This workflow ensures PRs are merged via the App token.