### PR TITLE
fix(run-dotnet-tests): gate coverage upload on runner.os, not the unavailable matrix context

### DIFF
--- a/run-dotnet-tests/action.yaml
+++ b/run-dotnet-tests/action.yaml
@@ -46,7 +46,7 @@ runs:
     # Linux only — one upload per repo avoids the matrix triple-reporting the same coverage.
     # best-effort: this is a preview feature, so it must never break .NET CI.
     - name: 🔀 Merge coverage into a single Cobertura report
-      if: matrix.os == 'ubuntu-latest'
+      if: runner.os == 'Linux'
       continue-on-error: true
       run: |
         dotnet tool install --global dotnet-reportgenerator-globaltool --version 5.5.10
@@ -55,7 +55,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
     - name: 📊 Upload Code Coverage to GitHub Code Quality
-      if: matrix.os == 'ubuntu-latest'
+      if: runner.os == 'Linux'
       continue-on-error: true
       uses: devantler-tech/actions/upload-coverage@60d895a7aabe6e3c0247c86a83560656a760ee08 # v3.5.0
       with:


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

The `run-dotnet-tests` composite action gates its **coverage merge + upload** steps on:

```yaml
if: matrix.os == 'ubuntu-latest'
```

The intent (per the inline comment) is *"Linux only — one upload per repo avoids the matrix
triple-reporting the same coverage."* The caller reusable workflow
(`run-dotnet-tests.yaml`) defines `strategy.matrix.os: [ubuntu-latest, windows-latest,
macos-latest]` at the **job** level and runs the action across all three legs.

The bug: the **`matrix` context is not available inside a composite action**. A composite
action's steps can reference only `github`, `inputs`, `env`, `steps`, `job`, and `runner` —
**not** `matrix`, `strategy`, `needs`, or `secrets`. So `matrix.os` evaluates to empty, the
condition is always false, and the *best-effort coverage merge + upload to GitHub Code
Quality never runs on any leg*. Because both steps are `continue-on-error: true`, the failure
is silent — CI stays green while coverage is simply never reported.

The guard is also doubly fragile even setting that aside: it couples the **composite** to the
**caller's** matrix variable being named exactly `os` with the literal value `ubuntu-latest`.
A caller using a differently-named matrix key, or `ubuntu-24.04` instead of `ubuntu-latest`,
would silently lose coverage.

## Fix

Gate on the `runner` context, which **is** available inside composite actions and reflects
the OS of the leg the action is currently running on:

```yaml
if: runner.os == 'Linux'
```

This yields exactly the intended behaviour — only the Linux leg of the caller's matrix merges
and uploads coverage — while being fully encapsulated: it no longer depends on the caller's
matrix shape, variable naming, or runner label.

## Why it's safe

- Behaviour-preserving with respect to *intent*; it restores the *originally intended* "upload
  once, on Linux" behaviour that the broken guard silently disabled.
- Both affected steps remain `continue-on-error: true` (coverage is a preview/best-effort
  feature that must never break .NET CI), so there is no risk to the required test result.
- Two-line change, no input/interface change; all consumers (`@v5` pin) inherit the fix on the
  next tag with no caller edits.

## Validation

- Confirmed against **live `main`** (the guard is present at `run-dotnet-tests/action.yaml:49`
  and `:58`).
- Confirmed `run-dotnet-tests` is the only action in the repo using a `matrix.*` reference, and
  that its caller (`reusable-workflows/.../run-dotnet-tests.yaml`) supplies the matrix at the
  job level and invokes the composite without passing the OS — so the composite had no legitimate
  way to see `matrix.os`.
- YAML-only change; the repo's `actionlint`/validate checks will exercise it on this PR.

Opened as a **draft** per the engineering contract; promote to ready when you're happy with it.
