### PR TITLE
ci: bound gh-skill network pulls with shared retry helper

### DIFF
--- a/.scripts/ensure-gh-skill.sh
+++ b/.scripts/ensure-gh-skill.sh
@@ -19,6 +19,12 @@ set -euo pipefail
 : "${REQUIRED:?REQUIRED (minimum gh version) must be set}"
 : "${INSTALL_NAMESPACE:?INSTALL_NAMESPACE must be set}"
 
+# Bounded retry for the network download below — a transient github.com release
+# 5xx or DNS/TLS blip must not red a required check (reliability pillar, #247).
+# Resolved relative to this script's own dir (alongside retry.sh), so it works for
+# both local `uses: ./<action>` and external `uses: …@<ref>` callers.
+retry() { bash "$(dirname "${BASH_SOURCE[0]}")/retry.sh" "$@"; }
+
 if command -v gh >/dev/null 2>&1 && gh skill --help >/dev/null 2>&1; then
   current=$(gh --version | awk '/^gh version /{print $3; exit}')
   if [ -z "$current" ]; then
@@ -46,15 +52,18 @@ tmp=$(mktemp -d)
 asset="gh_${REQUIRED}_${os}_${arch}.${ext}"
 url="https://github.com/cli/cli/releases/download/v${REQUIRED}/${asset}"
 echo "Downloading $url"
+if [ "$ext" = "zip" ] && ! command -v unzip >/dev/null 2>&1; then
+  echo "::error::unzip is required to extract the macOS gh release archive but is not available on PATH."
+  exit 1
+fi
+# Download (network — retried) to a file, then extract (local — not retried). The
+# Linux path downloads to a file rather than streaming `curl | tar` so the network
+# pull is a single retryable command.
+retry curl -fsSL -o "$tmp/$asset" "$url"
 if [ "$ext" = "zip" ]; then
-  if ! command -v unzip >/dev/null 2>&1; then
-    echo "::error::unzip is required to extract the macOS gh release archive but is not available on PATH."
-    exit 1
-  fi
-  curl -fsSL -o "$tmp/$asset" "$url"
   unzip -q "$tmp/$asset" -d "$tmp"
 else
-  curl -fsSL "$url" | tar -xzC "$tmp"
+  tar -xzC "$tmp" -f "$tmp/$asset"
 fi
 install_dir="${RUNNER_TEMP:-/tmp}/${INSTALL_NAMESPACE}/bin"
 mkdir -p "$install_dir"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,8 +98,11 @@ retry brew install <formula>
 `RETRY_MAX_ATTEMPTS`, `RETRY_BASE_DELAY`, `RETRY_MAX_DELAY`) and exits non-zero
 with the command's last status once attempts are exhausted, so a genuine failure
 still reds the check. Only wrap the **network** commands — leave local operations
