### PR TITLE
fix(setup-ksail-cli): trust first-party tap so brew can load the KSail Cask

### DIFF
--- a/setup-ksail-cli/action.yaml
+++ b/setup-ksail-cli/action.yaml
@@ -15,4 +15,9 @@ runs:
       shell: bash
       run: |
         brew tap devantler-tech/formulas
+        # KSail ships as a Cask. Homebrew refuses to load Casks from a non-official
+        # tap when HOMEBREW_REQUIRE_TAP_TRUST is set (now enforced on the CI runners),
+        # failing with "Refusing to load cask … from untrusted tap". Explicitly trust
+        # our own first-party tap so `brew install` can load it non-interactively.
+        brew trust --tap devantler-tech/formulas
         brew install ksail


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

`setup-ksail-cli` was failing in CI with:

```
Refusing to load cask devantler-tech/formulas/ksail from untrusted tap devantler-tech/formulas.
Run `brew trust --cask devantler-tech/formulas/ksail` or `brew trust devantler-tech/formulas` to trust it.
```

KSail is now distributed as a Homebrew **Cask** (the `devantler-tech/formulas` tap is Cask-only: `Casks/ksail.rb`, `Casks/ksail-desktop.rb`). Homebrew refuses to load Casks from a non-official tap when `HOMEBREW_REQUIRE_TAP_TRUST` is set — now enforced on the GitHub-hosted runners — so `brew install ksail` fails non-interactively. `actions` `main` CI is green only because it last ran before the runner-side enforcement landed; the failure reproduces on every fresh run (e.g. dependabot PRs [#259](https://github.com/devantler-tech/actions/pull/259), [#260](https://github.com/devantler-tech/actions/pull/260) — both red on `test-setup-ksail-cli`).

## Fix

Explicitly trust our own first-party tap before installing:

```bash
brew tap devantler-tech/formulas
brew trust --tap devantler-tech/formulas   # new
brew install ksail
```

`brew trust --tap <tap>` records the tap in Homebrew's `trust.json`, which is honoured when `HOMEBREW_REQUIRE_TAP_TRUST` is set (and is a harmless no-op when it isn't). Trusting the **tap** (vs. a single Cask) is robust to Cask-token edge cases and future-proofs `ksail-desktop`; it is safe because this is the maintainer's own first-party tap — exactly the second remediation Homebrew itself suggests.

## Validation

- `ruby -ryaml` parse of `action.yaml` — OK
- `shellcheck` on the `run:` script — clean
- End-to-end proof is this PR's own `test-setup-ksail-cli` job (it taps + installs the Cask on a fresh runner).

Once green, this unblocks the dependabot PRs whose only red is `test-setup-ksail-cli`.