### PR TITLE
refactor(agent-skills): share the gh bootstrap via one script

### DIFF
--- a/.scripts/ensure-gh-skill.sh
+++ b/.scripts/ensure-gh-skill.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Shared gh bootstrap for the agent-skills composite actions.
+#
+# Ensures a `gh` CLI that exposes the `gh skill` command is on PATH, installing a
+# pinned cli/cli release when the runner's gh is missing or too old. Invoked by both
+# setup-agent-skills/ and update-agent-skills/ via
+#   bash "${GITHUB_ACTION_PATH}/../.scripts/ensure-gh-skill.sh"
+# so the logic lives in one place — composite actions cannot share steps directly,
+# but they can share a script bundled in the same repository (resolved relative to
+# ${GITHUB_ACTION_PATH}, which works for both local `uses: ./<action>` callers and
+# external `uses: devantler-tech/actions/<action>@<ref>` consumers).
+#
+# Required environment:
+#   REQUIRED          minimum gh version to guarantee (e.g. 2.81.0)
+#   INSTALL_NAMESPACE per-action subdirectory under $RUNNER_TEMP for the installed
+#                     binary, so concurrent callers never clobber each other
+set -euo pipefail
+
+: "${REQUIRED:?REQUIRED (minimum gh version) must be set}"
+: "${INSTALL_NAMESPACE:?INSTALL_NAMESPACE must be set}"
+
+if command -v gh >/dev/null 2>&1 && gh skill --help >/dev/null 2>&1; then
+  current=$(gh --version | awk '/^gh version /{print $3; exit}')
+  if [ -z "$current" ]; then
+    echo "::error::Could not determine the installed gh version from 'gh --version' output."
+    exit 1
+  fi
+  if printf '%s\n%s\n' "$REQUIRED" "$current" | sort -V -C; then
+    echo "Installed gh ($current) already supports 'gh skill'."
+    exit 0
+  fi
+fi
+
+case "$(uname -s)" in
+  Linux)   os=linux;  ext=tar.gz ;;
+  Darwin)  os=macOS;  ext=zip ;;
+  *) echo "::error::Automatic gh install is only supported on Linux and macOS. On $(uname -s) (e.g. Windows), preinstall gh >= ${REQUIRED} on the runner before this step."; exit 1 ;;
+esac
+case "$(uname -m)" in
+  x86_64|amd64) arch=amd64 ;;
+  arm64|aarch64) arch=arm64 ;;
+  *) echo "::error::Unsupported arch: $(uname -m)"; exit 1 ;;
+esac
+
+tmp=$(mktemp -d)
+asset="gh_${REQUIRED}_${os}_${arch}.${ext}"
+url="https://github.com/cli/cli/releases/download/v${REQUIRED}/${asset}"
+echo "Downloading $url"
+if [ "$ext" = "zip" ]; then
+  if ! command -v unzip >/dev/null 2>&1; then
+    echo "::error::unzip is required to extract the macOS gh release archive but is not available on PATH."
+    exit 1
+  fi
+  curl -fsSL -o "$tmp/$asset" "$url"
+  unzip -q "$tmp/$asset" -d "$tmp"
+else
+  curl -fsSL "$url" | tar -xzC "$tmp"
+fi
+install_dir="${RUNNER_TEMP:-/tmp}/${INSTALL_NAMESPACE}/bin"
+mkdir -p "$install_dir"
+install "$tmp/gh_${REQUIRED}_${os}_${arch}/bin/gh" "$install_dir/gh"
+echo "$install_dir" >> "$GITHUB_PATH"
+export PATH="$install_dir:$PATH"
+hash -r
+gh --version
+if ! gh skill --help >/dev/null 2>&1; then
+  echo "::error::Installed gh still does not expose the 'skill' command."
+  exit 1
+fi

--- a/setup-agent-skills/action.yaml
+++ b/setup-agent-skills/action.yaml
@@ -39,56 +39,12 @@ runs:
       shell: bash
       env:
         REQUIRED: ${{ inputs.gh-version }}
