### PR TITLE
feat!: remove Codecov upload from coverage actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ flowchart TD
 | [setup-ksail-cli](setup-ksail-cli/README.md) | Install KSail CLI via Homebrew |
 | [sync-github-labels](sync-github-labels/README.md) | Sync GitHub labels from a configuration file |
 | [update-copilot-skills](update-copilot-skills/README.md) | Run `gh skill update --all` against installed skills and report changes |
-| [upload-coverage](upload-coverage/README.md) | Upload a Cobertura coverage report to GitHub Code Quality (and optionally Codecov) |
+| [upload-coverage](upload-coverage/README.md) | Upload a Cobertura coverage report to GitHub Code Quality |
 | [upsert-issue](upsert-issue/README.md) | Create, update, reopen, or close a GitHub issue by title |
 
 ## Contributing

--- a/run-dotnet-tests/README.md
+++ b/run-dotnet-tests/README.md
@@ -1,8 +1,8 @@
 # Run Dotnet Tests
 
-Test .NET solutions or projects across multiple platforms with code coverage reporting. Sets up the .NET 9 SDK, configures NuGet sources (including GHCR for private packages), runs tests with coverage collection, and uploads the report to **GitHub Code Quality** (native PR coverage) — and, when `codecov-token` is set, also to Codecov during the transition off the external service.
+Test .NET solutions or projects across multiple platforms with code coverage reporting. Sets up the .NET 9 SDK, configures NuGet sources (including GHCR for private packages), runs tests with coverage collection, and uploads the report to **GitHub Code Quality** (native PR coverage).
 
-> **Permissions:** the calling job must grant `code-quality: write` for the GitHub Code Quality upload. The coverage is merged into a single Cobertura report (via ReportGenerator) and uploaded once, from the Linux matrix leg only. The upload is best-effort (it never fails the build) and requires the repo's _Settings → Code quality_ to have coverage enabled.
+> **Permissions:** the calling job must grant `code-quality: write` for the GitHub Code Quality upload. The coverage is merged into a single Cobertura report (via ReportGenerator) and uploaded once, from the Linux matrix leg only. The upload is best-effort (it never fails the build) and requires the repo's **Code Quality** to be enabled (_Settings → Code quality_).
 
 ## Inputs
 
@@ -11,12 +11,11 @@ Test .NET solutions or projects across multiple platforms with code coverage rep
 | `app-id` | GitHub App ID to generate a token | ✅ | - |
 | `app-private-key` | Private key of the GitHub App | ✅ | - |
 | `github-token` | GitHub token to access the repository | ✅ | - |
-| `codecov-token` | Token to upload code coverage to CodeCov | ❌ | - |
 | `working-directory` | Directory to run the tests in | ❌ | `.` |
 
 ## Usage
 
-### With code coverage
+### Basic
 
 ```yaml
 steps:
@@ -26,7 +25,6 @@ steps:
       app-id: ${{ vars.APP_ID }}
       app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
       github-token: ${{ secrets.GITHUB_TOKEN }}
-      codecov-token: ${{ secrets.CODECOV_TOKEN }}
 ```
 
 ### Custom working directory
@@ -40,16 +38,4 @@ steps:
       app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
       github-token: ${{ secrets.GITHUB_TOKEN }}
       working-directory: src/MyProject
-```
-
-### Without code coverage
-
-```yaml
-steps:
-  - name: Test .NET project
-    uses: devantler-tech/actions/run-dotnet-tests@main
-    with:
-      app-id: ${{ vars.APP_ID }}
-      app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
-      github-token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/run-dotnet-tests/action.yaml
+++ b/run-dotnet-tests/action.yaml
@@ -11,8 +11,6 @@ inputs:
   github-token:
     description: GitHub token to access the repository
     required: true
-  codecov-token:
-    description: Token to upload code coverage to CodeCov
   working-directory:
     description: Directory to run the tests in
     required: false
@@ -40,31 +38,6 @@ runs:
       run: dotnet test --collect:"XPlat Code Coverage" --logger "console;verbosity=detailed"
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-    - name: 📄 Get Coverage Files
-      id: get_coverage_files
-      if: matrix.os != 'windows-latest' && inputs.codecov-token != ''
-      run: |
-        coverage_files=$(find . -name 'coverage.cobertura.xml' -print0 | tr '\0' ',' | sed 's/,$//')
-        echo "COVERAGE_FILES=$coverage_files" >> "$GITHUB_OUTPUT"
-      shell: bash
-      working-directory: ${{ inputs.working-directory }}
-    - name: 📄 Get Coverage Files on Windows
-      id: get_coverage_files_windows
-      if: matrix.os == 'windows-latest' && inputs.codecov-token != ''
-      run: |
-        $coverage_files = Get-ChildItem -Path . -Recurse -Filter coverage.cobertura.xml -ErrorAction SilentlyContinue | ForEach-Object { $_.FullName }
-        $coverage_files = $coverage_files -join ','
-        echo "COVERAGE_FILES=$coverage_files" >> "$GITHUB_OUTPUT"
-      shell: pwsh
-      working-directory: ${{ inputs.working-directory }}
-    - name: 📄 Upload Code Coverage to CodeCov
-      if: inputs.codecov-token != ''
-      uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
-      with:
-        files: ${{ steps.get_coverage_files.outputs.COVERAGE_FILES }}
-        fail_ci_if_error: true
-      env:
-        CODECOV_TOKEN: ${{ inputs.codecov-token }}
     # GitHub Code Quality accepts a single Cobertura report, so merge the per-project files.
     # Linux only — one upload per repo avoids the matrix triple-reporting the same coverage.
     # best-effort: this is a preview feature, so it must never break .NET CI.

