### PR TITLE
fix: scope GitHub App tokens to least privilege (zizmor github-app)

### DIFF
--- a/approve-pr/action.yaml
+++ b/approve-pr/action.yaml
@@ -27,6 +27,10 @@ runs:
       with:
         app-id: ${{ inputs.app-id }}
         private-key: ${{ inputs.app-private-key }}
+        # Least-privilege: the token only submits a PR review (gh pr review
+        # --approve), so scope it to pull-requests instead of inheriting the
+        # App installation's blanket permissions (zizmor github-app).
+        permission-pull-requests: write
 
     - name: ✅ Approve pull request
       if: inputs.dry-run != 'true'

--- a/create-issues-from-todos/action.yaml
+++ b/create-issues-from-todos/action.yaml
@@ -20,6 +20,12 @@ runs:
       with:
         app-id: ${{ inputs.app-id }}
         private-key: ${{ inputs.app-private-key }}
+        # Least-privilege: this token is consumed only as the todo-to-issue
+        # action's PROJECTS_SECRET (adding issues to an org Project); issue
+        # create/close/assign use the workflow's default GITHUB_TOKEN. Scope it
+        # to organization projects instead of inheriting the App installation's
+        # blanket permissions (zizmor github-app).
+        permission-organization-projects: write
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

`zizmor`'s `github-app` rule flags every `actions/create-github-app-token` step that mints a token **without `permission-*` inputs**, because the token then inherits the GitHub App installation's **blanket permissions** (a least-privilege violation). Two such steps remain in this repo, and they are the **two open code-scanning alerts on `main`** (#296 `approve-pr/action.yaml`, #297 `create-issues-from-todos/action.yaml`):

```
dangerous use of GitHub App tokens: app token inherits blanket installation permissions
```

Because the `code_scanning` branch ruleset blocks on any open alert, these two findings **gate the entire `actions` merge lane** (e.g. #271 sits `BLOCKED` with all required checks green — its only red is this `zizmor` code-scanning result). Clearing both alerts unblocks the lane.

## Fix

Scope each token to exactly the access it uses (mirrors the existing pattern in `create-release.yaml` / `update-agent-skills.yaml` / `template-sync.yaml`):

| Composite | What the token does | Scope added |
|---|---|---|
| `approve-pr` | only `gh pr review "$PR" --approve` | `permission-pull-requests: write` |
| `create-issues-from-todos` | consumed **only** as `todo-to-issue`'s `PROJECTS_SECRET` (adds issues to an org Project); issue create/close/assign use the workflow's **default `GITHUB_TOKEN`**, per the self-test's `permissions: issues: write`) | `permission-organization-projects: write` |

No inputs/outputs change (README parity preserved); these are internal token-scoping additions only.

## Validation

- **`zizmor` (persona `auditor`, repo `zizmor.yml`): 2 → 0** `github-app` findings on the two files.
- Both composite **self-tests exercise the tokens live** and will validate the scoping in CI before promotion:
  - `test-approve-pr` actually approves the PR (`dry-run` defaults to false) → proves `pull-requests: write` is sufficient.
  - `test-create-issues-from-todos` runs against org Project `organization/devantler-tech/5` → proves `organization-projects: write` is sufficient and that the App installation grants it.

`Fixes #274`.

## Note — overlap with #271

#271 (`feat(create-issues-from-todos): support client-id, deprecate app-id`) also edits `create-issues-from-todos/action.yaml`'s `create-github-app-token` step. The two changes are semantically independent (identifier migration vs. permission scoping) and add different lines to the same `with:` block. Whichever lands first, the other needs a trivial rebase to re-apply its line alongside this one. This PR is what unblocks #271's own code-scanning gate.

Opened as a **draft**; once promoted it merges normally (own/human-trusted, bare `--squash`). On merge, alerts #296/#297 auto-resolve as fixed and the actions lane is unblocked.
