### PR TITLE
docs: correct premature "reusable-workflows is archived" claim

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # devantler-tech/actions
 
-Composite GitHub Actions **and** reusable `workflow_call` workflows — the shared CI/CD building blocks used across all DevantlerTech projects. (The reusable workflows were merged in from the former `devantler-tech/reusable-workflows` repo, which is now archived.)
+Composite GitHub Actions **and** reusable `workflow_call` workflows — the shared CI/CD building blocks used across all DevantlerTech projects. (The reusable workflows were merged in from `devantler-tech/reusable-workflows`; that repo is being retired and will be archived once all consumers migrate their `uses:` pins here, so do new shared-CI work in this repo — not in `reusable-workflows`.)
 
 This file is the single canonical instructions file for the repository. It is read natively by GitHub Copilot, and by Cursor, Codex, and Claude (via `CLAUDE.md` → `@AGENTS.md`).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DevantlerTech GitHub Actions & Reusable Workflows 🚀
 
-The shared CI/CD building blocks used across all DevantlerTech projects — both **composite actions** and **reusable `workflow_call` workflows** — in one repository. (The reusable workflows were merged in from the former `devantler-tech/reusable-workflows` repo, which is now archived.)
+The shared CI/CD building blocks used across all DevantlerTech projects — both **composite actions** and **reusable `workflow_call` workflows** — in one repository. (The reusable workflows were merged in from `devantler-tech/reusable-workflows`; that repo is being retired and will be archived once all consumers migrate their `uses:` pins here.)
 
 The diagram below shows how GitHub Workflows, Jobs, Steps, Reusable Workflows, and Actions relate.
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

Both `AGENTS.md` and `README.md` (line 3 of each) state the reusable workflows were merged in *"from the former `devantler-tech/reusable-workflows` repo, **which is now archived**."*

That claim is **factually wrong** — verified live this run:

- `devantler-tech/reusable-workflows` has `isArchived: false` and still hosts **all 18 workflows**.
- **~13 consumer repos still pin** `devantler-tech/reusable-workflows/.github/workflows/...@` — `ksail`, `platform`, `wedding-app`, `ascoachingogvaner`, `dotnet-template`, `gitops-tenant-template`, `go-template`, `platform-template`, `.github`, `agent-plugins`, `agent-skills`, … The repo will be archived only **after** those consumers migrate their pins here.

A wrong canonical instructions file silently misleads every future agent and human reader — e.g. concluding the source repo is gone (risking broken consumers, or skipping the still-pending pin-migration work). `AGENTS.md` is also what GitHub Copilot code review reads directly, so the inaccuracy propagates into reviews.

## Fix

Reword the parenthetical in both files to describe the **actual in-progress state**: the workflows were merged in from `devantler-tech/reusable-workflows`; that repo is **being retired and will be archived once all consumers migrate their `uses:` pins here**. `AGENTS.md` additionally keeps the agent directive to do new shared-CI work in this repo, not in `reusable-workflows`.

Docs-only, behaviour-preserving — no workflow/action change. `docs:` so it does not on its own cut a release (rides the next `feat:`/`fix:`), per this repo's release-please convention.

## Validation

- Diff is a single prose sentence per file (line 3); no tables, code, or pins touched.
- Live-verified the archive status and consumer-pin set via `gh repo view` + `gh search code` before authoring.