### PR TITLE
fix(labels): add roadmap to canonical label set so weekly sync stops deleting it

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -4,6 +4,8 @@
   color: 'ededed'
 - name: next
   color: '5d3fd3'
+- name: roadmap
+  color: '0e8a16'
 - name: bug
   color: 'd73a4a'
 - name: enhancement


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

`sync-github-labels` runs the [EndBug/label-sync](https://github.com/EndBug/label-sync) action with **`delete-other-labels: "true"`** ([action.yaml](https://github.com/devantler-tech/actions/blob/main/sync-github-labels/action.yaml)) against this repo's canonical [`.github/labels.yaml`](https://github.com/devantler-tech/actions/blob/main/.github/labels.yaml). Every consumer repo runs a weekly `Sync labels` workflow (Mon 07:00 UTC) using this exact config.

The canonical set is **missing `roadmap`** — yet the whole portfolio's roadmap-of-record scheme depends on a persistent `roadmap` label (epic/theme-level issues carry it; `AGENTS.md` even instructs agents to "create it once per repo if missing"). Because `roadmap` isn't in the config and `delete-other-labels` is on, **every weekly sync deletes the `roadmap` label** on each repo that runs it — and deleting a label strips it from every issue that had it. The "create it if missing" instruction is the recurring symptom: agents keep recreating a label the sync keeps deleting.

## Evidence

- `devantler-tech/ksail` carries `roadmap` (epic #4988) and runs `sync-labels` weekly with the **default** (this) config — its `roadmap` label has had to be recreated between runs.
- `delete-other-labels` is hard-coded `"true"` in `sync-github-labels/action.yaml`; `roadmap` is absent from `labels.yaml`.

## Fix

Add `roadmap` (`#0e8a16`, the colour already used across the suite) to the canonical set, matching the file's existing `name`+`color` style. This is **additive and backward-compatible** — it only *protects* an already-used label from deletion and standardises its colour; no existing label is changed or removed.

## Blast radius

Affects every consumer repo's next weekly label sync: `roadmap` will be preserved (and colour-normalised) instead of deleted. No breaking input/output change to the action or workflow.

## Note (out of scope, one concern per PR)

The dependabot/GitHub-managed labels (`dependencies`, `docker`, `github_actions`) are also deleted by each sync, but those are auto-recreated by Dependabot on its next PR, so the churn is self-healing — unlike `roadmap`, which has no auto-recreator. Left for a separate decision.

## Validation

`labels.yaml` parses cleanly (22 entries, `roadmap` present, no duplicate names).