### PR TITLE
fix(workflows): revert step-security actions to original authors

### DIFF
--- a/.github/workflows/active-release.yaml
+++ b/.github/workflows/active-release.yaml
@@ -12,4 +12,4 @@ jobs:
   release:
     uses: devantler-tech/reusable-workflows/.github/workflows/create-release.yaml@9ec9792d6c140612f6b5bafa5dc786e751b5ff1a # v2.2.0
     secrets:
-      app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/active-sync-github-labels.yaml
+++ b/.github/workflows/active-sync-github-labels.yaml
@@ -13,11 +13,6 @@ jobs:
     name: Run EndBug/label-sync
     runs-on: ubuntu-latest
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
-        with:
-          egress-policy: audit
-
       - name: 📑 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/test-approve-pr.yaml
+++ b/.github/workflows/test-approve-pr.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: ./approve-pr
         with:
           app-id: ${{ vars.APP_ID }}
-          app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
           pr-number: ${{ github.event.pull_request.number }}
 
   status-check:

--- a/.github/workflows/test-approve-pr.yaml
+++ b/.github/workflows/test-approve-pr.yaml
@@ -11,11 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.event_name, 'pull_request') && (github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'botantler[bot]' || github.event.pull_request.user.login == 'devantler')
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
-        with:
-          egress-policy: audit
-
       - name: 📑 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -33,11 +28,6 @@ jobs:
     needs: [test-approve-pr]
     runs-on: ubuntu-latest
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
-        with:
-          egress-policy: audit
-
       - name: Check status
         env:
           RESULT: ${{ needs.test-approve-pr.result }}

--- a/.github/workflows/test-create-issues-from-todos.yaml
+++ b/.github/workflows/test-create-issues-from-todos.yaml
@@ -13,11 +13,6 @@ jobs:
   test-create-issues-from-todos:
     runs-on: ubuntu-latest
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
-        with:
-          egress-policy: audit
-
       - name: 📑 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -35,11 +30,6 @@ jobs:
     needs: [test-create-issues-from-todos]
     runs-on: ubuntu-latest
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
-        with:
-          egress-policy: audit
-
       - name: Check status
         env:
           RESULT: ${{ needs.test-create-issues-from-todos.result }}

--- a/.github/workflows/test-create-issues-from-todos.yaml
+++ b/.github/workflows/test-create-issues-from-todos.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: ./create-issues-from-todos
         with:
           app-id: ${{ vars.APP_ID }}
-          app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
           project: organization/devantler-tech/5
 
   status-check:

--- a/.github/workflows/test-enable-auto-merge-on-pr.yaml
+++ b/.github/workflows/test-enable-auto-merge-on-pr.yaml
@@ -11,11 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.event_name, 'pull_request') && (github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'botantler[bot]' || github.event.pull_request.user.login == 'devantler')
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
-        with:
-          egress-policy: audit
-
       - name: 📑 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -31,11 +26,6 @@ jobs:
     needs: [test-enable-auto-merge-on-pr]
     runs-on: ubuntu-latest
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
-        with:
-          egress-policy: audit
-
       - name: Check status
         env:
           RESULT: ${{ needs.test-enable-auto-merge-on-pr.result }}

--- a/.github/workflows/test-login-to-ghcr.yaml
+++ b/.github/workflows/test-login-to-ghcr.yaml
@@ -12,11 +12,6 @@ jobs:
   test-login-to-ghcr:
     runs-on: ubuntu-latest
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
-        with:
-          egress-policy: audit
-
       - name: 📑 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -35,11 +30,6 @@ jobs:
     needs: [test-login-to-ghcr]
     runs-on: ubuntu-latest
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
-        with:
-          egress-policy: audit
-
       - name: Check status
         env:
           RESULT: ${{ needs.test-login-to-ghcr.result }}

--- a/.github/workflows/test-login-to-ghcr.yaml
+++ b/.github/workflows/test-login-to-ghcr.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: 🧪 Run login-to-ghcr
         uses: ./login-to-ghcr
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: ✅ Verify GHCR login
         run: cat ~/.docker/config.json | grep -q "ghcr.io"

--- a/.github/workflows/test-run-dotnet-tests.yaml
+++ b/.github/workflows/test-run-dotnet-tests.yaml
@@ -14,11 +14,6 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
-        with:
-          egress-policy: audit
-
       - name: 📑 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -37,11 +32,6 @@ jobs:
     needs: [test-run-dotnet-tests]
     runs-on: ubuntu-latest
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
-        with:
-          egress-policy: audit
-
       - name: Check status
         env:
           RESULT: ${{ needs.test-run-dotnet-tests.result }}