-      run: | # zizmor: ignore[github-env]
-        set -euo pipefail
-        if command -v gh >/dev/null 2>&1 && gh skill --help >/dev/null 2>&1; then
-          current=$(gh --version | awk '/^gh version /{print $3; exit}')
-          if [ -z "$current" ]; then
-            echo "::error::Could not determine the installed gh version from 'gh --version' output."
-            exit 1
-          fi
-          if printf '%s\n%s\n' "$REQUIRED" "$current" | sort -V -C; then
-            echo "Installed gh ($current) already supports 'gh skill'."
-            exit 0
-          fi
-        fi
-
-        case "$(uname -s)" in
-          Linux)   os=linux;  ext=tar.gz ;;
-          Darwin)  os=macOS;  ext=zip ;;
-          *) echo "::error::Automatic gh install is only supported on Linux and macOS. On $(uname -s) (e.g. Windows), preinstall gh >= ${REQUIRED} on the runner before this step."; exit 1 ;;
-        esac
-        case "$(uname -m)" in
-          x86_64|amd64) arch=amd64 ;;
-          arm64|aarch64) arch=arm64 ;;
-          *) echo "::error::Unsupported arch: $(uname -m)"; exit 1 ;;
-        esac
-
-        tmp=$(mktemp -d)
-        asset="gh_${REQUIRED}_${os}_${arch}.${ext}"
-        url="https://github.com/cli/cli/releases/download/v${REQUIRED}/${asset}"
-        echo "Downloading $url"
-        if [ "$ext" = "zip" ]; then
-          if ! command -v unzip >/dev/null 2>&1; then
-            echo "::error::unzip is required to extract the macOS gh release archive but is not available on PATH."
-            exit 1
-          fi
-          curl -fsSL -o "$tmp/$asset" "$url"
-          unzip -q "$tmp/$asset" -d "$tmp"
-        else
-          curl -fsSL "$url" | tar -xzC "$tmp"
-        fi
-        install_dir="${RUNNER_TEMP:-/tmp}/setup-agent-skills/bin"
-        mkdir -p "$install_dir"
-        install "$tmp/gh_${REQUIRED}_${os}_${arch}/bin/gh" "$install_dir/gh"
-        echo "$install_dir" >> "$GITHUB_PATH"  # zizmor: ignore[github-env]
-        export PATH="$install_dir:$PATH"
-        hash -r
-        gh --version
-        if ! gh skill --help >/dev/null 2>&1; then
-          echo "::error::Installed gh still does not expose the 'skill' command."
-          exit 1
-        fi
+        INSTALL_NAMESPACE: setup-agent-skills
+      # Shared with update-agent-skills via .scripts/ensure-gh-skill.sh. Composite
+      # actions cannot share steps, but they can share a bundled script resolved
+      # relative to ${GITHUB_ACTION_PATH} (works for both local `uses: ./<action>`
+      # and external `uses: devantler-tech/actions/<action>@<ref>` callers).
+      run: bash "${GITHUB_ACTION_PATH}/../.scripts/ensure-gh-skill.sh"
 
     - name: 📦 Install skills
       id: install

--- a/update-agent-skills/action.yaml
+++ b/update-agent-skills/action.yaml
@@ -32,62 +32,16 @@ outputs:
 runs:
   using: composite
   steps:
-    # Mirror of the gh bootstrap in setup-agent-skills/action.yaml.
-    # Keep these two blocks in sync — composite actions cannot share steps.
     - name: 🔧 Ensure gh >= required version
       shell: bash
       env:
         REQUIRED: ${{ inputs.gh-version }}
