### PR TITLE
feat(free-disk-space): add composite action to reclaim runner disk

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -167,8 +167,14 @@ jobs:
           FREED: ${{ steps.disk.outputs.freed }}
           AVAILABLE: ${{ steps.disk.outputs.available }}
         run: |
-          if [[ -z "$AVAILABLE" ]]; then
-            echo "::error::available output is empty"
+          if [[ -z "$FREED" || -z "$AVAILABLE" ]]; then
+            echo "::error::freed/available outputs are empty"
+            exit 1
+          fi
+          # Disabling every category removes nothing, so the reclaim MUST be 0 —
+          # any non-zero value means the action deleted something it shouldn't.
+          if (( FREED != 0 )); then
+            echo "::error::expected freed=0 on the all-disabled no-op, got ${FREED}G"
             exit 1
           fi
           echo "No-op reclaim: freed=${FREED}G, available=${AVAILABLE}G"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,6 +100,79 @@ jobs:
           pr-number: ${{ github.event.pull_request.number }}
           dry-run: "true"
 
+  # ── free-disk-space ─────────────────────────────────────────
+  test-free-disk-space:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: 🧪 Run free-disk-space
+        id: disk
+        uses: ./free-disk-space
+
+      - name: ✅ Verify space was reclaimed
+        shell: bash
+        env:
+          FREED: ${{ steps.disk.outputs.freed }}
+          AVAILABLE: ${{ steps.disk.outputs.available }}
+        run: |
+          if [[ -z "$FREED" || -z "$AVAILABLE" ]]; then
+            echo "::error::freed/available outputs are empty"
+            exit 1
+          fi
+          # The default set removes ~11+ GB of toolchains; require a real gain so
+          # a silently no-op'd reclaim (e.g. paths moved on a new runner image)
+          # is caught rather than passing vacuously.
+          if (( FREED < 1 )); then
+            echo "::error::expected to reclaim >=1G, got ${FREED}G"
+            exit 1
+          fi
+          echo "Reclaimed ${FREED}G; ${AVAILABLE}G free."
+
+  # ── free-disk-space (keep a toolchain) ──────────────────────
+  test-free-disk-space-keep:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # Disabling every category must be a clean no-op (0 G reclaimed), not an
+      # error — exercises the "empty path list" branch and the false toggles.
+      - name: 🧪 Run free-disk-space with all categories disabled
+        id: disk
+        uses: ./free-disk-space
+        with:
+          android: "false"
+          dotnet: "false"
+          haskell: "false"
+          boost: "false"
+          swift: "false"
+          codeql: "false"
+          pypy: "false"
+          powershell: "false"
+          miniconda: "false"
+
+      - name: ✅ Verify no-op succeeded with outputs
+        shell: bash
+        env:
+          FREED: ${{ steps.disk.outputs.freed }}
+          AVAILABLE: ${{ steps.disk.outputs.available }}
+        run: |
+          if [[ -z "$AVAILABLE" ]]; then
+            echo "::error::available output is empty"
+            exit 1
+          fi
+          echo "No-op reclaim: freed=${FREED}G, available=${AVAILABLE}G"
+
   # ── login-to-ghcr ──────────────────────────────────────────
   test-login-to-ghcr:
     runs-on: ubuntu-latest
@@ -958,6 +1031,8 @@ jobs:
       - test-cleanup-ghcr-packages
       - test-create-issues-from-todos
       - test-enable-auto-merge-on-pr
+      - test-free-disk-space
+      - test-free-disk-space-keep
       - test-login-to-ghcr
       - test-aggregate-job-checks-empty
       - test-aggregate-job-checks-success

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -134,7 +134,7 @@ jobs:
           fi
           echo "Reclaimed ${FREED}G; ${AVAILABLE}G free."
 
