### PR TITLE
test(ci): backfill negative-path tests for happy-path-only actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -755,38 +755,6 @@ jobs:
             exit 1
           fi
 
-  # ── enable-auto-merge-on-pr (negative path) ────────────────
-  test-enable-auto-merge-on-pr-invalid-method:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: 📑 Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      # dry-run defaults to "false" so the merge-method validation runs, and auto-merge
-      # is enabled on this repo, so the validation step executes and rejects the typo'd
-      # method with `exit 1` before any `gh pr merge` call is made (PR #1 is never touched).
-      - name: 🧪 Run enable-auto-merge-on-pr with an invalid merge-method (expected to fail)
-        id: enable
-        continue-on-error: true
-        uses: ./enable-auto-merge-on-pr
-        with:
-          pr-number: "1"
-          merge-method: rebasee
-
-      - name: ✅ Verify step failed as expected
-        shell: bash
-        env:
-          OUTCOME: ${{ steps.enable.outcome }}
-        run: |
-          if [[ "$OUTCOME" != "failure" ]]; then
-            echo "::error::Expected the action to fail on an invalid merge-method, got: $OUTCOME"
-            exit 1
-          fi
-
   # ── setup-go-toolchain (negative path) ─────────────────────
   test-setup-go-toolchain-invalid-version:
     runs-on: ubuntu-latest
@@ -924,7 +892,6 @@ jobs:
       - test-upsert-issue-close
       - test-sync-github-labels-missing-config
       - test-login-to-ghcr-empty-token
-      - test-enable-auto-merge-on-pr-invalid-method
       - test-setup-go-toolchain-invalid-version
       - test-upsert-issue-missing-body
       - test-run-dotnet-tests-missing-working-directory
@@ -968,7 +935,6 @@ jobs:
             ${{ needs.test-upsert-issue-close.result }}
             ${{ needs.test-sync-github-labels-missing-config.result }}
             ${{ needs.test-login-to-ghcr-empty-token.result }}
