### PR TITLE
feat: upload .NET coverage to GitHub Code Quality

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -191,6 +191,7 @@ jobs:
     permissions:
       contents: read
       packages: read
+      code-quality: write # for the GitHub Code Quality coverage upload
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]

--- a/run-dotnet-tests/README.md
+++ b/run-dotnet-tests/README.md
@@ -1,6 +1,8 @@
 # Run Dotnet Tests
 
-Test .NET solutions or projects across multiple platforms with code coverage reporting. Sets up the .NET 9 SDK, configures NuGet sources (including GHCR for private packages), runs tests with coverage collection, and uploads reports to Codecov.
+Test .NET solutions or projects across multiple platforms with code coverage reporting. Sets up the .NET 9 SDK, configures NuGet sources (including GHCR for private packages), runs tests with coverage collection, and uploads the report to **GitHub Code Quality** (native PR coverage) — and, when `codecov-token` is set, also to Codecov during the transition off the external service.
+
+> **Permissions:** the calling job must grant `code-quality: write` for the GitHub Code Quality upload. The coverage is merged into a single Cobertura report (via ReportGenerator) and uploaded once, from the Linux matrix leg only. The upload is best-effort (it never fails the build) and requires the repo's _Settings → Code quality_ to have coverage enabled.
 
 ## Inputs
 

--- a/run-dotnet-tests/action.yaml
+++ b/run-dotnet-tests/action.yaml
@@ -65,3 +65,23 @@ runs:
         fail_ci_if_error: true
       env:
         CODECOV_TOKEN: ${{ inputs.codecov-token }}
+    # GitHub Code Quality accepts a single Cobertura report, so merge the per-project files.
+    # Linux only — one upload per repo avoids the matrix triple-reporting the same coverage.
+    # best-effort: this is a preview feature, so it must never break .NET CI.
+    - name: 🔀 Merge coverage into a single Cobertura report
+      if: matrix.os == 'ubuntu-latest'
+      continue-on-error: true
+      run: |
+        dotnet tool install --global dotnet-reportgenerator-globaltool --version 5.5.10
+        export PATH="$PATH:$HOME/.dotnet/tools"
+        reportgenerator -reports:'**/coverage.cobertura.xml' -targetdir:coverage-merged -reporttypes:Cobertura
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+    - name: 📊 Upload Code Coverage to GitHub Code Quality
+      if: matrix.os == 'ubuntu-latest'
+      continue-on-error: true
+      uses: devantler-tech/actions/upload-coverage@60d895a7aabe6e3c0247c86a83560656a760ee08 # v3.5.0
+      with:
+        file: ${{ inputs.working-directory }}/coverage-merged/Cobertura.xml
+        language: C#
+        label: code-coverage/dotnet


### PR DESCRIPTION
## What

Wires the `run-dotnet-tests` action into GitHub's native [Code Quality PR coverage](https://github.blog/changelog/2026-05-26-code-coverage-in-pull-requests-is-now-in-public-preview/), the .NET counterpart to the Go path:

1. Merges the per-project `coverage.cobertura.xml` files into **one** Cobertura report with ReportGenerator (`5.5.10`) — GitHub's `upload-code-coverage` takes a single file.
2. Uploads it via [`upload-coverage@v3.5.0`](https://github.com/devantler-tech/actions/tree/main/upload-coverage), **Linux matrix leg only** (one upload per repo; avoids the 3× matrix duplication).
3. Both new steps are `continue-on-error: true` — best-effort during the preview, so they **never break .NET CI**.

The existing **Codecov** upload is left completely unchanged (coexistence). Grants `code-quality: write` to the `test-run-dotnet-tests` CI job.

**PR D** of the coverage migration (depends on the now-merged PR A / `v3.5.0`).

## Notes

- **Caller permission:** consuming jobs must grant `code-quality: write`. Unlike the reusable-workflow path, a *composite action* doesn't declare permissions, so a missing grant doesn't fail at startup — the upload just 403s and (being best-effort) is annotated, not fatal.
- **Repo prerequisite:** coverage must be enabled in _Settings → Code quality_.
- `actionlint` ≤1.7.12 falsely flags `code-quality`; zizmor (the repo gate) is clean; `yamllint` clean.
- Follow-up: `run-dotnet-tests.yaml` (reusable-workflows) will grant `code-quality: write` to its test job + caller, pinned to this action's next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)