### PR TITLE
ci: add shared retry.sh and bound setup-ksail-cli network pulls

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -602,6 +602,70 @@ jobs:
         shell: bash
         run: ksail --version
 
+  # ── .scripts/retry.sh (shared reliability helper) ──────────
+  test-retry-script:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: 📑 Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: 🧪 Exercise retry.sh (success, retry-then-succeed, exhaust, no-arg)
+        shell: bash
+        env:
+          RETRY_BASE_DELAY: "0" # keep the test fast — no real backoff sleeps
+        run: |
+          set -uo pipefail
+          retry="$GITHUB_WORKSPACE/.scripts/retry.sh"
+
+          # 1. Succeeds on the first try → exit 0, no retries.
+          RETRY_MAX_ATTEMPTS=3 bash "$retry" true
+          echo "✅ success-first-try: exit 0 as expected"
+
+          # 2. Flaky command (fails twice, succeeds on the 3rd attempt) → exit 0.
+          counter="$(mktemp)"
+          printf '0' > "$counter"
+          flaky="$(mktemp)"
+          cat > "$flaky" <<EOF
+          #!/usr/bin/env bash
+          n=\$(cat "$counter")
+          n=\$((n + 1))
+          printf '%s' "\$n" > "$counter"
+          [ "\$n" -ge 3 ]
+          EOF
+          chmod +x "$flaky"
+          RETRY_MAX_ATTEMPTS=3 bash "$retry" "$flaky"
+          attempts="$(cat "$counter")"
+          if [ "$attempts" -ne 3 ]; then
+            echo "::error::expected 3 attempts before success, got $attempts"; exit 1
+          fi
+          echo "✅ retry-then-succeed: succeeded on attempt 3 as expected"
+
+          # 3. Always fails → exits non-zero with the command's status after N attempts.
+          set +e
+          RETRY_MAX_ATTEMPTS=2 bash "$retry" false
+          status=$?
+          set -e
+          if [ "$status" -eq 0 ]; then
+            echo "::error::expected non-zero exit after exhausting attempts, got 0"; exit 1
+          fi
+          echo "✅ exhaust-and-fail: non-zero exit ($status) as expected"
+
+          # 4. No command given → usage error (exit 2).
+          set +e
+          bash "$retry"
+          status=$?
+          set -e
+          if [ "$status" -ne 2 ]; then
+            echo "::error::expected exit 2 for missing command, got $status"; exit 1
+          fi
+          echo "✅ no-arg: exit 2 as expected"
+
+          rm -f "$counter" "$flaky"
+
   # ── sync-github-labels ─────────────────────────────────────
   test-sync-github-labels:
     runs-on: ubuntu-latest
@@ -1090,6 +1154,7 @@ jobs:
       - test-setup-go-toolchain
       - test-setup-go-toolchain-private-modules
       - test-setup-ksail-cli
+      - test-retry-script
       - test-sync-github-labels
       - test-update-agent-skills-noop
       - test-update-agent-skills-dry-run
@@ -1135,6 +1200,7 @@ jobs:
             ${{ needs.test-setup-go-toolchain.result }}
             ${{ needs.test-setup-go-toolchain-private-modules.result }}
             ${{ needs.test-setup-ksail-cli.result }}
+            ${{ needs.test-retry-script.result }}
             ${{ needs.test-sync-github-labels.result }}
             ${{ needs.test-update-agent-skills-noop.result }}
             ${{ needs.test-update-agent-skills-dry-run.result }}

