### PR TITLE
feat(setup-ksail-cli): retry brew network pulls on transient flakes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -604,6 +604,62 @@ jobs:
         shell: bash
         run: ksail --version
 
+  # ── .scripts/retry.sh ──────────────────────────────────────
+  test-retry-script:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: ✅ Succeeds on the first attempt
+        shell: bash
+        run: bash .scripts/retry.sh 3 0 -- true
+
+      - name: ✅ Retries a flaky command until it succeeds
+        shell: bash
+        run: |
+          export COUNTER
+          COUNTER="$(mktemp)"
+          echo 0 >"$COUNTER"
+          flaky="$(mktemp)"
+          # Quoted heredoc: the body is written verbatim and only evaluated when
+          # the flaky script runs, so it fails on attempts 1-2 and succeeds on 3.
+          cat >"$flaky" <<'EOF'
+          n=$(( $(cat "$COUNTER") + 1 ))
+          echo "$n" >"$COUNTER"
+          [ "$n" -ge 3 ]
+          EOF
+          bash .scripts/retry.sh 3 0 -- bash "$flaky"
+          got="$(cat "$COUNTER")"
+          if [ "$got" -ne 3 ]; then
+            echo "::error::expected 3 attempts before success, got $got"
+            exit 1
+          fi
+
+      - name: ✅ Propagates the failure code after exhausting attempts
+        shell: bash
+        run: |
+          status=0
+          bash .scripts/retry.sh 2 0 -- bash -c 'exit 7' || status=$?
+          if [ "$status" -ne 7 ]; then
+            echo "::error::expected exhausted retry to exit 7, got $status"
+            exit 1
+          fi
+
+      - name: ✅ Rejects malformed arguments
+        shell: bash
+        run: |
+          status=0
+          bash .scripts/retry.sh 3 -- true || status=$?
+          if [ "$status" -ne 2 ]; then
+            echo "::error::expected usage error (exit 2) for missing delimiter, got $status"
+            exit 1
+          fi
+
   # ── sync-github-labels ─────────────────────────────────────
   test-sync-github-labels:
     runs-on: ubuntu-latest
@@ -1088,6 +1144,7 @@ jobs:
       - test-setup-go-toolchain
       - test-setup-go-toolchain-private-modules
       - test-setup-ksail-cli
+      - test-retry-script
       - test-sync-github-labels
       - test-update-agent-skills-noop
       - test-update-agent-skills-dry-run
@@ -1133,6 +1190,7 @@ jobs:
             ${{ needs.test-setup-go-toolchain.result }}
             ${{ needs.test-setup-go-toolchain-private-modules.result }}
             ${{ needs.test-setup-ksail-cli.result }}
+            ${{ needs.test-retry-script.result }}
             ${{ needs.test-sync-github-labels.result }}
             ${{ needs.test-update-agent-skills-noop.result }}
             ${{ needs.test-update-agent-skills-dry-run.result }}

--- a/.scripts/retry.sh
+++ b/.scripts/retry.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Bounded retry-with-backoff wrapper for transient-failure-prone commands.
+#
+# Realizes the "composites resilient to transient infra" reliability pillar
+# (devantler-tech/actions#247 item 3): a composite that does a NETWORK PULL
+# (brew install, registry pull, toolchain download) should tolerate transient
+# registry/network flakes with a bounded retry + backoff so it never reds a
+# *required* check on infra noise rather than on a real failure.
+#
+# Shared across composites via the bundled-script pattern (the same one
+# .scripts/ensure-gh-skill.sh uses): composite actions cannot share steps, but
+# they can share a script bundled in this repository, resolved relative to
+# ${GITHUB_ACTION_PATH} so it works for both local `uses: ./<action>` callers
+# and external `uses: devantler-tech/actions/<action>@<ref>` consumers:
+#   bash "${GITHUB_ACTION_PATH}/../.scripts/retry.sh" <attempts> <base-delay-s> -- <cmd> [args...]
+#
+# Backoff is exponential: base-delay * 2^(attempt-1) seconds between tries
+# (e.g. base 5 → waits 5s, then 10s, then 20s …). Exits 0 on the first success;
+# on exhaustion, exits with the last attempt's status code so the caller still
+# sees a genuine, persistent failure.
+set -euo pipefail
+
+usage() {
+  echo "::error::Usage: retry.sh <max-attempts> <base-delay-seconds> -- <command> [args...]" >&2
+  exit 2
+}
+
+# Need at least: <attempts> <base-delay> -- <command>
+[ "$#" -ge 4 ] || usage
+attempts="$1"
+base_delay="$2"
+shift 2
+[ "$1" = "--" ] || usage
+shift
+
+case "$attempts" in '' | *[!0-9]*) usage ;; esac
+case "$base_delay" in '' | *[!0-9]*) usage ;; esac
+[ "$attempts" -ge 1 ] || usage
+[ "$#" -ge 1 ] || usage
+
+attempt=1
+while true; do
+  # `cmd || status=$?` runs the command with errexit suspended and captures its
+  # real exit code (a bare `if cmd; then` would leave $? as 0 on the else path).
+  status=0
+  "$@" || status=$?
+  if [ "$status" -eq 0 ]; then
+    exit 0
+  fi
+  if [ "$attempt" -ge "$attempts" ]; then
+    echo "::error::Command failed after ${attempts} attempt(s): $* (last exit ${status})" >&2
+    exit "$status"
+  fi
+  delay=$((base_delay * (1 << (attempt - 1))))
+  echo "::warning::Attempt ${attempt}/${attempts} failed (exit ${status}): $* — retrying in ${delay}s" >&2
+  sleep "$delay"
+  attempt=$((attempt + 1))
+done

