### PR TITLE
refactor: replace inline status-check jobs with require-checks-in-pr action

### DIFF
--- a/.github/workflows/test-approve-pr.yaml
+++ b/.github/workflows/test-approve-pr.yaml
@@ -28,8 +28,9 @@ jobs:
           app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
           pr-number: ${{ github.event.pull_request.number }}
 
-  status-check:
-    if: ${{ !cancelled() }}
+  ci-required-checks:
+    name: CI - Required Checks
+    if: ${{ always() }}
     needs: [test-approve-pr]
     runs-on: ubuntu-latest
     steps:
@@ -38,10 +39,12 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Check status
-        env:
-          RESULT: ${{ needs.test-approve-pr.result }}
-        run: |
-          if [[ "$RESULT" == "failure" ]]; then
-            exit 1
-          fi
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: ./require-checks-in-pr
+        with:
+          job-results: >-
+            ${{ needs.test-approve-pr.result }}

--- a/.github/workflows/test-create-issues-from-todos.yaml
+++ b/.github/workflows/test-create-issues-from-todos.yaml
@@ -30,8 +30,9 @@ jobs:
           app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
           project: organization/devantler-tech/5
 
-  status-check:
-    if: ${{ !cancelled() }}
+  ci-required-checks:
+    name: CI - Required Checks
+    if: ${{ always() }}
     needs: [test-create-issues-from-todos]
     runs-on: ubuntu-latest
     steps:
@@ -40,10 +41,12 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Check status
-        env:
-          RESULT: ${{ needs.test-create-issues-from-todos.result }}
-        run: |
-          if [[ "$RESULT" == "failure" ]]; then
-            exit 1
-          fi
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: ./require-checks-in-pr
+        with:
+          job-results: >-
+            ${{ needs.test-create-issues-from-todos.result }}

--- a/.github/workflows/test-enable-auto-merge-on-pr.yaml
+++ b/.github/workflows/test-enable-auto-merge-on-pr.yaml
@@ -26,8 +26,9 @@ jobs:
         with:
           pr-number: ${{ github.event.pull_request.number }}
 
-  status-check:
-    if: ${{ !cancelled() }}
+  ci-required-checks:
+    name: CI - Required Checks
+    if: ${{ always() }}
     needs: [test-enable-auto-merge-on-pr]
     runs-on: ubuntu-latest
     steps:
@@ -36,10 +37,12 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Check status
-        env:
-          RESULT: ${{ needs.test-enable-auto-merge-on-pr.result }}
-        run: |
-          if [[ "$RESULT" == "failure" ]]; then
-            exit 1
-          fi
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: ./require-checks-in-pr
+        with:
+          job-results: >-
+            ${{ needs.test-enable-auto-merge-on-pr.result }}

--- a/.github/workflows/test-login-to-ghcr.yaml
+++ b/.github/workflows/test-login-to-ghcr.yaml
@@ -30,8 +30,9 @@ jobs:
       - name: ✅ Verify GHCR login
         run: cat ~/.docker/config.json | grep -q "ghcr.io"
 
-  status-check:
-    if: ${{ !cancelled() }}
+  ci-required-checks:
+    name: CI - Required Checks
+    if: ${{ always() }}
     needs: [test-login-to-ghcr]
     runs-on: ubuntu-latest
     steps:
@@ -40,10 +41,12 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Check status
-        env:
-          RESULT: ${{ needs.test-login-to-ghcr.result }}
-        run: |
-          if [[ "$RESULT" == "failure" ]]; then
-            exit 1
-          fi
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: ./require-checks-in-pr
+        with:
+          job-results: >-
+            ${{ needs.test-login-to-ghcr.result }}

--- a/.github/workflows/test-run-dotnet-tests.yaml
+++ b/.github/workflows/test-run-dotnet-tests.yaml
@@ -32,8 +32,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           working-directory: .github/fixtures/run-dotnet-tests
 
-  status-check:
-    if: ${{ !cancelled() }}
+  ci-required-checks:
+    name: CI - Required Checks
+    if: ${{ always() }}
     needs: [test-run-dotnet-tests]
     runs-on: ubuntu-latest
     steps:
@@ -42,10 +43,12 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Check status
-        env:
-          RESULT: ${{ needs.test-run-dotnet-tests.result }}
-        run: |
-          if [[ "$RESULT" == "failure" ]]; then
-            exit 1
-          fi
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: ./require-checks-in-pr
+        with:
+          job-results: >-
+            ${{ needs.test-run-dotnet-tests.result }}

--- a/.github/workflows/test-setup-copilot-skills.yaml
+++ b/.github/workflows/test-setup-copilot-skills.yaml
@@ -162,8 +162,9 @@ jobs:
             exit 1
           fi
 
-  status-check:
-    if: ${{ always() && !cancelled() }}
+  ci-required-checks:
+    name: CI - Required Checks
+    if: ${{ always() }}
     needs: [test-inline, test-pinned, test-missing-skills-input, test-malformed-line]
     runs-on: ubuntu-latest
     steps:
@@ -172,15 +173,15 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Check status
-        env:
-          RESULT_INLINE: ${{ needs.test-inline.result }}
-          RESULT_PINNED: ${{ needs.test-pinned.result }}
-          RESULT_MISSING: ${{ needs.test-missing-skills-input.result }}
-          RESULT_MALFORMED: ${{ needs.test-malformed-line.result }}
-        run: |
-          for result in "$RESULT_INLINE" "$RESULT_PINNED" "$RESULT_MISSING" "$RESULT_MALFORMED"; do
-            if [[ "$result" == "failure" ]]; then
-              exit 1
-            fi
-          done
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: ./require-checks-in-pr
+        with:
+          job-results: >-
+            ${{ needs.test-inline.result }}
+            ${{ needs.test-pinned.result }}
+            ${{ needs.test-missing-skills-input.result }}
+            ${{ needs.test-malformed-line.result }}

--- a/.github/workflows/test-setup-go-toolchain.yaml
+++ b/.github/workflows/test-setup-go-toolchain.yaml
@@ -74,8 +74,9 @@ jobs:
           fi
           echo "GOPRIVATE: $goprivate"
 
-  status-check:
-    if: ${{ !cancelled() }}
+  ci-required-checks:
+    name: CI - Required Checks
+    if: ${{ always() }}
     needs: [test-setup-go-toolchain, test-private-modules]
     runs-on: ubuntu-latest
     steps:
@@ -84,14 +85,13 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Check status
-        env:
-          RESULT_SETUP: ${{ needs.test-setup-go-toolchain.result }}
-          RESULT_PRIVATE: ${{ needs.test-private-modules.result }}
-        run: |
-          results=("$RESULT_SETUP" "$RESULT_PRIVATE")
-          for result in "${results[@]}"; do
-            if [[ "$result" == "failure" ]]; then
-              exit 1
-            fi
-          done
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: ./require-checks-in-pr
+        with:
+          job-results: >-
+            ${{ needs.test-setup-go-toolchain.result }}
+            ${{ needs.test-private-modules.result }}

--- a/.github/workflows/test-setup-ksail-cli.yaml
+++ b/.github/workflows/test-setup-ksail-cli.yaml
@@ -32,8 +32,9 @@ jobs:
         shell: bash
         run: ksail --version
 
-  status-check:
-    if: ${{ !cancelled() }}
+  ci-required-checks:
+    name: CI - Required Checks
+    if: ${{ always() }}
     needs: [test-setup-ksail-cli]
     runs-on: ubuntu-latest
     steps:
@@ -42,10 +43,12 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Check status
-        env:
-          RESULT: ${{ needs.test-setup-ksail-cli.result }}
-        run: |
-          if [[ "$RESULT" == "failure" ]]; then
-            exit 1
-          fi
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: ./require-checks-in-pr
+        with:
+          job-results: >-
+            ${{ needs.test-setup-ksail-cli.result }}

--- a/.github/workflows/test-sync-github-labels.yaml
+++ b/.github/workflows/test-sync-github-labels.yaml
@@ -28,8 +28,9 @@ jobs:
           config-file: .github/labels.yaml
           delete-other-labels: "false"
 
-  status-check:
-    if: ${{ !cancelled() }}
+  ci-required-checks:
+    name: CI - Required Checks
+    if: ${{ always() }}
     needs: [test-sync-github-labels]
     runs-on: ubuntu-latest
     steps:
@@ -38,10 +39,12 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Check status
-        env:
-          RESULT: ${{ needs.test-sync-github-labels.result }}
-        run: |
-          if [[ "$RESULT" == "failure" ]]; then
-            exit 1
-          fi
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: ./require-checks-in-pr
+        with:
+          job-results: >-
+            ${{ needs.test-sync-github-labels.result }}

--- a/.github/workflows/test-update-copilot-skills.yaml
+++ b/.github/workflows/test-update-copilot-skills.yaml
@@ -130,8 +130,9 @@ jobs:
             exit 1
           fi
 
-  status-check:
-    if: ${{ always() && !cancelled() }}
+  ci-required-checks:
+    name: CI - Required Checks
+    if: ${{ always() }}
     needs: [test-update-noop, test-update-dry-run, test-missing-dir]
     runs-on: ubuntu-latest
     steps:
@@ -140,14 +141,14 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Check status
-        env:
-          RESULT_NOOP: ${{ needs.test-update-noop.result }}
-          RESULT_DRY: ${{ needs.test-update-dry-run.result }}
-          RESULT_MISSING: ${{ needs.test-missing-dir.result }}
-        run: |
-          for result in "$RESULT_NOOP" "$RESULT_DRY" "$RESULT_MISSING"; do
-            if [[ "$result" == "failure" ]]; then
-              exit 1
-            fi
-          done
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: ./require-checks-in-pr
+        with:
+          job-results: >-
+            ${{ needs.test-update-noop.result }}
+            ${{ needs.test-update-dry-run.result }}
+            ${{ needs.test-missing-dir.result }}

--- a/.github/workflows/test-upsert-issue.yaml
+++ b/.github/workflows/test-upsert-issue.yaml
@@ -67,8 +67,9 @@ jobs:
           close-comment: "🧪 Closed by test workflow."
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-  status-check:
-    if: ${{ !cancelled() }}
+  ci-required-checks:
+    name: CI - Required Checks
+    if: ${{ always() }}
     needs: [test-upsert-issue-create, test-upsert-issue-close]
     runs-on: ubuntu-latest
     steps:
@@ -77,11 +78,13 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Check status
-        env:
-          CREATE_RESULT: ${{ needs.test-upsert-issue-create.result }}
-          CLOSE_RESULT: ${{ needs.test-upsert-issue-close.result }}
-        run: |
-          if [[ "$CREATE_RESULT" == "failure" || "$CLOSE_RESULT" == "failure" ]]; then
-            exit 1
-          fi
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: ./require-checks-in-pr
+        with:
+          job-results: >-
+            ${{ needs.test-upsert-issue-create.result }}
+            ${{ needs.test-upsert-issue-close.result }}

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -26,3 +26,24 @@ jobs:
 
       - name: 🔒 Run zizmor
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+
+  ci-required-checks:
+    name: CI - Required Checks
+    if: ${{ always() }}
+    needs: [zizmor]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: ./require-checks-in-pr
+        with:
+          job-results: >-
+            ${{ needs.zizmor.result }}


### PR DESCRIPTION
## Summary

Replace all 11 hand-rolled `status-check` jobs across test workflows with the standardized `require-checks-in-pr` composite action, using the job name **"CI - Required Checks"** to match the new org-wide ruleset.

## Changes

- **11 test workflows**: Replaced inline `status-check` jobs with `ci-required-checks` jobs using `./require-checks-in-pr`
- **zizmor.yaml**: Added a new `ci-required-checks` aggregator (previously had no status gate for PRs)
- **No changes**: `active-release.yaml`, `active-sync-github-labels.yaml` (not PR workflows)

### Behaviour improvement

The existing inline scripts only checked for `"failure"` results, silently letting `cancelled` jobs pass through. The `require-checks-in-pr` action treats `cancelled` as failure — providing stricter CI guarantees.

### Consistency

All aggregator jobs now use:
- `if: ${{ always() }}` — ensures the check always reports a status
- `name: CI - Required Checks` — matches the org-wide ruleset
- `./require-checks-in-pr` — dog-foods the local action