--- a/.github/workflows/test-run-dotnet-tests.yaml
+++ b/.github/workflows/test-run-dotnet-tests.yaml
@@ -28,8 +28,8 @@ jobs:
         uses: ./run-dotnet-tests
         with:
           app-id: ${{ vars.APP_ID }}
-          app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           working-directory: .github/fixtures/run-dotnet-tests
 
   status-check:

--- a/.github/workflows/test-setup-go-toolchain.yaml
+++ b/.github/workflows/test-setup-go-toolchain.yaml
@@ -62,7 +62,7 @@ jobs:
       - name: 🧪 Run setup-go-toolchain with token
         uses: ./setup-go-toolchain
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: ✅ Verify GOPRIVATE is set
         shell: bash

--- a/.github/workflows/test-setup-go-toolchain.yaml
+++ b/.github/workflows/test-setup-go-toolchain.yaml
@@ -15,11 +15,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
-        with:
-          egress-policy: audit
-
       - name: 📑 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -49,11 +44,6 @@ jobs:
   test-private-modules:
     runs-on: ubuntu-latest
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
-        with:
-          egress-policy: audit
-
       - name: 📑 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -79,11 +69,6 @@ jobs:
     needs: [test-setup-go-toolchain, test-private-modules]
     runs-on: ubuntu-latest
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
-        with:
-          egress-policy: audit
-
       - name: Check status
         env:
           RESULT_SETUP: ${{ needs.test-setup-go-toolchain.result }}

--- a/.github/workflows/test-setup-ksail-cli.yaml
+++ b/.github/workflows/test-setup-ksail-cli.yaml
@@ -15,11 +15,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
-        with:
-          egress-policy: audit
-
       - name: 📑 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -37,11 +32,6 @@ jobs:
     needs: [test-setup-ksail-cli]
     runs-on: ubuntu-latest
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
-        with:
-          egress-policy: audit
-
       - name: Check status
         env:
           RESULT: ${{ needs.test-setup-ksail-cli.result }}

--- a/.github/workflows/test-sync-github-labels.yaml
+++ b/.github/workflows/test-sync-github-labels.yaml
@@ -12,11 +12,6 @@ jobs:
   test-sync-github-labels:
     runs-on: ubuntu-latest
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
-        with:
-          egress-policy: audit
-
       - name: 📑 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -33,11 +28,6 @@ jobs:
     needs: [test-sync-github-labels]
     runs-on: ubuntu-latest
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
-        with:
-          egress-policy: audit
-
       - name: Check status
         env:
           RESULT: ${{ needs.test-sync-github-labels.result }}

--- a/.github/workflows/test-upsert-issue.yaml
+++ b/.github/workflows/test-upsert-issue.yaml
@@ -31,7 +31,7 @@ jobs:
           body: |
             This issue is created by the `upsert-issue` test workflow.
             Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify outputs
         env:
@@ -65,7 +65,7 @@ jobs:
           body: "Closed by test."
           open: "false"
           close-comment: "🧪 Closed by test workflow."
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   status-check:
     if: ${{ !cancelled() }}

--- a/.github/workflows/test-upsert-issue.yaml
+++ b/.github/workflows/test-upsert-issue.yaml
@@ -13,11 +13,6 @@ jobs:
   test-upsert-issue-create:
     runs-on: ubuntu-latest
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
-        with:
-          egress-policy: audit
-
       - name: 📑 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -48,11 +43,6 @@ jobs:
     needs: [test-upsert-issue-create]
     runs-on: ubuntu-latest
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
-        with:
-          egress-policy: audit
-
       - name: 📑 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -72,11 +62,6 @@ jobs:
     needs: [test-upsert-issue-create, test-upsert-issue-close]
     runs-on: ubuntu-latest
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
-        with:
-          egress-policy: audit
-
       - name: Check status
         env:
           CREATE_RESULT: ${{ needs.test-upsert-issue-create.result }}

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -14,11 +14,6 @@ jobs:
       contents: read
       actions: read
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
-        with:
-          egress-policy: audit
-
       - name: 📑 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,10 +11,10 @@ Use the `<active-verb>-<purpose>` pattern:
 
 ### Inputs and Outputs
 
-Use **kebab-case**:
+Use **kebab-case** for non-secret inputs, and **UPPER_SNAKE_CASE** for secret inputs:
 
