### PR TITLE
feat(dependency-review): add composite for GitHub Dependency Review

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,6 +74,40 @@ jobs:
           app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
           project: organization/devantler-tech/5
 
+  # ── dependency-review ───────────────────────────────────────
+  test-dependency-review:
+    runs-on: ubuntu-latest
+    # The underlying action only produces a diff on pull_request events; on push /
+    # merge_group there is no PR to review, so the test is PR-gated (skipped
+    # otherwise, which aggregate-job-checks tolerates — like test-approve-pr).
+    if: startsWith(github.event_name, 'pull_request')
+    permissions:
+      contents: read
+    steps:
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # warn-only defaults to true, so this exercises the action's wiring on the
+      # real PR diff without ever failing CI on a finding in this repo's own deps.
+      - name: 🧪 Run dependency-review
+        id: review
+        uses: ./dependency-review
+
+      - name: ✅ Verify the review ran and produced outputs
+        shell: bash
+        env:
+          CHANGES: ${{ steps.review.outputs.dependency-changes }}
+        run: |
+          # dependency-changes is always emitted (JSON, "[]" when nothing changed);
+          # an empty value means the action never ran / its wiring is broken.
+          if [[ -z "$CHANGES" ]]; then
+            echo "::error::dependency-changes output is empty — the action did not run"
+            exit 1
+          fi
+          echo "Dependency review ran; dependency-changes=${CHANGES}"
+
   # ── enable-auto-merge-on-pr ─────────────────────────────────
   test-enable-auto-merge-on-pr:
     runs-on: ubuntu-latest
@@ -957,6 +991,7 @@ jobs:
       - test-approve-pr
       - test-cleanup-ghcr-packages
       - test-create-issues-from-todos
+      - test-dependency-review
       - test-enable-auto-merge-on-pr
       - test-login-to-ghcr
       - test-aggregate-job-checks-empty
@@ -1001,6 +1036,7 @@ jobs:
             ${{ needs.test-approve-pr.result }}
             ${{ needs.test-cleanup-ghcr-packages.result }}
             ${{ needs.test-create-issues-from-todos.result }}
+            ${{ needs.test-dependency-review.result }}
             ${{ needs.test-enable-auto-merge-on-pr.result }}
             ${{ needs.test-login-to-ghcr.result }}
             ${{ needs.test-aggregate-job-checks-empty.result }}

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ flowchart TD
 | [approve-pr](approve-pr/README.md) | Approve a PR using a GitHub App identity |
 | [cleanup-ghcr-packages](cleanup-ghcr-packages/README.md) | Clean up old GHCR packages |
 | [create-issues-from-todos](create-issues-from-todos/README.md) | Create GitHub issues from TODO comments |
+| [dependency-review](dependency-review/README.md) | Scan a PR's dependency changes for vulnerabilities and disallowed licenses |
 | [enable-auto-merge-on-pr](enable-auto-merge-on-pr/README.md) | Enable auto-merge on a pull request |
 | [login-to-ghcr](login-to-ghcr/README.md) | Login to GitHub Container Registry |
 | [run-dotnet-tests](run-dotnet-tests/README.md) | Test .NET solution or project with coverage |

