### PR TITLE
feat: add Repo Assist labels to central config

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -4,3 +4,39 @@
   color: 'ededed'
 - name: next
   color: '5d3fd3'
+- name: bug
+  color: 'd73a4a'
+- name: enhancement
+  color: 'a2eeef'
+- name: help wanted
+  color: '008672'
+- name: good first issue
+  color: '7057ff'
+- name: documentation
+  color: '0075ca'
+- name: question
+  color: 'd876e3'
+- name: duplicate
+  color: 'cfd3d7'
+- name: wontfix
+  color: 'ffffff'
+- name: spam
+  color: 'e4e669'
+- name: off topic
+  color: 'e4e669'
+- name: needs triage
+  color: 'fbca04'
+- name: needs investigation
+  color: 'fbca04'
+- name: breaking change
+  color: 'b60205'
+- name: performance
+  color: 'f9d0c4'
+- name: security
+  color: 'b60205'
+- name: refactor
+  color: 'c5def5'
+- name: automation
+  color: 'bfdadc'
+- name: repo-assist
+  color: 'bfdadc'


### PR DESCRIPTION
## Description

Add labels required by the [Repo Assist](https://github.com/githubnext/agentics/blob/main/docs/repo-assist.md) agentic workflow to the central label config.

## Changes

Extends `.github/labels.yaml` with 18 additional labels that Repo Assist uses for issue triage (`bug`, `enhancement`, `help wanted`, `good first issue`, `documentation`, `question`, `duplicate`, `wontfix`, `spam`, `off topic`, `needs triage`, `needs investigation`, `breaking change`, `performance`, `security`, `refactor`) and for its own PRs/issues (`automation`, `repo-assist`).

Once merged, the `sync-labels` workflow will propagate these labels to all org repos on the next scheduled run.

## Context

Setting up Repo Assist on `devantler-tech/platform`. This is a prerequisite — see the companion PR on `platform` for the workflow itself.