### PR TITLE
ci: add README↔action.yaml input/output parity guard

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -715,6 +715,55 @@ jobs:
       - name: 🔒 Run zizmor
         uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
 
+  # ── lint-readme-parity ──────────────────────────────────────
+  lint-readme-parity:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: 📋 Check README ↔ action.yaml input/output parity
+        shell: bash
+        run: |
+          # Fail if any input/output declared in an action.yaml is missing from
+          # its README's ## Inputs / ## Outputs table. yq is preinstalled on the
+          # GitHub-hosted ubuntu-latest runner image.
+          status=0
+          for action_yaml in */action.yaml; do
+            dir="$(dirname "$action_yaml")"
+            readme="$dir/README.md"
+            if [[ ! -f "$readme" ]]; then
+              echo "::error file=$dir::missing README.md"
+              status=1
+              continue
+            fi
+            # README section between '## Inputs'/'## Outputs' and the next '## ' heading.
+            inputs_doc="$(awk '/^## Inputs/{f=1;next} /^## /{f=0} f' "$readme")"
+            outputs_doc="$(awk '/^## Outputs/{f=1;next} /^## /{f=0} f' "$readme")"
+            while IFS= read -r name; do
+              [[ -z "$name" ]] && continue
+              if ! grep -qF "\`$name\`" <<<"$inputs_doc"; then
+                echo "::error file=$action_yaml::input '$name' is declared in action.yaml but not documented in $readme (## Inputs)"
+                status=1
+              fi
+            done < <(yq -r '.inputs // {} | keys | .[]' "$action_yaml")
+            while IFS= read -r name; do
+              [[ -z "$name" ]] && continue
+              if ! grep -qF "\`$name\`" <<<"$outputs_doc"; then
+                echo "::error file=$action_yaml::output '$name' is declared in action.yaml but not documented in $readme (## Outputs)"
+                status=1
+              fi
+            done < <(yq -r '.outputs // {} | keys | .[]' "$action_yaml")
+          done
+          if [[ "$status" -eq 0 ]]; then
+            echo "README parity OK: every action.yaml input/output is documented."
+          fi
+          exit "$status"
+
   # ── gate ────────────────────────────────────────────────────
   ci-required-checks:
     name: CI - Required Checks
@@ -746,6 +795,7 @@ jobs:
       - test-upsert-issue-create
       - test-upsert-issue-close
       - zizmor
+      - lint-readme-parity
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -784,3 +834,4 @@ jobs:
             ${{ needs.test-upsert-issue-create.result }}
             ${{ needs.test-upsert-issue-close.result }}
             ${{ needs.zizmor.result }}
+            ${{ needs.lint-readme-parity.result }}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #185.

## What

Adds a **`lint-readme-parity`** CI job that fails if any `input`/`output` declared in an action's `action.yaml` is missing from its README's `## Inputs` / `## Outputs` table. It emits `::error` annotations pointing at the offending `action.yaml`, and is wired into the `CI - Required Checks` gate (`needs` + the `aggregate-job-checks` result list). The check uses `yq` (preinstalled on the `ubuntu-latest` runner image) for the `action.yaml` side and `awk`/`grep` for the README side — no new dependencies, runs on every event with `contents: read` only.

## Parity audit (acceptance criterion: one bullet per action)

I read every `action.yaml` against its `README.md`. **Result: zero parity drift found** — every declared input/output is already documented with matching `required`/`default`:

- **aggregate-job-checks** — `job-results`, `check-name` documented; required/default match. ✅
- **approve-pr** — `app-id`, `app-private-key`, `pr-number`, `dry-run` all documented. ✅
- **cleanup-ghcr-packages** — `older-than`, `keep-n-tagged`, `package`, `dry-run` documented. ✅
- **create-issues-from-todos** — `app-id`, `app-private-key`, `project` documented. ✅
- **enable-auto-merge-on-pr** — `pr-number`, `merge-method`, `dry-run` documented. ✅
- **login-to-ghcr** — `github-token` documented. ✅
- **run-dotnet-tests** — `app-id`, `app-private-key`, `github-token`, `working-directory` documented. ✅
- **setup-agent-skills** — 5 inputs + output `installed-skills` documented. ✅
- **setup-go-toolchain** — `go-version`, `github-token` + output `go-version` documented. ✅
- **setup-ksail-cli** — no inputs/outputs declared; README correctly omits the tables. ✅
- **sync-github-labels** — `config-file`, `delete-other-labels` documented. ✅
- **update-agent-skills** — 5 inputs + outputs `changed`, `updated-skills` documented. ✅
- **upload-coverage** — 5 inputs documented; no outputs ("This action has no outputs."). ✅
- **upsert-issue** — 8 inputs + outputs `issue-number` **and** `issue-url` documented (the issue flagged `issue-url` as "unknown" — it is in fact already documented). ✅

So the READMEs are already in good shape; the durable value of this PR is the **guard** that keeps them that way and catches the "silent drift" #185 describes (e.g. a future `agents:`-style input added to `action.yaml` without a README row).

## Validation

- `actionlint .github/workflows/ci.yaml` — clean for this change (the two pre-existing `code-quality` permission-scope warnings at lines 213/629 are unrelated to this job and stem from actionlint's allowlist not yet knowing that scope).
- Parity logic exercised locally against the live READMEs (**passes**) and against a synthetic action with an undocumented input + output (**fails with `::error` annotations + non-zero exit**).

## Notes / trade-offs

- Kept the check inline in `ci.yaml` (self-contained, matching the repo's job style and the `zizmor` precedent) rather than introducing a new `.github/scripts/` convention.
- Forward-direction only (every `action.yaml` name must be documented) — it does not flag README rows with no matching `action.yaml` entry, to avoid false positives on intentionally-documented effective defaults (e.g. `cleanup-ghcr-packages` `package`).