--- a/.scripts/retry.sh
+++ b/.scripts/retry.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Bounded retry with exponential backoff for transient-failure-prone commands.
+#
+# Wraps a command so a composite action's *network pull* — a Homebrew tap/install,
+# a registry login, a tool/toolchain download — tolerates transient registry or
+# network flakes (GHCR 5xx, DNS/TLS blips) instead of redding a *required* CI check
+# on infra noise rather than a real failure. See the reliability pillar of the
+# actions roadmap (devantler-tech/actions#247).
+#
+# Shared across composite actions and resolved relative to ${GITHUB_ACTION_PATH}
+# (like .scripts/ensure-gh-skill.sh) so the retry logic lives in one place —
+# composite actions cannot share steps, but they can share a bundled script that
+# works for both local `uses: ./<action>` callers and external
+# `uses: devantler-tech/actions/<action>@<ref>` consumers.
+#
+# Usage:
+#   bash "${GITHUB_ACTION_PATH}/../.scripts/retry.sh" <command> [args...]
+#
+# Tunable via environment (sensible CI defaults):
+#   RETRY_MAX_ATTEMPTS   total attempts before giving up         (default 3)
+#   RETRY_BASE_DELAY     seconds to wait before the first retry  (default 5)
+#   RETRY_MAX_DELAY      cap on the backoff delay in seconds     (default 60)
+#
+# Exit status: 0 on the first success; otherwise the failing command's last exit
+# status after RETRY_MAX_ATTEMPTS attempts, so a genuine failure still reds the
+# check. (No `set -e`: command failure is handled explicitly, not fatally.)
+set -uo pipefail
+
+max_attempts="${RETRY_MAX_ATTEMPTS:-3}"
+base_delay="${RETRY_BASE_DELAY:-5}"
+max_delay="${RETRY_MAX_DELAY:-60}"
+
+if [ "$#" -eq 0 ]; then
+  echo "::error::retry.sh: no command given" >&2
+  exit 2
+fi
+
+attempt=1
+delay="$base_delay"
+while true; do
+  "$@" && exit 0
+  status=$?
+  if [ "$attempt" -ge "$max_attempts" ]; then
+    echo "::error::'$*' failed after ${max_attempts} attempt(s) (last exit ${status})" >&2
+    exit "$status"
+  fi
+  echo "::warning::'$*' failed (exit ${status}); attempt ${attempt}/${max_attempts}, retrying in ${delay}s" >&2
+  sleep "$delay"
+  attempt=$((attempt + 1))
+  delay=$((delay * 2))
+  if [ "$delay" -gt "$max_delay" ]; then
+    delay="$max_delay"
+  fi
+done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,27 @@ Every action must have a corresponding test workflow at `.github/workflows/test-
     commit isn't mistaken for a floating `@main` ref. The lone such dep today is
     `Homebrew/actions/setup-homebrew` in `setup-ksail-cli`.
 
+## Reliability
+
+A composite step that performs a **network pull** — a Homebrew tap/install, a
+registry login, a tool/toolchain download — can fail a *required* CI check on a
+transient registry/network flake (a GHCR 5xx, a DNS/TLS blip) rather than on a
+real defect, blocking unrelated PRs across every consumer repo. Wrap such pulls
+in the shared bounded-retry helper so infra noise can't masquerade as a failure:
+
+```bash
+retry() { bash "${GITHUB_ACTION_PATH}/../.scripts/retry.sh" "$@"; }
+retry brew install <formula>
+```
+
+`.scripts/retry.sh` retries with exponential backoff (tunable via
+`RETRY_MAX_ATTEMPTS`, `RETRY_BASE_DELAY`, `RETRY_MAX_DELAY`) and exits non-zero
+with the command's last status once attempts are exhausted, so a genuine failure
+still reds the check. Only wrap the **network** commands — leave local operations
+unwrapped. `setup-ksail-cli` uses it for `brew tap` / `brew install`; extend it
+to the other network-pull composites as part of the reliability pillar
+([#247](https://github.com/devantler-tech/actions/issues/247)).
+
 ## Commits
 
 Use [semantic commits](https://www.conventionalcommits.org/):

--- a/setup-ksail-cli/action.yaml
+++ b/setup-ksail-cli/action.yaml
@@ -14,10 +14,19 @@ runs:
     - name: ⤵️ Install KSail
       shell: bash
       run: |
-        brew tap devantler-tech/formulas
+        set -euo pipefail
+        # A required CI check must never red on transient registry/network noise
+        # (GHCR 5xx, DNS/TLS blips) when fetching the tap or downloading the cask +
+        # bottle. Bound each network pull with retry + backoff via the shared
+        # .scripts/retry.sh helper — see the reliability pillar of the actions
+        # roadmap (devantler-tech/actions#247).
+        retry() { bash "${GITHUB_ACTION_PATH}/../.scripts/retry.sh" "$@"; }
+
+        retry brew tap devantler-tech/formulas
         # KSail ships as a Cask. Homebrew refuses to load Casks from a non-official
         # tap when HOMEBREW_REQUIRE_TAP_TRUST is set (now enforced on the CI runners),
         # failing with "Refusing to load cask … from untrusted tap". Explicitly trust
         # our own first-party tap so `brew install` can load it non-interactively.
+        # (Local operation — no network — so it is not wrapped in retry.)
         brew trust --tap devantler-tech/formulas
-        brew install ksail
+        retry brew install ksail


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What & why

**Part of #247** — the *reliability* pillar of the composite-action library roadmap:

> a composite that does a **network pull** … should tolerate transient registry/network flakes (bounded retry + backoff) so it never reds a *required* check on infra noise rather than a real failure.

A composite step that fetches over the network (a Homebrew tap/install, a registry login, a tool download) can fail a **required** check on a transient GHCR 5xx or DNS/TLS blip — blocking unrelated PRs across *every* consumer repo with no code defect. This PR ships the shared primitive for that pillar and applies it to the first instance.

## Changes

- **`.scripts/retry.sh` (new)** — a shared bounded-retry-with-exponential-backoff helper, following the existing shared-script convention (`.scripts/ensure-gh-skill.sh`): resolved relative to `${GITHUB_ACTION_PATH}` so it works for both local `uses: ./<action>` and external `uses: devantler-tech/actions/<action>@<ref>` callers. Tunable via `RETRY_MAX_ATTEMPTS` / `RETRY_BASE_DELAY` / `RETRY_MAX_DELAY`. Exits non-zero with the command's last status once attempts are exhausted, so a **genuine** failure still reds the check.
- **`setup-ksail-cli/action.yaml`** — wrap the two network pulls (`brew tap`, `brew install`) in `retry`; the local `brew trust` is left unwrapped. No input/output change — fully additive and backward-compatible.
- **`CONTRIBUTING.md`** — document the reliability convention (when and how to wrap network pulls), so future composites adopt it consistently.
- **`.github/workflows/ci.yaml`** — new deterministic `test-retry-script` job exercising all four paths (success-first-try, retry-then-succeed, exhaust-and-fail, no-arg→exit 2), wired into the `CI - Required Checks` aggregate. This is the only way to actually exercise the retry/backoff logic, since `brew` can't be made to fail transiently on demand.

## Validation (local, isolated `/tmp` clone off `origin/main`)

- `shellcheck .scripts/retry.sh` → clean; same for the `setup-ksail-cli` run block.
- Ran all four test scenarios locally (mirroring the CI job): success-first-try → exit 0; flaky-fails-twice → succeeds on attempt 3; always-fails → non-zero after N attempts; no-arg → exit 2. All pass.
- `actionlint .github/workflows/ci.yaml` → only the two **pre-existing** `code-quality` permission-scope warnings (run-dotnet-tests jobs, on `main`; older-local-actionlint false-positive), none from this diff.
- `zizmor .github/workflows/ci.yaml` (repo `zizmor.yml`) → **No findings to report** (50 suppressed by repo policy — unchanged by this diff).

## Follow-ups (same pillar, not in this PR)

The other network-pull composites can adopt `.scripts/retry.sh` incrementally: `login-to-ghcr` (registry login), `cleanup-ghcr-packages` (GHCR API), `setup-go-toolchain` / `setup-agent-skills` (tool/toolchain downloads). Each is independently shippable; tracked under #247.