-unwrapped. `setup-ksail-cli` uses it for `brew tap` / `brew install`; extend it
-to the other network-pull composites as part of the reliability pillar
+unwrapped. It is used by `setup-ksail-cli` (`brew tap` / `brew install`), by the
+shared `.scripts/ensure-gh-skill.sh` (the `gh` release download), and by
+`setup-agent-skills` / `update-agent-skills` (`gh skill install` / `gh skill
+update` registry pulls) — covering every shell-based network pull in the suite as
+part of the reliability pillar
 ([#247](https://github.com/devantler-tech/actions/issues/247)).
 
 ## Commits

--- a/setup-agent-skills/action.yaml
+++ b/setup-agent-skills/action.yaml
@@ -57,6 +57,12 @@ runs:
       run: |
         set -euo pipefail
 
+        # Bounded retry for the registry pulls below — `gh skill install` fetches
+        # each skill over the network, so a transient flake must not red a required
+        # check (reliability pillar, #247). Same shared helper + path resolution as
+        # the gh bootstrap above.
+        retry() { bash "${GITHUB_ACTION_PATH}/../.scripts/retry.sh" "$@"; }
+
         if [ -z "${INPUT_SKILLS//[[:space:]]/}" ]; then
           echo "::error::'skills' input is empty. Provide a newline-separated list of '<owner/repo> <skill>[@pin]' entries."
           exit 1
@@ -100,10 +106,10 @@ runs:
           for agent in "${agents[@]}"; do
             if [ -n "$pin" ]; then
               echo "Installing ${src}/${name}@${pin} (agent=${agent}, scope=${INPUT_SCOPE})..."
-              gh skill install "$src" "$name" --agent "$agent" --scope "$INPUT_SCOPE" --pin "$pin"
+              retry gh skill install "$src" "$name" --agent "$agent" --scope "$INPUT_SCOPE" --pin "$pin"
             else
               echo "Installing ${src}/${name} (agent=${agent}, scope=${INPUT_SCOPE})..."
-              gh skill install "$src" "$name" --agent "$agent" --scope "$INPUT_SCOPE"
+              retry gh skill install "$src" "$name" --agent "$agent" --scope "$INPUT_SCOPE"
             fi
           done
           # Record each skill once, regardless of how many agents it was installed for.

--- a/update-agent-skills/action.yaml
+++ b/update-agent-skills/action.yaml
@@ -54,6 +54,12 @@ runs:
       run: |
         set -euo pipefail
 
+        # Bounded retry for the registry pulls below — `gh skill update` checks each
+        # skill's source over the network, so a transient flake must not red a
+        # required check (reliability pillar, #247). Same shared helper + path
+        # resolution as the gh bootstrap above.
+        retry() { bash "${GITHUB_ACTION_PATH}/../.scripts/retry.sh" "$@"; }
+
         if [ ! -d "$INPUT_DIR" ]; then
           echo "::error::Directory not found: $INPUT_DIR"
           exit 1
@@ -111,7 +117,7 @@ runs:
             true|1|yes) root_flags+=(--unpin) ;;
           esac
           echo "::group::Updating skills in $root"
-          if ! gh skill update "${root_flags[@]}" 2>&1 | tee -a "$out"; then
+          if ! retry gh skill update "${root_flags[@]}" 2>&1 | tee -a "$out"; then
             echo "::error::'gh skill update ${root_flags[*]}' failed."
             status=1
           fi


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What & why

Completes the **reliability pillar** of the composite-action roadmap
([#247](https://github.com/devantler-tech/actions/issues/247), item 3). #302
established the shared `.scripts/retry.sh` helper and wired it into
`setup-ksail-cli`; `CONTRIBUTING.md` already says to *"extend it to the other
network-pull composites."* This PR does that for **every remaining shell-based
network pull** in the suite, so a transient registry/network flake (GHCR 5xx,
DNS/TLS blip, github.com release hiccup) can no longer red a **required** check
across consumer repos on infra noise rather than a real defect.

## Changes (additive, backward-compatible)

| File | Network pull now retried |
|---|---|
| `.scripts/ensure-gh-skill.sh` | the `cli/cli` release download (shared by `setup-agent-skills` + `update-agent-skills`) |
| `setup-agent-skills/action.yaml` | `gh skill install` (per-skill registry pull) |
| `update-agent-skills/action.yaml` | `gh skill update` (per-root registry pull) |
| `CONTRIBUTING.md` | documents the helper now covers these |

In `ensure-gh-skill.sh` the Linux path is restructured from a streaming
`curl … | tar` pipe to **download-to-file then extract**, so the network pull is
a single retryable command (the macOS zip path already downloaded to a file). The
`unzip`-availability guard moves up; extraction stays local (unwrapped). No
behaviour change on the happy path — `retry` runs the command once and exits 0 on
success.

## Scope notes
- Only **network** commands are wrapped; local operations (extraction, parsing,
  hashing) stay unwrapped, per the CONTRIBUTING reliability convention.
- Composites that pull via a third-party `uses:` action (`login-to-ghcr`,
  `setup-go-toolchain`, `dependency-review`, …) are intentionally **not** touched
  — those delegate networking to the upstream action and `retry.sh` only wraps
  shell `run:` commands.
- `update-agent-skills`: on a genuine transient retry the helper's `::warning::`
  line may appear in the `updated-skills` output; the `changed` output is computed
  from SKILL.md hashes (not stdout), so correctness is unaffected.

## Validation
- `shellcheck` clean on `ensure-gh-skill.sh` and both composites' embedded `run:`
  scripts; `bash -n` syntax-OK; `yamllint` clean; `yq` parses both actions.
- Functional test of `retry.sh`: succeeds first try (exit 0); preserves a genuine
  failure's exit code after exhausting attempts (still reds the check); recovers a
  flaky command on the 2nd attempt.
- Existing CI test jobs (`test-setup-agent-skills-*`, `test-update-agent-skills-*`)
  exercise both composites end-to-end; the wrapper is transparent on success so
  they stay green.

Draft pending your promotion to "ready for review".