-            ${{ needs.test-enable-auto-merge-on-pr-invalid-method.result }}
             ${{ needs.test-setup-go-toolchain-invalid-version.result }}
             ${{ needs.test-upsert-issue-missing-body.result }}
             ${{ needs.test-run-dotnet-tests-missing-working-directory.result }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -698,6 +698,183 @@ jobs:
           close-comment: "🧪 Closed by test workflow."
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+  # ── sync-github-labels (negative path) ─────────────────────
+  test-sync-github-labels-missing-config:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: 🧪 Run sync-github-labels with a missing config file (expected to fail)
+        id: sync
+        continue-on-error: true
+        uses: ./sync-github-labels
+        with:
+          config-file: .github/this-config-does-not-exist.yaml
+          delete-other-labels: "false"
+
+      - name: ✅ Verify step failed as expected
+        shell: bash
+        env:
+          OUTCOME: ${{ steps.sync.outcome }}
+        run: |
+          if [[ "$OUTCOME" != "failure" ]]; then
+            echo "::error::Expected the action to fail on a missing config file, got: $OUTCOME"
+            exit 1
+          fi
+
+  # ── login-to-ghcr (negative path) ──────────────────────────
+  test-login-to-ghcr-empty-token:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: 🧪 Run login-to-ghcr with an empty token (expected to fail)
+        id: login
+        continue-on-error: true
+        uses: ./login-to-ghcr
+        with:
+          github-token: ""
+
+      - name: ✅ Verify step failed as expected
+        shell: bash
+        env:
+          OUTCOME: ${{ steps.login.outcome }}
+        run: |
+          if [[ "$OUTCOME" != "failure" ]]; then
+            echo "::error::Expected the action to fail with an empty github-token, got: $OUTCOME"
+            exit 1
+          fi
+
+  # ── enable-auto-merge-on-pr (negative path) ────────────────
+  test-enable-auto-merge-on-pr-invalid-method:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # dry-run defaults to "false" so the merge-method validation runs, and auto-merge
+      # is enabled on this repo, so the validation step executes and rejects the typo'd
+      # method with `exit 1` before any `gh pr merge` call is made (PR #1 is never touched).
+      - name: 🧪 Run enable-auto-merge-on-pr with an invalid merge-method (expected to fail)
+        id: enable
+        continue-on-error: true
+        uses: ./enable-auto-merge-on-pr
+        with:
+          pr-number: "1"
+          merge-method: rebasee
+
+      - name: ✅ Verify step failed as expected
+        shell: bash
+        env:
+          OUTCOME: ${{ steps.enable.outcome }}
+        run: |
+          if [[ "$OUTCOME" != "failure" ]]; then
+            echo "::error::Expected the action to fail on an invalid merge-method, got: $OUTCOME"
+            exit 1
+          fi
+
+  # ── setup-go-toolchain (negative path) ─────────────────────
+  test-setup-go-toolchain-invalid-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: 🧪 Run setup-go-toolchain with a non-existent version (expected to fail)
+        id: setup-go
+        continue-on-error: true
+        uses: ./setup-go-toolchain
+        with:
+          go-version: "99.99.99"
+
+      - name: ✅ Verify step failed as expected
+        shell: bash
+        env:
+          OUTCOME: ${{ steps.setup-go.outcome }}
+        run: |
+          if [[ "$OUTCOME" != "failure" ]]; then
+            echo "::error::Expected the action to fail on a non-existent Go version, got: $OUTCOME"
+            exit 1
+          fi
+
+  # ── upsert-issue (negative path) ───────────────────────────
+  test-upsert-issue-missing-body:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: 🧪 Run upsert-issue with neither body nor body-file (expected to fail)
+        id: upsert
+        continue-on-error: true
+        uses: ./upsert-issue
+        with:
+          title: "[test] upsert-issue missing-body negative test"
+
+      - name: ✅ Verify step failed as expected
+        shell: bash
+        env:
+          OUTCOME: ${{ steps.upsert.outcome }}
+        run: |
+          if [[ "$OUTCOME" != "failure" ]]; then
+            echo "::error::Expected the action to fail when neither body nor body-file is provided, got: $OUTCOME"
+            exit 1
+          fi
+
+  # ── run-dotnet-tests (negative path) ───────────────────────
+  test-run-dotnet-tests-missing-working-directory:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: 🧪 Run run-dotnet-tests against a non-existent working-directory (expected to fail)
+        id: dotnet
+        continue-on-error: true
+        uses: ./run-dotnet-tests
+        with:
+          app-id: ${{ vars.APP_ID }}
+          app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          working-directory: does-not-exist
+
+      - name: ✅ Verify step failed as expected
+        shell: bash
+        env:
+          OUTCOME: ${{ steps.dotnet.outcome }}
+        run: |
+          if [[ "$OUTCOME" != "failure" ]]; then
+            echo "::error::Expected the action to fail on a non-existent working-directory, got: $OUTCOME"
+            exit 1
+          fi
+
   # ── zizmor ──────────────────────────────────────────────────
   zizmor:
     runs-on: ubuntu-latest
@@ -745,6 +922,12 @@ jobs:
       - test-upload-coverage
       - test-upsert-issue-create
       - test-upsert-issue-close
+      - test-sync-github-labels-missing-config
+      - test-login-to-ghcr-empty-token
+      - test-enable-auto-merge-on-pr-invalid-method
+      - test-setup-go-toolchain-invalid-version
+      - test-upsert-issue-missing-body
+      - test-run-dotnet-tests-missing-working-directory
       - zizmor
     runs-on: ubuntu-latest
     permissions:
@@ -783,4 +966,10 @@ jobs:
             ${{ needs.test-upload-coverage.result }}
             ${{ needs.test-upsert-issue-create.result }}
             ${{ needs.test-upsert-issue-close.result }}
+            ${{ needs.test-sync-github-labels-missing-config.result }}
+            ${{ needs.test-login-to-ghcr-empty-token.result }}
+            ${{ needs.test-enable-auto-merge-on-pr-invalid-method.result }}
+            ${{ needs.test-setup-go-toolchain-invalid-version.result }}
+            ${{ needs.test-upsert-issue-missing-body.result }}
+            ${{ needs.test-run-dotnet-tests-missing-working-directory.result }}
             ${{ needs.zizmor.result }}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #183. Part of the actions roadmap epic #181.

## What

Backfills **negative-path test coverage** for the happy-path-only composite actions. Each new job follows the repo's established pattern (`continue-on-error: true` on the action invocation → a follow-up `bash` step asserting `steps.<id>.outcome == 'failure'`) and is wired into the `CI - Required Checks` gate (`needs:` + the `aggregate-job-checks` results list).

| Action | Negative path exercised | Why it deterministically fails |
| --- | --- | --- |
| `sync-github-labels` | missing `config-file` | `EndBug/label-sync` can't read a non-existent local file |
| `login-to-ghcr` | empty `github-token` | `docker/login-action` requires a non-empty password |
| `setup-go-toolchain` | non-existent `go-version` (`99.99.99`) | `actions/setup-go` can't resolve the version |
| `upsert-issue` | neither `body` nor `body-file` | the action's own `exit 1` (documented error path) |
| `run-dotnet-tests` | non-existent `working-directory` | the runner fails the `dotnet test` step when its `working-directory` is absent |

All five pass in CI — each correctly triggers its action's failure and the assertion confirms `outcome == 'failure'`.

## Skipped (with justification, per the issue's acceptance criteria)

- **`enable-auto-merge-on-pr`** — *deviation from the issue's "must" list, with CI evidence.* The invalid-`merge-method` `exit 1` lives behind the action's `auto-merge-enabled == 'true'` gate, which reads `gh api repos/<repo> --jq .allow_auto_merge`. That repos-API field is **only visible to push/admin tokens** — the standard CI `GITHUB_TOKEN` reads it as `null`, so the gate is never satisfied and the action returns `success` (verified: a first revision of this PR added the test and CI showed `##[warning]Auto-merge is not enabled on this repository` → `outcome: success`). Reaching the validation would require changing the action's hardcoded `GH_TOKEN: ${{ github.token }}`, which is an action behaviour change and out of scope for a test-coverage PR. Worth revisiting if the action ever accepts a token input. Tracked under #181.
- **`upload-coverage`** — the action wraps the **preview-period** `actions/upload-code-coverage`, whose `fail-on-error` defaults to `false` *by design* (the existing smoke test documents that upload errors surface as annotations, not CI failures, until GitHub Code Quality is enabled). A negative test can't reliably distinguish a genuine input-validation failure from a preview-period upload rejection without flaking. Worth revisiting once the feature is GA.
- **`setup-ksail-cli`** — no mechanically-reachable negative path: it takes no validated inputs and installs the latest released CLI.
- **`approve-pr`** / **`create-issues-from-todos`** — both require real GitHub App auth (`APP_ID`/`APP_PRIVATE_KEY`) and PR/issue context, and are `if:`-gated to devantler/bot PRs. Their failure modes are auth/permission errors rather than clean, mechanically-reachable input validation, so a public negative test would be brittle and leak-prone.

## Validation

- `actionlint 1.7.12`: **0 new findings** (the only two reported warnings — `code-quality` permission scope on the pre-existing `run-dotnet-tests` and `upload-coverage` jobs — are unchanged from `origin/main`).
- All five negative-path jobs pass in this PR's own CI run, against the changed workflow.
