### PR TITLE
feat: add upload-coverage action for GitHub Code Quality

### DIFF
--- a/.github/fixtures/upload-coverage/coverage.cobertura.xml
+++ b/.github/fixtures/upload-coverage/coverage.cobertura.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?>
+<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
+<coverage line-rate="0.5" branch-rate="0" lines-covered="1" lines-valid="2" branches-covered="0" branches-valid="0" complexity="0" version="0" timestamp="0">
+  <sources>
+    <source>.</source>
+  </sources>
+  <packages>
+    <package name="sample" line-rate="0.5" branch-rate="0" complexity="0">
+      <classes>
+        <class name="sample" filename="sample.go" line-rate="0.5" branch-rate="0" complexity="0">
+          <methods/>
+          <lines>
+            <line number="1" hits="1"/>
+            <line number="2" hits="0"/>
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -561,6 +561,29 @@ jobs:
             exit 1
           fi
 
+  # ── upload-coverage ─────────────────────────────────────────
+  test-upload-coverage:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      code-quality: write
+    steps:
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # Smoke test: the action must wire up and run without crashing. The upload is best-effort
+      # (fail-on-error: false) because GitHub Code Quality coverage must be enabled in repo settings
+      # before reports are accepted — upload errors surface as annotations, not CI failures.
+      - name: 🧪 Run upload-coverage
+        uses: ./upload-coverage
+        with:
+          file: .github/fixtures/upload-coverage/coverage.cobertura.xml
+          language: Go
+          label: code-coverage/test
+          fail-on-error: "false"
+
   # ── upsert-issue ────────────────────────────────────────────
   test-upsert-issue-create:
     runs-on: ubuntu-latest
@@ -657,6 +680,7 @@ jobs:
       - test-update-copilot-skills-noop
       - test-update-copilot-skills-dry-run
       - test-update-copilot-skills-missing-dir
+      - test-upload-coverage
       - test-upsert-issue-create
       - test-upsert-issue-close
       - zizmor
@@ -692,6 +716,7 @@ jobs:
             ${{ needs.test-update-copilot-skills-noop.result }}
             ${{ needs.test-update-copilot-skills-dry-run.result }}
             ${{ needs.test-update-copilot-skills-missing-dir.result }}
+            ${{ needs.test-upload-coverage.result }}
             ${{ needs.test-upsert-issue-create.result }}
             ${{ needs.test-upsert-issue-close.result }}
             ${{ needs.zizmor.result }}

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ flowchart TD
 | [setup-ksail-cli](setup-ksail-cli/README.md) | Install KSail CLI via Homebrew |
 | [sync-github-labels](sync-github-labels/README.md) | Sync GitHub labels from a configuration file |
 | [update-copilot-skills](update-copilot-skills/README.md) | Run `gh skill update --all` against installed skills and report changes |
+| [upload-coverage](upload-coverage/README.md) | Upload a Cobertura coverage report to GitHub Code Quality (and optionally Codecov) |
 | [upsert-issue](upsert-issue/README.md) | Create, update, reopen, or close a GitHub issue by title |
 
 ## Contributing

--- a/upload-coverage/README.md
+++ b/upload-coverage/README.md
@@ -12,7 +12,7 @@ GitHub Code Quality coverage requires the org/repo to be on a **Team** or **Ente
 | `language` | Linguist language name for the report (e.g. `Go`, `C#`) | ✅ | - |
 | `label` | Label for the coverage report (e.g. `code-coverage/go`) | ❌ | `code-coverage` |
 | `fail-on-error` | Fail the step if the GitHub upload fails (errors are always surfaced as annotations) | ❌ | `false` |
-| `token` | GitHub token with `code-quality:write` (the calling job must grant the permission) | ❌ | `${{ github.token }}` |
+| `token` | GitHub token with `code-quality: write` (the calling job must grant the permission) | ❌ | `${{ github.token }}` |
 | `codecov-token` | Optional Codecov token; when set, the report is also uploaded to Codecov (transitional) | ❌ | - |
 
 ## Outputs