-- ✅ `app-id`, `go-version`, `github-token`
-- ❌ `app_id`, `goVersion`, `APP_ID`
+- ✅ `app-id`, `go-version` (non-secret), `GITHUB_TOKEN`, `APP_PRIVATE_KEY` (secret)
+- ❌ `app_id`, `goVersion`, `github-token` (secret in kebab-case)
 
 ## Action Structure
 

--- a/approve-pr/README.md
+++ b/approve-pr/README.md
@@ -7,7 +7,7 @@ Approve a pull request using a GitHub App identity. This is needed because `GITH
 | Name | Description | Required | Default |
 |------|-------------|----------|---------|
 | `app-id` | GitHub App ID | ✅ | - |
-| `app-private-key` | GitHub App Private Key | ✅ | - |
+| `APP_PRIVATE_KEY` | GitHub App Private Key | ✅ | - |
 | `pr-number` | Pull request number to approve | ✅ | - |
 | `dry-run` | Validate only; do not approve the pull request | - | `false` |
 
@@ -21,7 +21,7 @@ steps:
     uses: devantler-tech/actions/approve-pr@main
     with:
       app-id: ${{ vars.APP_ID }}
-      app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
       pr-number: ${{ github.event.pull_request.number }}
 ```
 
@@ -33,7 +33,7 @@ steps:
     uses: devantler-tech/actions/approve-pr@main
     with:
       app-id: ${{ vars.APP_ID }}
-      app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
       pr-number: ${{ github.event.pull_request.number }}
 
   - name: Enable auto-merge

--- a/approve-pr/action.yaml
+++ b/approve-pr/action.yaml
@@ -6,7 +6,7 @@ inputs:
   app-id:
     description: GitHub App ID
     required: true
-  app-private-key:
+  APP_PRIVATE_KEY:
     description: GitHub App Private Key
     required: true
   pr-number:
@@ -26,7 +26,7 @@ runs:
       id: app-token
       with:
         app-id: ${{ inputs.app-id }}
-        private-key: ${{ inputs.app-private-key }}
+        private-key: ${{ inputs.APP_PRIVATE_KEY }}
 
     - name: ✅ Approve pull request
       if: inputs.dry-run != 'true'

--- a/create-issues-from-todos/README.md
+++ b/create-issues-from-todos/README.md
@@ -7,7 +7,7 @@ Scan code for TODO comments and automatically create corresponding GitHub issues
 | Name | Description | Required | Default |
 |------|-------------|----------|---------|
 | `app-id` | GitHub App ID | ✅ | - |
-| `app-private-key` | GitHub App Private Key | ✅ | - |
+| `APP_PRIVATE_KEY` | GitHub App Private Key | ✅ | - |
 | `project` | GitHub Project to add issues to | ❌ | - |
 
 ## Usage
@@ -20,7 +20,7 @@ steps:
     uses: devantler-tech/actions/create-issues-from-todos@main
     with:
       app-id: ${{ vars.APP_ID }}
-      app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 ```
 
 ### With project integration
@@ -31,6 +31,6 @@ steps:
     uses: devantler-tech/actions/create-issues-from-todos@main
     with:
       app-id: ${{ vars.APP_ID }}
-      app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
       project: "organization/devantler-tech/1"
 ```

--- a/create-issues-from-todos/action.yaml
+++ b/create-issues-from-todos/action.yaml
@@ -5,7 +5,7 @@ inputs:
   app-id:
     description: GitHub App ID
     required: true
-  app-private-key:
+  APP_PRIVATE_KEY:
     description: GitHub App Private Key
     required: true
   project:
@@ -19,7 +19,7 @@ runs:
       id: app-token
       with:
         app-id: ${{ inputs.app-id }}
-        private-key: ${{ inputs.app-private-key }}
+        private-key: ${{ inputs.APP_PRIVATE_KEY }}
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false

--- a/login-to-ghcr/README.md
+++ b/login-to-ghcr/README.md
@@ -6,7 +6,7 @@ Login to GitHub Container Registry (GHCR) for pulling or pushing container image
 
 | Name | Description | Required | Default |
 |------|-------------|----------|---------|
-| `github-token` | GitHub token with `packages:read` (or `packages:write`) scope | ✅ | - |
+| `GITHUB_TOKEN` | GitHub token with `packages:read` (or `packages:write`) scope | ✅ | - |
 
 ## Usage
 
@@ -15,5 +15,5 @@ steps:
   - name: Login to GHCR
     uses: devantler-tech/actions/login-to-ghcr@main
     with:
-      github-token: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/login-to-ghcr/action.yaml
+++ b/login-to-ghcr/action.yaml
@@ -2,7 +2,7 @@ name: Login to GHCR
 description: Login to GitHub Container Registry (GHCR)
 author: devantler-tech
 inputs:
-  github-token:
+  GITHUB_TOKEN:
     description: GitHub token with packages:read (or packages:write) scope
     required: true
 runs:
@@ -13,4 +13,4 @@ runs:
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ inputs.github-token }}
+        password: ${{ inputs.GITHUB_TOKEN }}

--- a/login-to-ghcr/action.yaml
+++ b/login-to-ghcr/action.yaml
@@ -9,7 +9,7 @@ runs:
   using: composite
   steps:
     - name: 🔑 Login to GHCR
-      uses: step-security/docker-login-action@6aa05fe688caf2c58e784663f01b3415ced503e8 # v3.7.0
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
       with:
         registry: ghcr.io
         username: ${{ github.actor }}

--- a/run-dotnet-tests/README.md
+++ b/run-dotnet-tests/README.md
@@ -7,9 +7,9 @@ Test .NET solutions or projects across multiple platforms with code coverage rep
 | Name | Description | Required | Default |
 |------|-------------|----------|---------|
 | `app-id` | GitHub App ID to generate a token | ✅ | - |
-| `app-private-key` | Private key of the GitHub App | ✅ | - |
-| `github-token` | GitHub token to access the repository | ✅ | - |
-| `codecov-token` | Token to upload code coverage to CodeCov | ❌ | - |
+| `APP_PRIVATE_KEY` | Private key of the GitHub App | ✅ | - |
+| `GITHUB_TOKEN` | GitHub token to access the repository | ✅ | - |
+| `CODECOV_TOKEN` | Token to upload code coverage to CodeCov | ❌ | - |
 | `working-directory` | Directory to run the tests in | ❌ | `.` |
 
 ## Usage
@@ -22,9 +22,9 @@ steps:
     uses: devantler-tech/actions/run-dotnet-tests@main
     with:
       app-id: ${{ vars.APP_ID }}
