### PR TITLE
feat(run-dotnet-tests): provision .NET 10 SDK alongside 9

### DIFF
--- a/.github/fixtures/run-dotnet-tests/src/Example/Example.csproj
+++ b/.github/fixtures/run-dotnet-tests/src/Example/Example.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AnalysisMode>All</AnalysisMode>

--- a/.github/fixtures/run-dotnet-tests/tests/Example.Tests/Example.Tests.csproj
+++ b/.github/fixtures/run-dotnet-tests/tests/Example.Tests/Example.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AnalysisMode>All</AnalysisMode>

--- a/run-dotnet-tests/action.yaml
+++ b/run-dotnet-tests/action.yaml
@@ -21,7 +21,11 @@ runs:
     - name: ⚙️ Setup .NET
       uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
       with:
-        dotnet-version: 9
+        # Provision both the previous STS (9) and the current LTS (10) so callers can
+        # target either TFM. Multiple lines install side-by-side SDKs.
+        dotnet-version: |
+          9
+          10
     - name: 🚚 Add GHCR as NuGet feed
       run: |
         dotnet nuget add source \


### PR DESCRIPTION
> 🤖 Opened by the Daily AI Assistant (autonomous run).

## What
`run-dotnet-tests` provisions only the **.NET 9** SDK (`dotnet-version: 9`). This blocks any caller from targeting **.NET 10** (current LTS) — `dotnet test` fails because the runner has no .NET 10 SDK.

This PR provisions **both** SDKs side-by-side and bumps the action's own smoke-test fixture to `net10.0` so CI actively exercises the new LTS build path.

## Changes
- `run-dotnet-tests/action.yaml` — `dotnet-version` now installs `9` **and** `10` (multi-line list → side-by-side install).
- `.github/fixtures/run-dotnet-tests/{src,tests}` — fixture TFM `net9.0` → `net10.0`.

## Why additive / low-risk
Installing 9 alongside 10 means **net9 consumers are unaffected** — nothing is dropped. The fixture bump proves the net10 path end-to-end through the action.

## Validation
Ran the fixture locally on **.NET SDK 10.0.300** (the same `dotnet test` the action runs), with `TreatWarningsAsErrors=true`:

```
Example -> .../net10.0/Example.dll
Example.Tests -> .../net10.0/.../Example.Tests.dll
Passed!  - Failed: 0, Passed: 17, Skipped: 0, Total: 17 (net10.0)
```

Restore was clean; no test-tooling package bumps needed (coverlet 6.0.4 / Microsoft.NET.Test.Sdk 18.0.1 / xunit 2.9.3 are net10-compatible).

## Unblocks
[devantler-tech/dotnet-template#168](https://github.com/devantler-tech/dotnet-template/issues/168) — the `net9.0 → net10.0` TFM bump, which #168 itself flags as gated on the shared CI provisioning a .NET 10 SDK. After this releases and dotnet-template's pin to `run-dotnet-tests` propagates, the template TFM bump can land green.

Pairs with the matching `publish-dotnet-library.yaml` SDK bump in `reusable-workflows` (release path).