-  # ── free-disk-space (keep a toolchain) ──────────────────────
+  # ── free-disk-space (all categories disabled → clean no-op) ──
   test-free-disk-space-keep:
     runs-on: ubuntu-latest
     permissions:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ flowchart TD
 | [cleanup-ghcr-packages](cleanup-ghcr-packages/README.md) | Clean up old GHCR packages |
 | [create-issues-from-todos](create-issues-from-todos/README.md) | Create GitHub issues from TODO comments |
 | [enable-auto-merge-on-pr](enable-auto-merge-on-pr/README.md) | Enable auto-merge on a pull request |
+| [free-disk-space](free-disk-space/README.md) | Reclaim runner disk by removing large preinstalled toolchains |
 | [login-to-ghcr](login-to-ghcr/README.md) | Login to GitHub Container Registry |
 | [run-dotnet-tests](run-dotnet-tests/README.md) | Test .NET solution or project with coverage |
 | [setup-agent-skills](setup-agent-skills/README.md) | Install agent skills via `gh skill` from a newline list of `<owner/repo> <skill>[@pin]` entries, for one or more agents (e.g. Copilot, Claude Code) |

--- a/free-disk-space/README.md
+++ b/free-disk-space/README.md
@@ -1,0 +1,76 @@
+# Free Disk Space
+
+Reclaim runner disk by removing large preinstalled toolchains a job never uses
+(Android SDK, .NET, GHC, …). GitHub-hosted `ubuntu-latest` runners ship ~14 GB
+free on `/`; a large module's `go build` / `go test ./...` build cache (and the
+coverage job's `-race` binaries) can exhaust it, producing a hard
+`No space left on device` failure. This action reclaims ~11+ GB with targeted
+`rm -rf` only — it avoids the slow `apt-get remove` path and is best-effort
+(a missing path is never an error).
+
+Each toolchain is removed by default and can be kept by setting its input to
+`false` (e.g. a job that runs `.NET` should pass `dotnet: "false"`).
+
+## Inputs
+
+| Name | Description | Required | Default |
+|------|-------------|----------|---------|
+| `android` | Remove the Android SDK (/usr/local/lib/android, ~9 GB) | ❌ | `true` |
+| `dotnet` | Remove the .NET SDK (/usr/share/dotnet) | ❌ | `true` |
+| `haskell` | Remove GHC / Haskell (/opt/ghc) | ❌ | `true` |
+| `boost` | Remove the Boost C++ libraries (/usr/local/share/boost) | ❌ | `true` |
+| `swift` | Remove the Swift toolchain (/usr/share/swift) | ❌ | `true` |
+| `codeql` | Remove the CodeQL tool cache (/opt/hostedtoolcache/CodeQL) | ❌ | `true` |
+| `pypy` | Remove the PyPy tool cache (/opt/hostedtoolcache/PyPy) | ❌ | `true` |
+| `powershell` | Remove PowerShell (/usr/local/share/powershell) | ❌ | `true` |
+| `miniconda` | Remove Miniconda (/usr/share/miniconda) | ❌ | `true` |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `freed` | Approximate gigabytes of disk space reclaimed on / |
+| `available` | Gigabytes available on / after reclaiming |
+
+## Usage
+
+### Reclaim before a Go build/test
+
+```yaml
+steps:
+  - name: Free disk space
+    uses: devantler-tech/actions/free-disk-space@main
+
+  - name: Setup Go
+    uses: devantler-tech/actions/setup-go-toolchain@main
+
+  - name: Test
+    shell: bash
+    run: go test ./...
+```
+
+### Keep a toolchain the job needs
+
+```yaml
+steps:
+  - name: Free disk space
+    uses: devantler-tech/actions/free-disk-space@main
+    with:
+      dotnet: "false" # job runs .NET — keep /usr/share/dotnet
+```
+
+### Read how much was reclaimed
+
+```yaml
+steps:
+  - name: Free disk space
+    id: disk
+    uses: devantler-tech/actions/free-disk-space@main
+
+  - name: Report
+    shell: bash
+    env:
+      FREED: ${{ steps.disk.outputs.freed }}
+      AVAILABLE: ${{ steps.disk.outputs.available }}
+    run: echo "Reclaimed ${FREED}G; ${AVAILABLE}G now free."
+```