--- a/upload-coverage/README.md
+++ b/upload-coverage/README.md
@@ -1,0 +1,82 @@
+# Upload Coverage
+
+Upload a Cobertura XML coverage report to [GitHub Code Quality](https://docs.github.com/code-security/code-quality) so the aggregate coverage percentage appears on pull requests. Optionally also uploads the same report to Codecov during the transition off the external service.
+
+GitHub Code Quality coverage requires the org/repo to be on a **Team** or **Enterprise Cloud** plan, and coverage must be **enabled in the repository's _Settings → Code quality_**. Fork PRs and merge-queue runs are skipped automatically by the underlying [`actions/upload-code-coverage`](https://github.com/actions/upload-code-coverage) action.
+
+## Inputs
+
+| Name | Description | Required | Default |
+|------|-------------|----------|---------|
+| `file` | Path to the Cobertura XML coverage report to upload | ✅ | - |
+| `language` | Linguist language name for the report (e.g. `Go`, `C#`) | ✅ | - |
+| `label` | Label for the coverage report (e.g. `code-coverage/go`) | ❌ | `code-coverage` |
+| `fail-on-error` | Fail the step if the GitHub upload fails (errors are always surfaced as annotations) | ❌ | `false` |
+| `token` | GitHub token with `code-quality:write` (the calling job must grant the permission) | ❌ | `${{ github.token }}` |
+| `codecov-token` | Optional Codecov token; when set, the report is also uploaded to Codecov (transitional) | ❌ | - |
+
+## Outputs
+
+This action has no outputs.
+
+## Permissions
+
+The **calling job** must grant `code-quality: write` — a composite action cannot declare it. For push-triggered workflows that resolve PR numbers, also add `pull-requests: read`.
+
+```yaml
+permissions:
+  contents: read
+  code-quality: write
+```
+
+## Usage
+
+### Go (Cobertura produced via gocover-cobertura)
+
+```yaml
+permissions:
+  contents: read
+  code-quality: write
+steps:
+  - name: 📄 Generate coverage
+    run: |
+      go test -race -coverprofile=coverage.txt -covermode=atomic ./...
+      go run github.com/boumenot/gocover-cobertura@latest < coverage.txt > coverage.cobertura.xml
+
+  - name: 📊 Upload coverage
+    uses: devantler-tech/actions/upload-coverage@main
+    with:
+      file: coverage.cobertura.xml
+      language: Go
+      label: code-coverage/go
+```
+
+### .NET (Cobertura produced by `dotnet test --collect:"XPlat Code Coverage"`)
+
+```yaml
+permissions:
+  contents: read
+  code-quality: write
+steps:
+  - name: 📊 Upload coverage
+    uses: devantler-tech/actions/upload-coverage@main
+    with:
+      file: ./TestResults/coverage.cobertura.xml
+      language: C#
+      label: code-coverage/dotnet
+```
+
+### Transitional Codecov upload
+
+Pass `codecov-token` to additionally upload to Codecov while validating the native feature:
+
+```yaml
+steps:
+  - name: 📊 Upload coverage
+    uses: devantler-tech/actions/upload-coverage@main
+    with:
+      file: coverage.cobertura.xml
+      language: Go
+      label: code-coverage/go
+      codecov-token: ${{ secrets.CODECOV_TOKEN }}
+```

--- a/upload-coverage/action.yaml
+++ b/upload-coverage/action.yaml
@@ -21,7 +21,7 @@ inputs:
     default: "false"
   token:
     description: >-
-      GitHub token with the code-quality:write permission. Defaults to the workflow token. The
+      GitHub token with the `code-quality: write` permission. Defaults to the workflow token. The
       CALLING job must grant `code-quality: write` — a composite action cannot declare it itself.
     required: false
     default: ${{ github.token }}

--- a/upload-coverage/action.yaml
+++ b/upload-coverage/action.yaml
@@ -1,0 +1,53 @@
+name: Upload Coverage
+description: Upload a Cobertura XML coverage report to GitHub Code Quality (and optionally Codecov).
+author: devantler-tech
+inputs:
+  file:
+    description: Path to the Cobertura XML coverage report to upload.
+    required: true
+  language:
+    description: Linguist language name for the report (e.g. "Go", "C#", "TypeScript").
+    required: true
+  label:
+    description: Label for the coverage report (e.g. "code-coverage/go").
+    required: false
+    default: code-coverage
+  fail-on-error:
+    description: >-
+      Fail the step if the GitHub Code Quality upload fails. Defaults to "false" so a transient
+      preview-period hiccup never blocks CI; upload errors are still surfaced as ::error::
+      annotations. Set to "true" once the feature is generally available.
+    required: false
+    default: "false"
+  token:
+    description: >-
+      GitHub token with the code-quality:write permission. Defaults to the workflow token. The
+      CALLING job must grant `code-quality: write` — a composite action cannot declare it itself.
+    required: false
+    default: ${{ github.token }}
+  codecov-token:
+    description: >-
+      Optional Codecov token. When provided, the report is ALSO uploaded to Codecov. This is a
+      transitional coexistence path while GitHub Code Quality coverage is in public preview; it is
+      intended to be removed once native coverage is validated.
+    required: false
+    default: ""
+runs:
+  using: composite
+  steps:
+    - name: 📊 Upload coverage to GitHub Code Quality
+      uses: actions/upload-code-coverage@b51da2c3c1b23e04d2d6477cfc34350b1f5cd3e9 # v1.2.0
+      with:
+        file: ${{ inputs.file }}
+        language: ${{ inputs.language }}
+        label: ${{ inputs.label }}
+        fail-on-error: ${{ inputs.fail-on-error }}
+        token: ${{ inputs.token }}
+
+    - name: 📄 Upload coverage to Codecov (transitional)
+      if: inputs.codecov-token != ''
+      uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+      with:
+        files: ${{ inputs.file }}
+        token: ${{ inputs.codecov-token }}
+        fail_ci_if_error: true


### PR DESCRIPTION
## What

Adds a new shared composite action **`upload-coverage`** that uploads a Cobertura XML coverage report to **GitHub Code Quality** — GitHub's new native PR coverage feature ([changelog](https://github.blog/changelog/2026-05-26-code-coverage-in-pull-requests-is-now-in-public-preview/), public preview, available on our **Team** plan). It wraps [`actions/upload-code-coverage@v1.2.0`](https://github.com/actions/upload-code-coverage) and, during the transition, can **also** upload to Codecov when a `codecov-token` is passed.

This is **PR A** of a phased rollout. It is purely additive — no existing action changes — so it is safe to merge and release on its own.

## Why

Coverage upload is currently duplicated and Codecov-only in two shared blocks (`run-dotnet-tests` here, `validate-go-project` in reusable-workflows). Extracting one building block means every product gets native PR coverage by bumping a single ref, and lets us **reduce the external Codecov dependency**: the `codecov-token` passthrough is the transitional coexistence path, removable later by simply not passing the token.

## Contents

- `upload-coverage/action.yaml` — the composite action (`file` / `language` / `label` / `fail-on-error` / `token` / optional `codecov-token`).
- `upload-coverage/README.md` — docs per the CONTRIBUTING template.
- `.github/fixtures/upload-coverage/coverage.cobertura.xml` — minimal Cobertura fixture.
- `test-upload-coverage` smoke job in `ci.yaml`, wired into the `ci-required-checks` gate.
- README actions-table row.

## Notes / things to know

- **Permission:** `code-quality: write` must be granted by the **calling job** (a composite action can't declare it). The default `token` is `github.token`. The scope is valid per GitHub's docs; note that `actionlint` ≤ v1.7.12 doesn't yet know it and will emit a false "unknown permission scope" — zizmor (this repo's gate) is clean.
- **Repo prerequisite:** coverage must be enabled in **Settings → Code quality** before reports appear on PRs. Until then the smoke test uses `fail-on-error: false` so uploads degrade to annotations, not CI failures.
- **Fork PRs & merge-queue runs** are skipped automatically by the upstream action (aligns with our trust model).
- **`.NET` multi-project caveat (for the follow-up):** `actions/upload-code-coverage` takes a *single* `file`; multi-project solutions emit several `coverage.cobertura.xml` files, so the `run-dotnet-tests` wiring will need a merge step (e.g. ReportGenerator) and a single-OS guard to avoid matrix double-reporting.

## Next (follow-up PRs, after this releases)

- **PR B (reusable-workflows):** call `upload-coverage` from `validate-go-project.yaml` (with a `gocover-cobertura` conversion step) and grant `code-quality: write`; grant the permission + wire it into the `.NET` path; pin to this action's new tag.
- **PRs C (consumers):** ksail, go-template, dotnet-template — bump pins, enable the repo setting.
- **Phase 3:** once native coverage is validated on real PRs, drop the Codecov passthrough and `CODECOV_TOKEN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)