### PR TITLE
ci: grant release-please the workflows scope for self-pin rewrites

### DIFF
--- a/.github/workflows/active-release.yaml
+++ b/.github/workflows/active-release.yaml
@@ -32,9 +32,12 @@ jobs:
           # Least-privilege (zizmor github-app): release-please needs contents
           # (release + tag), pull-requests (the release PR), and issues (label
           # management); the auto-merge step reuses this token (contents + PRs).
+          # workflows: the extra-files self-pin rewrites touch .github/workflows/*,
+          # which GitHub refuses to write without the workflows scope.
           permission-contents: write
           permission-pull-requests: write
           permission-issues: write
+          permission-workflows: write
 
       # Maintains the release PR — version bump, CHANGELOG, and (via extra-files) rewrites the
       # self-referenced action/workflow tag pins to the version being released — then cuts the


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem — releases were wedged on `main`

The `🎉 Release` workflow failed on every push since #314 (`feat!: merge reusable-workflows into the actions repo`) with the opaque `release-please failed: Error adding to tree`. No GitHub release/tag could be cut.

## Root cause

`release-please` rewrites the `# x-release-please-version` self-pins listed in `extra-files`. Five of those targets live under `.github/workflows/`. The `🎉 Release` workflow mints a **botantler-1 App token** that requested only `contents` / `pull-requests` / `issues` — **not `workflows`** — so writing any file under `.github/workflows/` returned `403 Resource not accessible by integration`, which release-please surfaces as the opaque "Error adding to tree" ([release-please-action#938](https://github.com/googleapis/release-please-action/issues/938)). `feat!` (#314) was simply the first **releasable** commit to actually exercise the workflow-file rewrite.

## Fix

The **botantler-1 App holds the Workflows repository permission (read+write)**, so request it on the token:

```diff
           permission-contents: write
           permission-pull-requests: write
           permission-issues: write
+          permission-workflows: write
```

This **preserves the documented convention** that release-please owns the first-party self-pins (no change to `release-please-config.json`), rather than dropping the workflow files from `extra-files`.

## Validation

- `actionlint` clean on `active-release.yaml`; net diff is the single `permission-workflows: write` line (+ explanatory comment).
- The PR's own `[Test] Create Release - Dry Run / Release` check exercises release-please against this config.

Net diff: **+3 lines in `.github/workflows/active-release.yaml`**, nothing else.