--- a/free-disk-space/action.yaml
+++ b/free-disk-space/action.yaml
@@ -1,0 +1,96 @@
+name: Free Disk Space
+description: Reclaim runner disk by removing large preinstalled toolchains a job never uses (Android SDK, .NET, GHC, …).
+author: devantler-tech
+inputs:
+  android:
+    description: Remove the Android SDK (/usr/local/lib/android, ~9 GB)
+    required: false
+    default: "true"
+  dotnet:
+    description: Remove the .NET SDK (/usr/share/dotnet)
+    required: false
+    default: "true"
+  haskell:
+    description: Remove GHC / Haskell (/opt/ghc)
+    required: false
+    default: "true"
+  boost:
+    description: Remove the Boost C++ libraries (/usr/local/share/boost)
+    required: false
+    default: "true"
+  swift:
+    description: Remove the Swift toolchain (/usr/share/swift)
+    required: false
+    default: "true"
+  codeql:
+    description: Remove the CodeQL tool cache (/opt/hostedtoolcache/CodeQL)
+    required: false
+    default: "true"
+  pypy:
+    description: Remove the PyPy tool cache (/opt/hostedtoolcache/PyPy)
+    required: false
+    default: "true"
+  powershell:
+    description: Remove PowerShell (/usr/local/share/powershell)
+    required: false
+    default: "true"
+  miniconda:
+    description: Remove Miniconda (/usr/share/miniconda)
+    required: false
+    default: "true"
+outputs:
+  freed:
+    description: Approximate gigabytes of disk space reclaimed on /
+    value: ${{ steps.reclaim.outputs.freed }}
+  available:
+    description: Gigabytes available on / after reclaiming
+    value: ${{ steps.reclaim.outputs.available }}
+runs:
+  using: composite
+  steps:
+    - name: 🧹 Free disk space
+      id: reclaim
+      shell: bash
+      # Targeted `rm -rf` only (avoids the slow apt-remove path); best-effort.
+      # A large module's `go build`/`go test ./...` cache (and `-race` binaries)
+      # can otherwise exhaust the runner disk — a hard "No space left on device".
+      env:
+        ANDROID: ${{ inputs.android }}
+        DOTNET: ${{ inputs.dotnet }}
+        HASKELL: ${{ inputs.haskell }}
+        BOOST: ${{ inputs.boost }}
+        SWIFT: ${{ inputs.swift }}
+        CODEQL: ${{ inputs.codeql }}
+        PYPY: ${{ inputs.pypy }}
+        POWERSHELL: ${{ inputs.powershell }}
+        MINICONDA: ${{ inputs.miniconda }}
+      run: |
+        set -euo pipefail
+        declare -A targets=(
+          [ANDROID]=/usr/local/lib/android
+          [DOTNET]=/usr/share/dotnet
+          [HASKELL]=/opt/ghc
+          [BOOST]=/usr/local/share/boost
+          [SWIFT]=/usr/share/swift
+          [CODEQL]=/opt/hostedtoolcache/CodeQL
+          [PYPY]=/opt/hostedtoolcache/PyPy
+          [POWERSHELL]=/usr/local/share/powershell
+          [MINICONDA]=/usr/share/miniconda
+        )
+        before=$(df --output=avail -BG / | tail -1 | tr -dc '0-9')
+        paths=()
+        for key in "${!targets[@]}"; do
+          if [ "${!key}" = "true" ]; then
+            paths+=("${targets[$key]}")
+          fi
+        done
+        if [ "${#paths[@]}" -gt 0 ]; then
+          sudo rm -rf "${paths[@]}" || true
+        fi
+        after=$(df --output=avail -BG / | tail -1 | tr -dc '0-9')
+        gained=$((after - before))
+        echo "Free disk on /: ${before}G -> ${after}G (gained ${gained}G)"
+        {
+          echo "freed=${gained}"
+          echo "available=${after}"
+        } >> "$GITHUB_OUTPUT"

