### PR TITLE
refactor(approve-pr): accept client-id, deprecate app-id input

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: 🧪 Run approve-pr
         uses: ./approve-pr
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
           pr-number: ${{ github.event.pull_request.number }}
 

--- a/approve-pr/README.md
+++ b/approve-pr/README.md
@@ -6,10 +6,13 @@ Approve a pull request using a GitHub App identity. This is needed because `GITH
 
 | Name | Description | Required | Default |
 |------|-------------|----------|---------|
-| `app-id` | GitHub App ID | ✅ | - |
+| `client-id` | GitHub App Client ID (preferred over the deprecated `app-id`) | ❌¹ | - |
+| `app-id` | GitHub App ID. **Deprecated** — use `client-id` instead | ❌¹ | - |
 | `app-private-key` | GitHub App Private Key | ✅ | - |
 | `pr-number` | Pull request number to approve | ✅ | - |
 | `dry-run` | Validate only; do not approve the pull request | - | `false` |
+
+¹ Provide exactly one of `client-id` or `app-id`. Prefer `client-id`: `actions/create-github-app-token` has deprecated `app-id`, so passing it emits a `Input 'app-id' has been deprecated` warning.
 
 ## Usage
 
@@ -20,7 +23,7 @@ steps:
   - name: Approve PR
     uses: devantler-tech/actions/approve-pr@main
     with:
-      app-id: ${{ vars.APP_ID }}
+      client-id: ${{ vars.APP_CLIENT_ID }}
       app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
       pr-number: ${{ github.event.pull_request.number }}
 ```
@@ -32,7 +35,7 @@ steps:
   - name: Approve PR
     uses: devantler-tech/actions/approve-pr@main
     with:
-      app-id: ${{ vars.APP_ID }}
+      client-id: ${{ vars.APP_CLIENT_ID }}
       app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
       pr-number: ${{ github.event.pull_request.number }}
 

--- a/approve-pr/action.yaml
+++ b/approve-pr/action.yaml
@@ -3,9 +3,12 @@ description: Approve a pull request using a GitHub App identity
 author: devantler-tech
 
 inputs:
+  client-id:
+    description: GitHub App Client ID (preferred over the deprecated app-id)
+    required: false
   app-id:
-    description: GitHub App ID
-    required: true
+    description: 'GitHub App ID. Deprecated: use client-id instead.'
+    required: false
   app-private-key:
     description: GitHub App Private Key
     required: true
@@ -22,9 +25,10 @@ runs:
   steps:
     - name: 🔑 Generate GitHub App Token
       if: inputs.dry-run != 'true'
-      uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: app-token
       with:
+        client-id: ${{ inputs.client-id }}
         app-id: ${{ inputs.app-id }}
         private-key: ${{ inputs.app-private-key }}
         # Least-privilege: the token only submits a PR review (gh pr review


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

`actions/create-github-app-token` has **deprecated the `app-id` input** in favour of `client-id` (its `action.yml`: `app-id … deprecationMessage: "Use 'client-id' instead."`). The `approve-pr` composite still passes `app-id`, so every PR-approval job emits:

```
Input 'app-id' has been deprecated with message: Use 'client-id' instead.
```

Non-failing today, but deprecated inputs are eventually removed upstream — at which point this composite breaks. This is the last unmigrated token-minting composite in the repo: `create-issues-from-todos` already migrated to the same shape, and `run-dotnet-tests`' dead inputs are being dropped in #264.

Part of devantler-tech/reusable-workflows#308 / #247 (epic #247, *reliable*).

## What — additive, backward-compatible (mirrors `create-issues-from-todos`)

`approve-pr/action.yaml`:
- Add an optional **`client-id`** input (`required: false`).
- Demote **`app-id`** to `required: false` with a deprecated description (kept as an alias — existing callers that still pass `app-id` keep working).
- Pass **both** `client-id` and `app-id` to `create-github-app-token` (it prefers `client-id` when set).
- Bump the pinned `create-github-app-token` `v2.2.1 → v3.2.0` (`bcd2ba49…`) — the exact pin already proven green on `create-issues-from-todos` in this repo — to guarantee `client-id` support and remove version drift between the two token-minting composites.

`.github/workflows/ci.yaml` — the `test-approve-pr` self-test now passes `client-id: ${{ vars.APP_CLIENT_ID }}` (the org already exposes `APP_CLIENT_ID`), exercising the new path.

`approve-pr/README.md` — inputs table + usage examples document `client-id` as preferred and `app-id` as deprecated, matching the sibling README (keeps `lint-readme-parity` green).

## Blast radius

Additive only — no consumer is forced to change. Callers passing `app-id` continue to work (alias still accepted); they should switch to `client-id` at leisure to clear the warning. No `workflow_call`/input removal here.

## Validation

- `actionlint .github/workflows/ci.yaml` — no errors in the changed region (the two pre-existing `code-quality` scope warnings are on `main`, unrelated).
- `approve-pr/action.yaml` parses as valid YAML.
- The `test-approve-pr` job in CI exercises the new `client-id` path end-to-end.