--- a/dependency-review/README.md
+++ b/dependency-review/README.md
@@ -1,0 +1,96 @@
+# Dependency Review
+
+Scan a pull request's dependency changes for known-vulnerable packages and
+disallowed licenses, using [GitHub Dependency Review][dra]. It diffs the base
+and head of a PR and surfaces any newly-introduced dependency that carries a
+known vulnerability or a license outside your policy.
+
+This composite wraps `actions/dependency-review-action` (SHA-pinned) and exposes
+the most useful knobs as inputs. It is **non-blocking by default**: `warn-only`
+defaults to `true`, so findings are reported as warnings and the check always
+succeeds — safe to roll out org-wide as a Required Workflow without blocking
+existing PRs. Set `warn-only` to `"false"` to start enforcing, optionally
+tightening `fail-on-severity`.
+
+> The underlying action only produces a meaningful diff on `pull_request` /
+> `pull_request_target` events (or when `base-ref` / `head-ref` are supplied
+> explicitly). Gate the calling job accordingly. `allow-licenses` and
+> `deny-licenses` are mutually exclusive — set at most one.
+
+[dra]: https://github.com/actions/dependency-review-action
+
+## Inputs
+
+| Name | Description | Required | Default |
+|------|-------------|----------|---------|
+| `fail-on-severity` | Block the PR on vulnerabilities of this severity or higher (`low`, `moderate`, `high`, `critical`). Only applies when `warn-only` is false. | ❌ | `critical` |
+| `fail-on-scopes` | Comma-separated dependency scopes to block on (`runtime`, `development`, `unknown`). Defaults to `runtime` so dev-only vulnerabilities don't block. | ❌ | `runtime` |
+| `allow-licenses` | Comma-separated allow-list of SPDX licenses; a dependency under any other license fails the check. Mutually exclusive with `deny-licenses`. | ❌ | - |
+| `deny-licenses` | Comma-separated deny-list of SPDX licenses; a dependency under any of these fails the check. Mutually exclusive with `allow-licenses`. | ❌ | - |
+| `comment-summary-in-pr` | Post the review summary as a PR comment (`always`, `on-failure`, `never`). Anything but `never` requires the calling job to grant `pull-requests: write`. | ❌ | `never` |
+| `base-ref` | Base git ref to diff from. Defaulted automatically on `pull_request` / `pull_request_target`; required for other events. | ❌ | - |
+| `head-ref` | Head git ref to diff to. Defaulted automatically on `pull_request` / `pull_request_target`; required for other events. | ❌ | - |
+| `retry-on-snapshot-warnings` | Retry when the dependency snapshot is not yet available, instead of failing immediately. | ❌ | `false` |
+| `warn-only` | Report every finding as a warning and always succeed, overriding `fail-on-severity`. Defaults to `true` so the check can roll out org-wide without blocking PRs; set to `false` to enforce. | ❌ | `true` |
+| `repo-token` | Token used to read dependency changes and (optionally) post the PR comment. | ❌ | `${{ github.token }}` |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `comment-content` | The prepared dependency-review report comment (markdown). |
+| `dependency-changes` | All dependency changes in the PR (JSON). |
+| `vulnerable-changes` | Vulnerable dependency changes (JSON). |
+| `invalid-license-changes` | Dependency changes with disallowed licenses (JSON). |
+| `denied-changes` | Denied dependency changes (JSON). |
+
+## Permissions
+
+The composite reads the dependency diff with `contents: read`. Posting a PR
+comment (`comment-summary-in-pr` ≠ `never`) additionally requires the **calling
+job** to grant `pull-requests: write` — a composite cannot declare it.
+
+## Usage
+
+### Non-blocking (default) — warn on findings
+
+```yaml
+jobs:
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: 🛡️ Review dependencies
+        uses: devantler-tech/actions/dependency-review@main
+```
+
+### Enforce — fail on high-severity vulnerabilities and post a comment
+
+```yaml
+jobs:
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write # required for comment-summary-in-pr
+    steps:
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: 🛡️ Review dependencies
+        uses: devantler-tech/actions/dependency-review@main
+        with:
+          warn-only: "false"
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure
+```