--- a/setup-ksail-cli/action.yaml
+++ b/setup-ksail-cli/action.yaml
@@ -10,6 +10,10 @@ runs:
 
     - name: ⤵️ Install KSail
       shell: bash
+      # The tap fetch and bottle pull are network operations that occasionally
+      # fail on transient registry/network flakes; a bounded retry + backoff
+      # keeps an infra hiccup from reding a required check (see the shared
+      # .scripts/retry.sh helper and devantler-tech/actions#247 item 3).
       run: |
-        brew tap devantler-tech/formulas
-        brew install ksail
+        bash "${GITHUB_ACTION_PATH}/../.scripts/retry.sh" 3 5 -- brew tap devantler-tech/formulas
+        bash "${GITHUB_ACTION_PATH}/../.scripts/retry.sh" 3 5 -- brew install ksail


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Make `setup-ksail-cli` resilient to transient infra. Its `brew tap` + `brew install ksail` are **network operations** (Homebrew fetch + GHCR bottle pull) that occasionally fail on transient registry/network flakes — and as a *required* check in many consumer pipelines, an infra hiccup currently reds a build that has nothing wrong with it.

This wraps both `brew` calls in a **bounded retry + backoff** via a new reusable `.scripts/retry.sh` helper, so a transient flake is retried (3 attempts, 5s → 10s backoff) instead of failing the check, while a *genuine, persistent* failure still surfaces (the last attempt's exit code is propagated).

Realizes the **"composites resilient to transient infra"** reliability pillar of the actions roadmap epic — [actions#247](https://github.com/devantler-tech/actions/issues/247) item 3 — which names `setup-ksail-cli`'s `brew install` explicitly and ties it to the live ksail `System Test (Docker)` registry-pull flake theme (ksail#5102 / ksail#4972).

## Changes

- **`.scripts/retry.sh`** (new) — generic `retry.sh <max-attempts> <base-delay-s> -- <cmd> [args…]` wrapper with exponential backoff. Follows the existing `.scripts/ensure-gh-skill.sh` *bundled-script* convention (composites can't share steps, but can share a script resolved relative to `${GITHUB_ACTION_PATH}`, working for both `uses: ./<action>` and external `uses: …@<ref>` callers). Exits 0 on first success; on exhaustion exits with the last attempt's status so a real failure is never masked.
- **`setup-ksail-cli/action.yaml`** — run `brew tap` / `brew install ksail` through the helper. Internal-only change: **no input/output change**, so the README ↔ action.yaml parity guard is unaffected and all consumers are unchanged.
- **`ci.yaml`** — new `test-retry-script` job (added to the `CI - Required Checks` gate) covering: first-try success, retry-then-succeed (asserts it actually retried 3×), failure-code propagation on exhaustion, and argument validation. The existing `test-setup-ksail-cli` job continues to exercise the real `brew` install on ubuntu + macOS.

## Blast radius / trade-offs

- **Additive & backward-compatible** — no published input/output changes; existing consumers keep working verbatim.
- Backoff caps a *failing* install at ~3 attempts (worst case +15s before a real failure surfaces) — a deliberate trade for not reding required checks on infra noise.
- The helper is intentionally reusable: the other network-pull composites (`login-to-ghcr`, `setup-go-toolchain` downloads) are natural follow-up consumers, to be hardened incrementally rather than in one big-bang PR.

## Validation

- `actionlint .github/workflows/ci.yaml` → clean (only the two pre-existing `code-quality`-permission warnings from actionlint's stale scope list remain, unrelated to this diff).
- `shellcheck .scripts/retry.sh` → clean.
- All four `test-retry-script` step bodies executed locally and pass; `retry.sh` unit-behaviors (first-try / retry-then-succeed / exhaust-propagates-7 / usage-exit-2) verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)