-      app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
-      github-token: ${{ secrets.GITHUB_TOKEN }}
-      codecov-token: ${{ secrets.CODECOV_TOKEN }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 ```
 
 ### Custom working directory
@@ -35,8 +35,8 @@ steps:
     uses: devantler-tech/actions/run-dotnet-tests@main
     with:
       app-id: ${{ vars.APP_ID }}
-      app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
-      github-token: ${{ secrets.GITHUB_TOKEN }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       working-directory: src/MyProject
 ```
 
@@ -48,6 +48,6 @@ steps:
     uses: devantler-tech/actions/run-dotnet-tests@main
     with:
       app-id: ${{ vars.APP_ID }}
-      app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
-      github-token: ${{ secrets.GITHUB_TOKEN }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/run-dotnet-tests/action.yaml
+++ b/run-dotnet-tests/action.yaml
@@ -5,13 +5,13 @@ inputs:
   app-id:
     description: GitHub App ID to generate a token
     required: true
-  app-private-key:
+  APP_PRIVATE_KEY:
     description: Private key of the GitHub App to generate a token
     required: true
-  github-token:
+  GITHUB_TOKEN:
     description: GitHub token to access the repository
     required: true
-  codecov-token:
+  CODECOV_TOKEN:
     description: Token to upload code coverage to CodeCov
   working-directory:
     description: Directory to run the tests in
@@ -34,7 +34,7 @@ runs:
           "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
       env:
         GITHUB_ACTOR: ${{ github.actor }}
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
       shell: bash
     - name: 🧪 Test
       run: dotnet test --collect:"XPlat Code Coverage" --logger "console;verbosity=detailed"
@@ -42,7 +42,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
     - name: 📄 Get Coverage Files
       id: get_coverage_files
-      if: matrix.os != 'windows-latest' && inputs.codecov-token != ''
+      if: matrix.os != 'windows-latest' && inputs.CODECOV_TOKEN != ''
       run: |
         coverage_files=$(find . -name 'coverage.cobertura.xml' -print0 | tr '\0' ',' | sed 's/,$//')
         echo "COVERAGE_FILES=$coverage_files" >> "$GITHUB_OUTPUT"
@@ -50,7 +50,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
     - name: 📄 Get Coverage Files on Windows
       id: get_coverage_files_windows
-      if: matrix.os == 'windows-latest' && inputs.codecov-token != ''
+      if: matrix.os == 'windows-latest' && inputs.CODECOV_TOKEN != ''
       run: |
         $coverage_files = Get-ChildItem -Path . -Recurse -Filter coverage.cobertura.xml -ErrorAction SilentlyContinue | ForEach-Object { $_.FullName }
         $coverage_files = $coverage_files -join ','
@@ -58,10 +58,10 @@ runs:
       shell: pwsh
       working-directory: ${{ inputs.working-directory }}
     - name: 📄 Upload Code Coverage to CodeCov
-      if: inputs.codecov-token != ''
+      if: inputs.CODECOV_TOKEN != ''
       uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
       with:
         files: ${{ steps.get_coverage_files.outputs.COVERAGE_FILES }}
         fail_ci_if_error: true
       env:
-        CODECOV_TOKEN: ${{ inputs.codecov-token }}
+        CODECOV_TOKEN: ${{ inputs.CODECOV_TOKEN }}

--- a/setup-go-toolchain/README.md
+++ b/setup-go-toolchain/README.md
@@ -7,7 +7,7 @@ Setup Go with optional private module support for devantler-tech repositories.
 | Name | Description | Required | Default |
 |------|-------------|----------|---------|
 | `go-version` | Go version to install | ❌ | `stable` |
-| `github-token` | GitHub token for private module access | ❌ | - |
+| `GITHUB_TOKEN` | GitHub token for private module access | ❌ | - |
 
 ## Outputs
 
@@ -42,5 +42,5 @@ steps:
   - name: Setup Go
     uses: devantler-tech/actions/setup-go-toolchain@main
     with:
-      github-token: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/setup-go-toolchain/action.yaml
+++ b/setup-go-toolchain/action.yaml
@@ -6,7 +6,7 @@ inputs:
     description: Go version to install
     required: false
     default: stable
-  github-token:
+  GITHUB_TOKEN:
     description: GitHub token for private module access
     required: false
 outputs:
@@ -23,10 +23,10 @@ runs:
         go-version: ${{ inputs.go-version }}
 
     - name: 🔑 Configure private modules
-      if: inputs.github-token != ''
+      if: inputs.GITHUB_TOKEN != ''
       shell: bash
       env:
-        TOKEN: ${{ inputs.github-token }}
+        TOKEN: ${{ inputs.GITHUB_TOKEN }}
       run: |
         go env -w GOPRIVATE=github.com/devantler-tech/*
         git config --global url."https://x-access-token:${TOKEN}@github.com/devantler-tech/".insteadOf "https://github.com/devantler-tech/"

--- a/upsert-issue/README.md
+++ b/upsert-issue/README.md
@@ -13,7 +13,7 @@ Create, update, reopen, or close a GitHub issue by title. Finds an existing issu
 | `open` | Whether the issue should be open (`true`) or closed (`false`) | ❌ | `true` |
 | `close-comment` | Comment to post when closing the issue | ❌ | `✅ Resolved — closing this issue.` |
 | `repository` | Target repository (`owner/repo`) | ❌ | `${{ github.repository }}` |
-| `github-token` | GitHub token with `issues: write` permission | ❌ | `${{ github.token }}` |
+| `GITHUB_TOKEN` | GitHub token with `issues: write` permission | ❌ | `${{ github.token }}` |
 
 ## Outputs
 

--- a/upsert-issue/action.yaml
+++ b/upsert-issue/action.yaml
@@ -27,7 +27,7 @@ inputs:
     description: "Repository to create/update the issue in (format: owner/repo). Defaults to the current repository."
     required: false
     default: ${{ github.repository }}
-  github-token:
+  GITHUB_TOKEN:
     description: "GitHub token with issues write permission"
     required: false
     default: ${{ github.token }}
@@ -46,7 +46,7 @@ runs:
     - id: upsert
       shell: bash
       env:
-        GH_TOKEN: ${{ inputs.github-token }}
+        GH_TOKEN: ${{ inputs.GITHUB_TOKEN }}
         TITLE: ${{ inputs.title }}
         BODY: ${{ inputs.body }}
         BODY_FILE: ${{ inputs.body-file }}


### PR DESCRIPTION
Replace step-security forks with original upstream actions using SHA pinning, and remove `harden-runner` steps (trial expired).

## Changes

### Replaced actions
| step-security fork | Original upstream |
|---|---|
| `step-security/docker-login-action@6aa05fe6 # v3.7.0` | `docker/login-action@c94ce9fb # v3.7.0` |

### Removed steps
- `step-security/harden-runner` (all versions) — trial expired, no upstream equivalent