### PR TITLE
ci: exempt internal devantler-tech deps from Dependabot cooldown

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,3 +6,6 @@ updates:
       interval: daily
     cooldown:
       default-days: 7
+      # devantler-tech actions/workflows are our own code — bump now, no cooldown.
+      exclude:
+        - "devantler-tech/*"


### PR DESCRIPTION
## What

Adds `exclude: ["devantler-tech/*"]` to the Dependabot `github-actions` cooldown. Per Dependabot's `WildcardMatcher`, `*` compiles to `.*` (anchored, matches across `/`), so it covers both `devantler-tech/actions` and reusable-workflow refs like `devantler-tech/reusable-workflows/.github/workflows/<file>.yaml`.

## Why

We trust our own code (CI is the gate), so internal `devantler-tech/*` bumps shouldn't wait in cooldown like third-party deps — they should land immediately.

Companion to devantler-tech/monorepo#1782 (portfolio-wide pass across every repo's Dependabot/Renovate config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