--- a/free-disk-space/action.yaml
+++ b/free-disk-space/action.yaml
@@ -86,9 +86,18 @@ runs:
         done
         if [ "${#paths[@]}" -gt 0 ]; then
           sudo rm -rf "${paths[@]}" || true
+          after=$(df --output=avail -BG / | tail -1 | tr -dc '0-9')
+          gained=$((after - before))
+          # `df` deltas include unrelated disk churn between the two reads, so a
+          # real reclaim can read back slightly negative; floor at 0 since `freed`
+          # is "space reclaimed" and can never be negative.
+          [ "$gained" -lt 0 ] && gained=0
+        else
+          # No categories selected: a true no-op. Report 0 directly instead of a
+          # df delta so the output isn't polluted by background disk activity.
+          after="$before"
+          gained=0
         fi
-        after=$(df --output=avail -BG / | tail -1 | tr -dc '0-9')
-        gained=$((after - before))
         echo "Free disk on /: ${before}G -> ${after}G (gained ${gained}G)"
         {
           echo "freed=${gained}"


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

The disk-reclaim pattern (delete large preinstalled toolchains the job never uses) has **independently appeared in 2+ products** — a signal it has become *generic* and belongs in the shared `actions` library rather than copy-pasted per repo (holistic shared-library stewardship):

- **ksail** `ci.yaml` system-test jobs already carry a `🧹 Free disk space` step.
- **[reusable-workflows#285](https://github.com/devantler-tech/reusable-workflows/pull/285)** adds the *same* inline `rm -rf` block to all **three** Go-compiling jobs (`build`/`test`/`coverage`) in `validate-go-project.yaml` — its body explicitly flagged "extract a `free-disk-space` composite into `devantler-tech/actions`" as a follow-up (pattern now appears 4×).

Root cause it fixes: `ubuntu-latest` ships ~14 GB free on `/`; a large module's `go build`/`go test ./...` build cache (and the coverage job's `-race` binaries) can exhaust it, producing a hard `No space left on device`. Observed **live this run** on ksail#5004's `validate-go-project` `🧪 Test` job (run `26867544884`) — all 27 system tests passed but the runner couldn't flush its own diag log.

Once this lands + releases, rw#285 (and ksail) can collapse the duplicated inline blocks into `uses: devantler-tech/actions/free-disk-space@main`.

## What

New composite action `free-disk-space/`:
- **Per-category boolean inputs** (`android`, `dotnet`, `haskell`, `boost`, `swift`, `codeql`, `pypy`, `powershell`, `miniconda`), all default `true`. A job that needs a toolchain keeps it (`dotnet: "false"`) — important because not every consumer can drop .NET.
- **Outputs** `freed` (GB reclaimed) and `available` (GB free after).
- Faithful extraction of rw#285's proven path set; targeted `rm -rf` only (no slow `apt-get remove`), best-effort (`|| true`).
- Inputs are **env-mapped** (no `${{ }}` interpolated into the `run:` body) to stay zizmor template-injection-clean.

CI (`ci.yaml`):
- `test-free-disk-space` — positive smoke test asserting **≥1 G** reclaimed (so a silently no-op'd reclaim, e.g. paths relocated on a new runner image, fails loudly rather than passing vacuously).
- `test-free-disk-space-keep` — all categories disabled must be a clean **no-op** (exercises the empty-path branch + the false toggles).
- Both added to the `CI - Required Checks` gate `needs`.
- Root README + action README satisfy the bidirectional README↔action.yaml parity guard.

## Validation
- `actionlint .github/workflows/ci.yaml` — **0 new findings** (only the two pre-existing `code-quality` permission-scope false-positives remain).
- `shellcheck -s bash` on the composite's embedded script — clean (indirect `${!key}` expansion handled).
- Repo's own bidirectional parity check run locally against the new action — **PASS**.
- `action.yaml` parses (`yq`).

## Blast radius
Purely **additive** — a brand-new action directory + two new CI jobs; no existing action or workflow interface changed. No consumer is affected until it opts in with a `uses:`.