### PR TITLE
feat(cleanup-ghcr-packages): add dry-run/package inputs and CI smoke test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,25 @@ jobs:
           app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
           pr-number: ${{ github.event.pull_request.number }}
 
+  # ── cleanup-ghcr-packages ───────────────────────────────────
+  test-cleanup-ghcr-packages:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: read
+    steps:
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # Dry run against a stable, long-lived package so the test exercises the
+      # action's wiring without ever deleting anything.
+      - name: 🧪 Run cleanup-ghcr-packages (dry run)
+        uses: ./cleanup-ghcr-packages
+        with:
+          package: pandoc-plus
+          dry-run: "true"
+
   # ── create-issues-from-todos ────────────────────────────────
   test-create-issues-from-todos:
     runs-on: ubuntu-latest
@@ -702,6 +721,7 @@ jobs:
     if: ${{ always() }}
     needs:
       - test-approve-pr
+      - test-cleanup-ghcr-packages
       - test-create-issues-from-todos
       - test-enable-auto-merge-on-pr
       - test-login-to-ghcr
@@ -739,6 +759,7 @@ jobs:
         with:
           job-results: >-
             ${{ needs.test-approve-pr.result }}
+            ${{ needs.test-cleanup-ghcr-packages.result }}
             ${{ needs.test-create-issues-from-todos.result }}
             ${{ needs.test-enable-auto-merge-on-pr.result }}
             ${{ needs.test-login-to-ghcr.result }}

--- a/cleanup-ghcr-packages/README.md
+++ b/cleanup-ghcr-packages/README.md
@@ -8,6 +8,8 @@ Clean up old GitHub Container Registry (GHCR) packages. Removes container images
 |------|-------------|----------|---------|
 | `older-than` | Delete images older than this duration | ❌ | `1 year` |
 | `keep-n-tagged` | Number of tagged images to keep | ❌ | `10` |
+| `package` | Package to clean up. Defaults to the calling repository's package | ❌ | |
+| `dry-run` | Simulate the cleanup without deleting anything (`true`/`false`) | ❌ | `false` |
 
 ## Usage
 
@@ -28,4 +30,17 @@ steps:
     with:
       older-than: "3 months"
       keep-n-tagged: "15"
+```
+
+### Dry run
+
+Preview what would be deleted without removing anything. Recommended before a first real run.
+
+```yaml
+steps:
+  - name: Preview GHCR cleanup
+    uses: devantler-tech/actions/cleanup-ghcr-packages@main
+    with:
+      package: "my-app"
+      dry-run: "true"
 ```

--- a/cleanup-ghcr-packages/README.md
+++ b/cleanup-ghcr-packages/README.md
@@ -8,7 +8,7 @@ Clean up old GitHub Container Registry (GHCR) packages. Removes container images
 |------|-------------|----------|---------|
 | `older-than` | Delete images older than this duration | ❌ | `1 year` |
 | `keep-n-tagged` | Number of tagged images to keep | ❌ | `10` |
-| `package` | Package to clean up. Defaults to the calling repository's package | ❌ | |
+| `package` | Package to clean up. Defaults to the calling repository's package (resolved by the underlying cleanup action) | ❌ | `repository name` |
 | `dry-run` | Simulate the cleanup without deleting anything (`true`/`false`) | ❌ | `false` |
 
 ## Usage

--- a/cleanup-ghcr-packages/action.yaml
+++ b/cleanup-ghcr-packages/action.yaml
@@ -10,6 +10,13 @@ inputs:
     description: "Number of tagged images to keep"
     required: false
     default: "10"
+  package:
+    description: "Package to clean up. Defaults to the calling repository's package."
+    required: false
+  dry-run:
+    description: "Simulate the cleanup without deleting anything (true/false)."
+    required: false
+    default: "false"
 runs:
   using: "composite"
   steps:
@@ -17,3 +24,5 @@ runs:
       with:
         older-than: ${{ inputs.older-than }}
         keep-n-tagged: ${{ inputs.keep-n-tagged }}
+        package: ${{ inputs.package }}
+        dry-run: ${{ inputs.dry-run }}

--- a/cleanup-ghcr-packages/action.yaml
+++ b/cleanup-ghcr-packages/action.yaml
@@ -11,7 +11,7 @@ inputs:
     required: false
     default: "10"
   package:
-    description: "Package to clean up. Defaults to the calling repository's package."
+    description: "Package to clean up. Defaults to the calling repository's package (resolved by the underlying cleanup action)."
     required: false
   dry-run:
     description: "Simulate the cleanup without deleting anything (true/false)."


### PR DESCRIPTION
Closes #182

## What

Closes the lone test-coverage gap called out in [#181](https://github.com/devantler-tech/actions/issues/181) (gap 1): `cleanup-ghcr-packages` was the **only** action without a `test-<name>` job, despite `AGENTS.md` mandating one for every action.

## How

The action wraps a *destructive* upstream (`dataaxiom/ghcr-cleanup-action`), so it can't be smoke-tested by actually running a deletion. This PR adds two passthrough inputs that make safe testing possible and are genuinely useful on their own:

- **`dry-run`** — simulate the cleanup without deleting anything (upstream's own guidance is *"always test with `dry-run: true` first"*).
- **`package`** — target a specific package instead of the calling repo's default.

The new `test-cleanup-ghcr-packages` job runs the action with `dry-run: "true"` against the stable, long-lived **`pandoc-plus`** package — exercising the action → upstream → GHCR-API wiring end-to-end without ever deleting an image — and is wired into the `ci-required-checks` aggregate (`needs` + result list).

## Design note for review

I targeted `pandoc-plus` for **determinism**: a `dry-run` against the *default* package (`devantler-tech/actions`) would depend on upstream's behaviour when the package doesn't exist, which I couldn't confirm for v1.0.16. Targeting an existing package avoids that ambiguity but introduces a small cross-package coupling (the test breaks if `pandoc-plus` is ever deleted). Happy to switch to the default-package approach if you'd prefer the decoupling — flagging it before promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)