### PR TITLE
refactor(run-dotnet-tests)!: drop dead app-id/app-private-key inputs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -336,8 +336,6 @@ jobs:
       - name: 🧪 Run run-dotnet-tests
         uses: ./run-dotnet-tests
         with:
-          app-id: ${{ vars.APP_ID }}
-          app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           working-directory: .github/fixtures/run-dotnet-tests
 
@@ -941,8 +939,6 @@ jobs:
         continue-on-error: true
         uses: ./run-dotnet-tests
         with:
-          app-id: ${{ vars.APP_ID }}
-          app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           working-directory: does-not-exist
 

--- a/run-dotnet-tests/README.md
+++ b/run-dotnet-tests/README.md
@@ -8,8 +8,6 @@ Test .NET solutions or projects across multiple platforms with code coverage rep
 
 | Name | Description | Required | Default |
 |------|-------------|----------|---------|
-| `app-id` | GitHub App ID to generate a token | ✅ | - |
-| `app-private-key` | Private key of the GitHub App | ✅ | - |
 | `github-token` | GitHub token to access the repository | ✅ | - |
 | `working-directory` | Directory to run the tests in | ❌ | `.` |
 
@@ -22,8 +20,6 @@ steps:
   - name: Test .NET project
     uses: devantler-tech/actions/run-dotnet-tests@main
     with:
-      app-id: ${{ vars.APP_ID }}
-      app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
       github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
@@ -34,8 +30,6 @@ steps:
   - name: Test .NET project
     uses: devantler-tech/actions/run-dotnet-tests@main
     with:
-      app-id: ${{ vars.APP_ID }}
-      app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
       github-token: ${{ secrets.GITHUB_TOKEN }}
       working-directory: src/MyProject
 ```

--- a/run-dotnet-tests/action.yaml
+++ b/run-dotnet-tests/action.yaml
@@ -2,12 +2,6 @@ name: Run Dotnet Tests
 description: Test .NET solution or project
 author: devantler-tech
 inputs:
-  app-id:
-    description: GitHub App ID to generate a token
-    required: true
-  app-private-key:
-    description: Private key of the GitHub App to generate a token
-    required: true
   github-token:
     description: GitHub token to access the repository
     required: true


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

`run-dotnet-tests/action.yaml` declares **`app-id`** and **`app-private-key`** as `required: true`, but **neither is referenced anywhere in the action body**. They were orphaned by #175 (`feat!: remove Codecov upload from coverage actions`): that PR removed the token-minting step they fed, switching coverage delivery to **GitHub Code Quality** (native, no app token). The action now authenticates solely via `github-token`, so these two inputs do nothing — yet every caller is still forced to wire up two unused secrets, and the README documents them as required.

## Change

Remove the two dead inputs from `action.yaml` and from `README.md` (Inputs table + both usage examples). Behaviour-preserving: `github-token` and `working-directory` are untouched and all 5 steps are intact.

```
run-dotnet-tests/README.md   | 6 ------
run-dotnet-tests/action.yaml | 6 ------
2 files changed, 12 deletions(-)
```

## Blast radius — runtime-safe, flagged breaking

Per the repo's *blast-radius-first* rule this is a **breaking interface change** (a public required input is removed), hence the `!` / `BREAKING CHANGE:`. In practice it is runtime-safe:
- The only consumer is `reusable-workflows/.github/workflows/run-dotnet-tests.yaml`, which **pins this composite by SHA** (`@b31ec7b…` v5.4.2) → unaffected until it repins.
- On repin, any `app-id:`/`app-private-key:` still passed to a composite that no longer declares them is **ignored** (an *unexpected input* warning, not a failure).

## Follow-up (gated, not in this PR)

Once this releases and `reusable-workflows` repins, drop the two now-ignored `with:` lines **and** the `APP_PRIVATE_KEY` secret from `reusable-workflows/.github/workflows/run-dotnet-tests.yaml`'s `workflow_call` interface (itself breaking for *that* reusable workflow's consumers → its own coordinated change). Tracked under reusable-workflows#308 phase 2 — this passthrough site needs **removal**, not the `app-id`→`client-id` rename the other two composites (`approve-pr`, `create-issues-from-todos`) require, because here the inputs were already dead.

## Validation

- Ruby YAML parse OK; `inputs` = `github-token`, `working-directory`; `runs.steps` = 5 (unchanged); `inputs.github-token` still referenced.
- No residual `app-id`/`app-private-key` references in `run-dotnet-tests/`.
- (actionlint lints workflows, not composite `action.yaml`; CI's action validation is the gate.)

Relates to reusable-workflows#308 · devantler-tech/actions#247