--- a/dependency-review/action.yaml
+++ b/dependency-review/action.yaml
@@ -1,0 +1,73 @@
+name: Dependency Review
+description: Scan a pull request's dependency changes for known-vulnerable packages and disallowed licenses (GitHub Dependency Review).
+author: devantler-tech
+inputs:
+  fail-on-severity:
+    description: Block the PR on vulnerabilities of this severity or higher (low, moderate, high, critical). Only applies when warn-only is false.
+    required: false
+    default: critical
+  fail-on-scopes:
+    description: Comma-separated dependency scopes to block on (runtime, development, unknown). Defaults to runtime so dev-only vulnerabilities don't block.
+    required: false
+    default: runtime
+  allow-licenses:
+    description: Comma-separated allow-list of SPDX licenses; a dependency under any other license fails the check. Mutually exclusive with deny-licenses.
+    required: false
+  deny-licenses:
+    description: Comma-separated deny-list of SPDX licenses; a dependency under any of these fails the check. Mutually exclusive with allow-licenses.
+    required: false
+  comment-summary-in-pr:
+    description: Post the review summary as a PR comment (always, on-failure, never). Anything but never requires the calling job to grant pull-requests write.
+    required: false
+    default: never
+  base-ref:
+    description: Base git ref to diff from. Defaulted automatically on pull_request / pull_request_target; required for other events.
+    required: false
+  head-ref:
+    description: Head git ref to diff to. Defaulted automatically on pull_request / pull_request_target; required for other events.
+    required: false
+  retry-on-snapshot-warnings:
+    description: Retry when the dependency snapshot is not yet available, instead of failing immediately.
+    required: false
+    default: "false"
+  warn-only:
+    description: Report every finding as a warning and always succeed, overriding fail-on-severity. Defaults to true so the check can roll out org-wide without blocking PRs; set to false to enforce.
+    required: false
+    default: "true"
+  repo-token:
+    description: Token used to read dependency changes and (optionally) post the PR comment.
+    required: false
+    default: ${{ github.token }}
+outputs:
+  comment-content:
+    description: The prepared dependency-review report comment (markdown).
+    value: ${{ steps.review.outputs.comment-content }}
+  dependency-changes:
+    description: All dependency changes in the PR (JSON).
+    value: ${{ steps.review.outputs.dependency-changes }}
+  vulnerable-changes:
+    description: Vulnerable dependency changes (JSON).
+    value: ${{ steps.review.outputs.vulnerable-changes }}
+  invalid-license-changes:
+    description: Dependency changes with disallowed licenses (JSON).
+    value: ${{ steps.review.outputs.invalid-license-changes }}
+  denied-changes:
+    description: Denied dependency changes (JSON).
+    value: ${{ steps.review.outputs.denied-changes }}
+runs:
+  using: composite
+  steps:
+    - name: 🛡️ Review dependencies
+      id: review
+      uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+      with:
+        fail-on-severity: ${{ inputs.fail-on-severity }}
+        fail-on-scopes: ${{ inputs.fail-on-scopes }}
+        allow-licenses: ${{ inputs.allow-licenses }}
+        deny-licenses: ${{ inputs.deny-licenses }}
+        comment-summary-in-pr: ${{ inputs.comment-summary-in-pr }}
+        base-ref: ${{ inputs.base-ref }}
+        head-ref: ${{ inputs.head-ref }}
+        retry-on-snapshot-warnings: ${{ inputs.retry-on-snapshot-warnings }}
+        warn-only: ${{ inputs.warn-only }}
+        repo-token: ${{ inputs.repo-token }}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

**Part 1 of 3** of an org-wide **Dependency Review Required Workflow** (maintainer-directed). This PR adds the reusable building block; the reusable workflow + the org ruleset follow.

## What
New `dependency-review/` composite wrapping `actions/dependency-review-action@a1d282b3… # v5.0.0` (SHA verified: lightweight tag → commit). It diffs a PR's dependency changes and flags newly-introduced vulnerable packages / disallowed licenses. All 10 inputs and 5 outputs are real upstream names (verified against the action's `action.yml`).

## Safe-by-default (this becomes a Required Workflow on every repo)
- `warn-only` defaults to **`true`** → findings are warnings, the check always succeeds. Lets it roll out org-wide without blocking a single existing PR. Flip to `"false"` (optionally lowering `fail-on-severity` from `critical`) to enforce.
- `comment-summary-in-pr` defaults to **`never`** → the calling job needs only `contents: read`; no `pull-requests: write`, no dependency on org "Actions create/approve PR" settings.
- `fail-on-scopes: runtime` so dev-only vulns don't block once enforced.

## CI
- PR-gated `test-dependency-review` smoke test — runs the composite on the real PR diff and asserts the `dependency-changes` output is emitted (wiring check). `warn-only` means a real finding never fails this repo's own CI.
- Wired into **both** the `ci-required-checks` `needs:` list **and** the `aggregate-job-checks` `job-results:` expression (the gate reads both — `needs:` alone would not detect a failure).
- Root + action READMEs satisfy the bidirectional README↔action.yaml parity guard.

## Validation
`actionlint` — only the 2 pre-existing `code-quality` permission-scope false-positives, **0 new**. `yq` parse OK, SHA-pin confirmed. Repo's own bidirectional parity check **PASS** locally.

## Sequencing (the other two parts)
1. **This PR (composite)** lands first → the composite exists on `actions` main (and ideally a release is cut so it has a tag/SHA).
2. **`reusable-workflows/dependency-review.yaml`** (next PR) — the `workflow_call` + Required-Workflow-trigger workflow that calls this composite (SHA-pinned, per house style).
3. **Org ruleset** `Require workflows to pass before merging - DependencyReview` — applied only **after** the workflow is on `reusable-workflows@main`, mirroring the `ScanGitHubActions` ruleset. Applying it earlier would error "workflow not found" on every PR org-wide.

Blast radius: purely **additive** — a new action dir + one new CI job; no existing action/workflow interface changes.