### PR TITLE
docs: adopt a pin-comment convention for tagless branch-tracked actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ All conventions are documented in [CONTRIBUTING.md](CONTRIBUTING.md). Key rules 
 - **Action directory naming:** `<active-verb>-<purpose>` (e.g., `setup-go-toolchain`, not `go-setup`)
 - **Inputs/outputs:** kebab-case only (e.g., `app-id`, `github-token`)
 - **Action type:** Prefer **composite** over JavaScript/Docker
-- **External action pinning:** Pin third-party actions (non-`actions/*`, non-`github/*`, non-`devantler-tech/*`) to commit SHAs with a `# v<version>` comment — enforced by `zizmor.yml`
+- **External action pinning:** Pin third-party actions (non-`actions/*`, non-`github/*`, non-`devantler-tech/*`) to commit SHAs with a `# v<version>` comment — enforced by `zizmor.yml`. For a dep that publishes **no tags/releases** (main-tracked only), use `# <branch> (no upstream releases)` instead so a branch-commit pin reads differently from a tag pin (see CONTRIBUTING.md)
 - **Test job required:** Every new action needs a `test-<action-name>` job in `.github/workflows/ci.yaml`, with `persist-credentials: false` on the `actions/checkout` step
 - **`action.yaml`:** Always set `author: devantler-tech`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,16 @@ Every action must have a corresponding test workflow at `.github/workflows/test-
 - Run [zizmor](https://github.com/zizmorcore/zizmor) to scan for GitHub Actions vulnerabilities
 - Pin third-party actions to commit SHAs (enforced by `zizmor.yml`)
 - Actions under `actions/*`, `github/*`, and `devantler-tech/*` may use tag-based refs
+- **External action pin comment convention.** Annotate each third-party SHA pin so a
+  reader can tell at a glance whether it tracks a tag or a branch:
+  - Pinned to a release tag → `# v<version>` (e.g. `# v6.0.2`). This is the default;
+    12/13 third-party pins use it.
+  - Pinned to a branch commit because the upstream publishes **no tags or releases**
+    (main-tracked only) → `# <branch> (no upstream releases)` (e.g.
+    `# main (no upstream releases)`). This keeps the comment honest — it names the
+    branch and *why* there is no version — so a future re-pin to a newer branch
+    commit isn't mistaken for a floating `@main` ref. The lone such dep today is
+    `Homebrew/actions/setup-homebrew` in `setup-ksail-cli`.
 
 ## Commits
 

--- a/setup-ksail-cli/action.yaml
+++ b/setup-ksail-cli/action.yaml
@@ -6,7 +6,10 @@ runs:
   using: "composite"
   steps:
     - name: 📦 Setup Homebrew
-      uses: Homebrew/actions/setup-homebrew@ac399ee818eb2bb93b838aeccd2cbaa6272e2403 # main
+      # Pinned to a branch commit, not a tag: Homebrew/actions publishes no tags
+      # or releases (main-tracked only), so the comment names the branch + why
+      # rather than a `# v<version>` — see CONTRIBUTING.md "External action pinning".
+      uses: Homebrew/actions/setup-homebrew@ac399ee818eb2bb93b838aeccd2cbaa6272e2403 # main (no upstream releases)
 
     - name: ⤵️ Install KSail
       shell: bash


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Adopts a documented pin-comment convention so a reader can tell **at a glance** whether a third-party SHA pin tracks a **release tag** or a **branch commit**:

- **Tag pin** → `# v<version>` (the default — 12/13 third-party pins).
- **Branch-commit pin** (upstream publishes no tags/releases, main-tracked only) → `# <branch> (no upstream releases)`.

Concretely:
- `setup-ksail-cli/action.yaml`: the lone outlier `Homebrew/actions/setup-homebrew@<sha> # main` becomes `# main (no upstream releases)`, with a short inline note explaining why it tracks a branch (Homebrew/actions ships no tags). The SHA is unchanged.
- `CONTRIBUTING.md` + `AGENTS.md`: document the convention next to the existing "Pin third-party actions to commit SHAs" rule.

## Why

`Homebrew/actions/setup-homebrew` is the only third-party dependency in the suite with **no upstream releases** — its bare `# main` comment was *honest* but indistinguishable from a (forbidden) floating `@main` ref, and a future re-pin to a newer `main` commit could be mistaken for a moving target. Naming the branch + the reason makes the pin self-documenting and keeps the whole action library on **one consistent, legible pin-comment style**. This is a pure convention/consistency improvement on a shared library every repo consumes.

## Scope

Addresses **item 1 (Consistency — pin-comment & metadata convention)** of roadmap epic #247. The epic's companion tidy-up (`setup-ksail-cli` being the only action with no `inputs:` section) is intentionally **skipped** — the action genuinely takes no inputs, so an empty `inputs:` block would be noise. Items 2 (Marketplace branding — maintainer-direction-gated) and 3 (reliability) remain open on the epic.

## Validation

- **Additive & backward-compatible**, comment-only change to the pin — **no behaviour change**, no input/output change (so the `lint-readme-parity` check is unaffected).
- `zizmor setup-ksail-cli/action.yaml` → **No findings** (the hash-pin is still recognised with the new comment); full-repo zizmor unchanged from base (the 2 pre-existing `create-github-app-token` high findings are untouched files).
- YAML well-formed; docs lint-clean against `.markdownlint.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)