### PR TITLE
docs(setup-agent-skills): Update renamed repo reference skills→agent-skills

### DIFF
--- a/setup-agent-skills/README.md
+++ b/setup-agent-skills/README.md
@@ -34,7 +34,7 @@ steps:
       skills: |
         github/awesome-copilot git-commit
         fluxcd/agent-skills gitops-knowledge
-        devantler-tech/skills ways-of-working@v1.2.0
+        devantler-tech/agent-skills ways-of-working@v1.2.0
         # Pin with @<tag|branch|sha> or omit to track the upstream default branch.
 ```
 


### PR DESCRIPTION
## What

The `devantler-tech/skills` repository was renamed to `devantler-tech/agent-skills` (and `devantler-tech/plugins` → `devantler-tech/agent-plugins`). This updates the one stale reference to the old repo name in this repo.

## Changes

- `setup-agent-skills/README.md`: the usage-example install entry `devantler-tech/skills ways-of-working@v1.2.0` → `devantler-tech/agent-skills ways-of-working@v1.2.0`.

## Notes

- A full repo grep for `devantler-tech/skills` and `devantler-tech/plugins` found only this single reference. No `devantler-tech/plugins` references exist anywhere.
- No `action.yaml` default input value, code default, or CI workflow defaults to the old repo as a clone/install source — nothing functional needed updating.
- The generic word "skills"/"plugins" and the (already-correct) action names `setup-agent-skills` / `update-agent-skills` were deliberately left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)