--- a/upload-coverage/README.md
+++ b/upload-coverage/README.md
@@ -1,8 +1,8 @@
 # Upload Coverage
 
-Upload a Cobertura XML coverage report to [GitHub Code Quality](https://docs.github.com/code-security/code-quality) so the aggregate coverage percentage appears on pull requests. Optionally also uploads the same report to Codecov during the transition off the external service.
+Upload a Cobertura XML coverage report to [GitHub Code Quality](https://docs.github.com/code-security/code-quality) so the aggregate coverage percentage appears on pull requests.
 
-GitHub Code Quality coverage requires the org/repo to be on a **Team** or **Enterprise Cloud** plan, and coverage must be **enabled in the repository's _Settings → Code quality_**. Fork PRs and merge-queue runs are skipped automatically by the underlying [`actions/upload-code-coverage`](https://github.com/actions/upload-code-coverage) action.
+GitHub Code Quality requires the org/repo to be on a **Team** or **Enterprise Cloud** plan, and **Code Quality must be enabled** in the repository's _Settings → Code quality_. Fork PRs and merge-queue runs are skipped automatically by the underlying [`actions/upload-code-coverage`](https://github.com/actions/upload-code-coverage) action.
 
 ## Inputs
 
@@ -13,7 +13,6 @@ GitHub Code Quality coverage requires the org/repo to be on a **Team** or **Ente
 | `label` | Label for the coverage report (e.g. `code-coverage/go`) | ❌ | `code-coverage` |
 | `fail-on-error` | Fail the step if the GitHub upload fails (errors are always surfaced as annotations) | ❌ | `false` |
 | `token` | GitHub token with `code-quality: write` (the calling job must grant the permission) | ❌ | `${{ github.token }}` |
-| `codecov-token` | Optional Codecov token; when set, the report is also uploaded to Codecov (transitional) | ❌ | - |
 
 ## Outputs
 
@@ -64,19 +63,4 @@ steps:
       file: ./TestResults/coverage.cobertura.xml
       language: C#
       label: code-coverage/dotnet
-```
-
-### Transitional Codecov upload
-
-Pass `codecov-token` to additionally upload to Codecov while validating the native feature:
-
-```yaml
-steps:
-  - name: 📊 Upload coverage
-    uses: devantler-tech/actions/upload-coverage@main
-    with:
-      file: coverage.cobertura.xml
-      language: Go
-      label: code-coverage/go
-      codecov-token: ${{ secrets.CODECOV_TOKEN }}
 ```

--- a/upload-coverage/action.yaml
+++ b/upload-coverage/action.yaml
@@ -1,5 +1,5 @@
 name: Upload Coverage
-description: Upload a Cobertura XML coverage report to GitHub Code Quality (and optionally Codecov).
+description: Upload a Cobertura XML coverage report to GitHub Code Quality.
 author: devantler-tech
 inputs:
   file:
@@ -25,13 +25,6 @@ inputs:
       CALLING job must grant `code-quality: write` — a composite action cannot declare it itself.
     required: false
     default: ${{ github.token }}
-  codecov-token:
-    description: >-
-      Optional Codecov token. When provided, the report is ALSO uploaded to Codecov. This is a
-      transitional coexistence path while GitHub Code Quality coverage is in public preview; it is
-      intended to be removed once native coverage is validated.
-    required: false
-    default: ""
 runs:
   using: composite
   steps:
@@ -43,11 +36,3 @@ runs:
         label: ${{ inputs.label }}
         fail-on-error: ${{ inputs.fail-on-error }}
         token: ${{ inputs.token }}
-
-    - name: 📄 Upload coverage to Codecov (transitional)
-      if: inputs.codecov-token != ''
-      uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
-      with:
-        files: ${{ inputs.file }}
-        token: ${{ inputs.codecov-token }}
-        fail_ci_if_error: true


### PR DESCRIPTION
## What

Phase 3 of the coverage migration — **retire the external Codecov dependency** now that GitHub Code Quality coverage is validated (ksail upload confirmed `201`).

- `upload-coverage`: removes the `codecov-token` input and the Codecov upload step.
- `run-dotnet-tests`: removes the `codecov-token` input and the get-coverage-files + Codecov upload steps (keeps the ReportGenerator merge → GitHub Code Quality upload).
- READMEs updated.

## ⚠️ Breaking

The `codecov-token` input is removed from both actions. Callers passing it must stop. The reusable workflows (`validate-go-project`, `run-dotnet-tests`) are updated in the **lockstep follow-up PR** that pins to this release. The actions repo's own CI doesn't pass `codecov-token`, so its smoke tests are unaffected.

## Safe to merge first

Consumers pin **old** versions of these actions (`v3.5.0`/`v3.6.0`, which still have `codecov-token`), so merging this and releasing a new tag doesn't break anything until they bump. zizmor + yamllint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)