-      run: | # zizmor: ignore[github-env]
-        set -euo pipefail
-        if command -v gh >/dev/null 2>&1 && gh skill --help >/dev/null 2>&1; then
-          current=$(gh --version | awk '/^gh version /{print $3; exit}')
-          if [ -z "$current" ]; then
-            echo "::error::Could not determine the installed gh version from 'gh --version' output."
-            exit 1
-          fi
-          if printf '%s\n%s\n' "$REQUIRED" "$current" | sort -V -C; then
-            echo "Installed gh ($current) already supports 'gh skill'."
-            exit 0
-          fi
-        fi
-
-        case "$(uname -s)" in
-          Linux)   os=linux;  ext=tar.gz ;;
-          Darwin)  os=macOS;  ext=zip ;;
-          *) echo "::error::Automatic gh install is only supported on Linux and macOS. On $(uname -s) (e.g. Windows), preinstall gh >= ${REQUIRED} on the runner before this step."; exit 1 ;;
-        esac
-        case "$(uname -m)" in
-          x86_64|amd64) arch=amd64 ;;
-          arm64|aarch64) arch=arm64 ;;
-          *) echo "::error::Unsupported arch: $(uname -m)"; exit 1 ;;
-        esac
-
-        tmp=$(mktemp -d)
-        asset="gh_${REQUIRED}_${os}_${arch}.${ext}"
-        url="https://github.com/cli/cli/releases/download/v${REQUIRED}/${asset}"
-        echo "Downloading $url"
-        if [ "$ext" = "zip" ]; then
-          if ! command -v unzip >/dev/null 2>&1; then
-            echo "::error::unzip is required to extract the macOS gh release archive but is not available on PATH."
-            exit 1
-          fi
-          curl -fsSL -o "$tmp/$asset" "$url"
-          unzip -q "$tmp/$asset" -d "$tmp"
-        else
-          curl -fsSL "$url" | tar -xzC "$tmp"
-        fi
-        install_dir="${RUNNER_TEMP:-/tmp}/update-agent-skills/bin"
-        mkdir -p "$install_dir"
-        install "$tmp/gh_${REQUIRED}_${os}_${arch}/bin/gh" "$install_dir/gh"
-        echo "$install_dir" >> "$GITHUB_PATH"  # zizmor: ignore[github-env]
-        export PATH="$install_dir:$PATH"
-        hash -r
-        gh --version
-        if ! gh skill --help >/dev/null 2>&1; then
-          echo "::error::Installed gh still does not expose the 'skill' command."
-          exit 1
-        fi
+        INSTALL_NAMESPACE: update-agent-skills
+      # Shared with setup-agent-skills via .scripts/ensure-gh-skill.sh. Composite
+      # actions cannot share steps, but they can share a bundled script resolved
+      # relative to ${GITHUB_ACTION_PATH} (works for both local `uses: ./<action>`
+      # and external `uses: devantler-tech/actions/<action>@<ref>` callers).
+      run: bash "${GITHUB_ACTION_PATH}/../.scripts/ensure-gh-skill.sh"
 
     - name: 🔄 Update skills
       id: update


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

`setup-agent-skills` and `update-agent-skills` carried **byte-identical** ~50-line `gh` bootstrap steps ("Ensure gh >= required version"), kept in lockstep only by a comment:

```
# Mirror of the gh bootstrap in setup-agent-skills/action.yaml.
# Keep these two blocks in sync — composite actions cannot share steps.
```

This extracts that logic into a single **`.scripts/ensure-gh-skill.sh`**, invoked from both actions via:

```yaml
run: bash "${GITHUB_ACTION_PATH}/../.scripts/ensure-gh-skill.sh"
```

The only per-action difference (the `$RUNNER_TEMP/<action>/bin` install dir) is parameterised via an `INSTALL_NAMESPACE` env var, so **behaviour is preserved exactly**.

## Why

- Removes the manual "keep these two blocks in sync" maintenance hazard and ~100 lines of duplication (net **+81 / −102**).
- `${GITHUB_ACTION_PATH}` resolves the bundled script for **both** local callers (`uses: ./setup-agent-skills`, as the CI tests do) **and** external consumers (`uses: devantler-tech/actions/setup-agent-skills@<ref>`) — GitHub checks out the whole repo to run a composite action, so the sibling `.scripts/` dir is always present.
- The `# zizmor: ignore[github-env]` annotation moves out of the YAML together with the `>> "$GITHUB_PATH"` write.

## Validation

- `bash -n` + **shellcheck**: clean on the new script.
- **zizmor** (repo `zizmor.yml`): `No findings to report` on both changed actions.
- YAML parses; README ↔ action.yaml parity unaffected (no input/output changes; READMEs document only behaviour, which is unchanged).
- **Runtime**: existing `ci.yaml` jobs run both actions on **ubuntu-latest + macos-latest** (`test-setup-agent-skills-*`, `test-update-agent-skills-*`), so CI exercises the shared-script path on both OSes.

## Blast radius

Internal-only change to two composite actions; inputs/outputs/defaults unchanged → backward-compatible for every consumer. The new top-level `.scripts/` dir is dot-prefixed, so it is excluded from the `lint-readme-parity` `*/action.yaml` glob.