### PR TITLE
ci: skip CI suite and dependency-review on release-please PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Every job below is guarded so the whole CI suite is skipped on release-please
+  # PRs (head branch `release-please--*`): those PRs only bump versions + the
+  # changelog — already tested in the PRs that introduced each change — and the
+  # x-release-please-version self-pins they rewrite point at a tag that does not
+  # exist until the release merges, so the suite cannot pass there anyway. The
+  # `CI - Required Checks` gate still runs (aggregate-job-checks treats skipped as
+  # success), keeping the required status check green so the release auto-merges.
   # ── approve-pr ──────────────────────────────────────────────
   test-approve-pr:
     runs-on: ubuntu-latest
@@ -20,6 +27,7 @@ jobs:
       pull-requests: write
       contents: write
     if: >-
+      !startsWith(github.head_ref, 'release-please--') &&
       startsWith(github.event_name, 'pull_request') &&
       (
         github.event.pull_request.user.login == 'dependabot[bot]' ||
@@ -42,6 +50,7 @@ jobs:
 
   # ── cleanup-ghcr-packages ───────────────────────────────────
   test-cleanup-ghcr-packages:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     permissions:
       packages: read
@@ -61,6 +70,7 @@ jobs:
 
   # ── create-issues-from-todos ────────────────────────────────
   test-create-issues-from-todos:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -84,7 +94,7 @@ jobs:
     # The underlying action only produces a diff on pull_request events; on push /
     # merge_group there is no PR to review, so the test is PR-gated (skipped
     # otherwise, which aggregate-job-checks tolerates — like test-approve-pr).
-    if: startsWith(github.event_name, 'pull_request')
+    if: ${{ !startsWith(github.head_ref, 'release-please--') && startsWith(github.event_name, 'pull_request') }}
     permissions:
       contents: read
     steps:
@@ -119,6 +129,7 @@ jobs:
       pull-requests: write
       contents: write
     if: >-
+      !startsWith(github.head_ref, 'release-please--') &&
       startsWith(github.event_name, 'pull_request') &&
       (
         github.event.pull_request.user.login == 'dependabot[bot]' ||
@@ -140,6 +151,7 @@ jobs:
 
   # ── free-disk-space ─────────────────────────────────────────
   test-free-disk-space:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -174,6 +186,7 @@ jobs:
 
   # ── free-disk-space (all categories disabled → clean no-op) ──
   test-free-disk-space-keep:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -219,6 +232,7 @@ jobs:
 
   # ── login-to-ghcr ──────────────────────────────────────────
   test-login-to-ghcr:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     permissions:
       packages: read
@@ -238,6 +252,7 @@ jobs:
 
   # ── aggregate-job-checks ────────────────────────────────────
   test-aggregate-job-checks-empty:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -253,6 +268,7 @@ jobs:
           job-results: ""
 
   test-aggregate-job-checks-success:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -268,6 +284,7 @@ jobs:
           job-results: "success skipped success"
 
   test-aggregate-job-checks-failure:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -295,6 +312,7 @@ jobs:
           fi
 
   test-aggregate-job-checks-unknown:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -323,6 +341,7 @@ jobs:
 
   # ── run-dotnet-tests ────────────────────────────────────────
   test-run-dotnet-tests:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -345,6 +364,7 @@ jobs:
 
   # ── setup-agent-skills ────────────────────────────────────
   test-setup-agent-skills-inline:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -392,6 +412,7 @@ jobs:
           done
 
   test-setup-agent-skills-pinned:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -431,6 +452,7 @@ jobs:
           fi
 
   test-setup-agent-skills-missing-input:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -458,6 +480,7 @@ jobs:
           fi
 
   test-setup-agent-skills-malformed-line:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -486,6 +509,7 @@ jobs:
           fi
 
   test-setup-agent-skills-multi-agent:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -527,6 +551,7 @@ jobs:
 
   # ── setup-go-toolchain ─────────────────────────────────────
   test-setup-go-toolchain:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -561,6 +586,7 @@ jobs:
           echo "Go version: $GO_VERSION"
 
   test-setup-go-toolchain-private-modules:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -587,6 +613,7 @@ jobs:
 
   # ── setup-ksail-cli ────────────────────────────────────────
   test-setup-ksail-cli:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -608,6 +635,7 @@ jobs:
 
   # ── .scripts/retry.sh (shared reliability helper) ──────────
   test-retry-script:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -672,6 +700,7 @@ jobs:
 
   # ── .scripts/ensure-gh-skill.sh (shared gh-skill bootstrap) ─
   test-ensure-gh-skill-script:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -795,6 +824,7 @@ jobs:
 
   # ── sync-github-labels ─────────────────────────────────────
   test-sync-github-labels:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -812,6 +842,7 @@ jobs:
 
   # ── update-agent-skills ───────────────────────────────────
   test-update-agent-skills-noop:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -856,6 +887,7 @@ jobs:
           fi
 
   test-update-agent-skills-dry-run:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -897,6 +929,7 @@ jobs:
           fi
 
   test-update-agent-skills-missing-dir:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -925,6 +958,7 @@ jobs:
 
   # ── upload-coverage ─────────────────────────────────────────
   test-upload-coverage:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -948,6 +982,7 @@ jobs:
 
   # ── upsert-issue ────────────────────────────────────────────
   test-upsert-issue-create:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -980,6 +1015,7 @@ jobs:
           echo "Issue: $ISSUE_URL"
 
   test-upsert-issue-close:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     needs: [test-upsert-issue-create]
     runs-on: ubuntu-latest
     permissions:
@@ -1002,6 +1038,7 @@ jobs:
 
   # ── sync-github-labels (negative path) ─────────────────────
   test-sync-github-labels-missing-config:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -1031,6 +1068,7 @@ jobs:
 
   # ── login-to-ghcr (negative path) ──────────────────────────
   test-login-to-ghcr-empty-token:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1059,6 +1097,7 @@ jobs:
 
   # ── setup-go-toolchain (negative path) ─────────────────────
   test-setup-go-toolchain-invalid-version:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1087,6 +1126,7 @@ jobs:
 
   # ── upsert-issue (negative path) ───────────────────────────
   test-upsert-issue-missing-body:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1115,6 +1155,7 @@ jobs:
 
   # ── run-dotnet-tests (negative path) ───────────────────────
   test-run-dotnet-tests-missing-working-directory:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1152,7 +1193,7 @@ jobs:
     # Scanning on push to main is essential: without it the default-branch
     # code-scanning baseline never refreshes, leaving stale alerts that the
     # `code_scanning` branch rule treats as a merge blocker on every PR.
-    if: github.event_name != 'merge_group'
+    if: ${{ github.event_name != 'merge_group' && !startsWith(github.head_ref, 'release-please--') }}
     permissions:
       security-events: write
       contents: read
@@ -1168,6 +1209,7 @@ jobs:
 
   # ── lint-readme-parity ──────────────────────────────────────
   lint-readme-parity:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1256,6 +1298,7 @@ jobs:
           exit "$status"
 
   lint-ci-coverage-parity:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1323,6 +1366,7 @@ jobs:
           exit "$status"
 
   test-zizmor:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: "[Test] Zizmor - Default Settings"
     uses: ./.github/workflows/scan-for-workflow-vulnerabilities.yaml
     permissions:
@@ -1331,12 +1375,14 @@ jobs:
       actions: read
 
   test-dependency-review-workflow:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: "[Test] Dependency Review - Default Settings"
     uses: ./.github/workflows/dependency-review.yaml
     permissions:
       contents: read
 
   test-delete-workflow-runs-all:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: "[Test] Delete Workflow Runs - All Workflows"
     uses: ./.github/workflows/delete-workflow-runs.yaml
     with:
@@ -1350,6 +1396,7 @@ jobs:
       contents: read
 
   test-delete-workflow-runs-specific:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: "[Test] Delete Workflow Runs - Specific Pattern"
     uses: ./.github/workflows/delete-workflow-runs.yaml
     with:
@@ -1363,6 +1410,7 @@ jobs:
       contents: read
 
   test-delete-workflow-runs-minimal:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: "[Test] Delete Workflow Runs - Minimal Parameters"
     uses: ./.github/workflows/delete-workflow-runs.yaml
     with:
@@ -1372,6 +1420,7 @@ jobs:
       contents: read
 
   test-validate-go-project:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: "[Test] Validate Go Project"
     uses: ./.github/workflows/validate-go-project.yaml
     # Fixture-targeted: validate the known-good Go fixture (this repo is not itself a Go module).
@@ -1384,6 +1433,7 @@ jobs:
       code-quality: write # callers must grant this for the coverage upload (GitHub Code Quality)
 
   test-run-dotnet-tests-workflow:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: "[Test] Run .NET Tests"
     uses: ./.github/workflows/run-dotnet-tests.yaml
     # Fixture-targeted: exercise the workflow against the known-good .NET fixture
@@ -1396,6 +1446,7 @@ jobs:
       code-quality: write # callers must grant this for the coverage upload (GitHub Code Quality)
 
   test-enable-auto-merge:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: "[Test] Enable Auto-Merge"
     uses: ./.github/workflows/enable-auto-merge.yaml
     permissions:
@@ -1405,6 +1456,7 @@ jobs:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 
   test-create-release:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: "[Test] Create Release - Dry Run"
     uses: ./.github/workflows/create-release.yaml
     with:
@@ -1413,6 +1465,7 @@ jobs:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 
   test-deploy-github-pages:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: "[Test] Deploy GitHub Pages - Dry Run"
     uses: ./.github/workflows/deploy-github-pages.yaml
     permissions:
@@ -1423,6 +1476,7 @@ jobs:
       dry-run: true
 
   test-publish-dotnet-library:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: "[Test] Publish .NET Library - Dry Run"
     uses: ./.github/workflows/publish-dotnet-library.yaml
     permissions:
@@ -1432,6 +1486,7 @@ jobs:
       dry-run: true
 
   test-publish-app:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: "[Test] Publish App - Dry Run"
     uses: ./.github/workflows/publish-app.yaml
     permissions:
@@ -1443,6 +1498,7 @@ jobs:
       dry-run: true
 
   test-publish-manifests:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: "[Test] Publish Manifests - Dry Run"
     uses: ./.github/workflows/publish-manifests.yaml
     permissions:
@@ -1453,6 +1509,7 @@ jobs:
       dry-run: true
 
   test-scan-for-todo-comments:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: "[Test] Scan for TODO Comments - Dry Run"
     uses: ./.github/workflows/scan-for-todo-comments.yaml
     permissions:
@@ -1464,6 +1521,7 @@ jobs:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 
   test-sync-cluster-policies:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: "[Test] Sync Cluster Policies - Dry Run"
     uses: ./.github/workflows/sync-cluster-policies.yaml
     with:
@@ -1473,6 +1531,7 @@ jobs:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 
   test-update-agent-skills:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: "[Test] Update Agent Skills - Dry Run"
     uses: ./.github/workflows/update-agent-skills.yaml
     permissions:
@@ -1482,6 +1541,7 @@ jobs:
       dry-run: true
 
   test-template-sync:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: "[Test] Template Sync - Dry Run"
     uses: ./.github/workflows/template-sync.yaml
     permissions:
@@ -1503,6 +1563,7 @@ jobs:
   # The govulncheck job in validate-go-project.yaml is skipped on this repo, so it
   # cannot self-test itself — hence a dedicated, faithful replica here.
   test-govulncheck-allowlist-honored:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: "[Test] Govulncheck Allowlist - Allowlisted Advisory Passes"
     runs-on: ubuntu-latest
     permissions:
@@ -1532,6 +1593,7 @@ jobs:
           allow-file: .github/tests/govulncheck-allowlist/.govulncheck-allow.txt
 
   test-govulncheck-strict-blocks:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: "[Test] Govulncheck Allowlist - Strict Path Blocks"
     runs-on: ubuntu-latest
     permissions:
@@ -1584,6 +1646,7 @@ jobs:
           echo "Strict scan correctly blocked on the reachable advisory ✅"
 
   test-govulncheck-action-lockstep:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: "[Test] Govulncheck Allowlist - Gate Pins Self-Tested Action"
     runs-on: ubuntu-latest
     permissions:
@@ -1635,6 +1698,7 @@ jobs:
   # path, audits it. Keep the action SHA in lockstep with the gate
   # (enforced by test-zizmor-action-lockstep).
   test-zizmor-blocks:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: "[Test] Zizmor - Blocks On Vulnerable Fixture"
     runs-on: ubuntu-latest
     permissions:
@@ -1687,6 +1751,7 @@ jobs:
           echo "Zizmor gate correctly blocked on the vulnerable fixture ✅"
 
   test-zizmor-action-lockstep:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: "[Test] Zizmor - Gate Pins Self-Tested Action"
     runs-on: ubuntu-latest
     permissions:
@@ -1730,6 +1795,7 @@ jobs:
   # "the gate silently stopped blocking" into a red check. test-validate-go-gate-lockstep
   # keeps the tool pins hard-coded here in step with the gate.
   test-validate-go-lint-blocks:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: "[Test] Validate Go Project - Lint Gate Blocks"
     runs-on: ubuntu-latest
     permissions:
@@ -1785,6 +1851,7 @@ jobs:
           echo "Lint gate correctly blocked on the errcheck violation ✅"
 
   test-validate-go-test-blocks:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: "[Test] Validate Go Project - Test Gate Blocks"
     runs-on: ubuntu-latest
     permissions:
@@ -1839,6 +1906,7 @@ jobs:
           echo "Test gate correctly blocked on the failing test ✅"
 
   test-validate-go-gate-lockstep:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: "[Test] Validate Go Project - Gate Lockstep"
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -60,7 +60,11 @@ jobs:
     # underlying action has no diff to inspect and errors out, so guard with an allow-list of the
     # supported events and let the job no-op (skipped → green) everywhere else. This keeps the
     # reusable workflow safe to wire into a push-triggered CI without breaking it.
-    if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+    # Also skip release-please PRs (head branch `release-please--*`): they only bump versions +
+    # the changelog (no dependency changes to review) and rewrite x-release-please-version
+    # self-pins to a tag that does not exist until the release merges. A skipped run still
+    # satisfies the required-workflow rule (skipped → green).
+    if: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && !startsWith(github.head_ref, 'release-please--') }}
     permissions:
       contents: read # read the dependency graph / diff base..head
     steps:


### PR DESCRIPTION
## Problem

The `chore(main): release 7.0.0` PR (#340) is wedged in CI. Release-please rewrites the `# x-release-please-version` self-pins (now including five `.github/workflows/*` files, after #337 granted it the `workflows` token scope) from `@v6.1.0` → `@v7.0.0`. But `v7.0.0` does not exist until the release **merges**, so on the release PR:

- **`🧪 CI`** — `test-run-dotnet-tests*` and `test-*-workflow` jobs try to resolve nested self-pins like `devantler-tech/actions/upload-coverage@v7.0.0` → `Unable to resolve action … unable to find version v7.0.0`, failing the `CI - Required Checks` gate.
- **`🛡️ Dependency Review`** — its step uses `devantler-tech/actions/dependency-review@v7.0.0` → same error.

This breaks **every** release PR, not just this one — and the CI is redundant: each change was already tested in the PR that introduced it.

## Fix

Skip the CI test suite and Dependency Review on release-please PRs by guarding their jobs with `!startsWith(github.head_ref, 'release-please--')`:

- **`ci.yaml`** — every job **except** the `CI - Required Checks` gate. The gate still runs (`if: always()`) and [`aggregate-job-checks`](../blob/main/aggregate-job-checks/action.yaml) already treats `skipped` as success, so the required status check stays **green**.
- **`dependency-review.yaml`** — the `dependency-review` job. A skipped run still satisfies the *Require workflows to pass* rule (skipped → green), and a version-bump PR has no dependency changes to review anyway.

The guard keys on the **head branch**, which is empty on `push` / `merge_group`, so the full suite — including the `zizmor` code-scanning baseline refresh on push-to-main — still runs there and on normal PRs.

## Why this is safe

- **Merge path intact** — `enable-auto-merge.yaml` (separate workflow) still approves + arms auto-merge, so once the required checks go green the release lands itself.
- **Security intact** — `scan-for-workflow-vulnerabilities.yaml` (zizmor) and CodeQL still run on release PRs. CodeQL is the only tool the *Require code scanning results* rule requires, so nothing is weakened.

## Rollout

This lands on `main`; release-please then regenerates the #340 branch from `main` (with the version bumps on top), so #340 picks up the guards and goes green on its next refresh. Future release PRs are guarded from the start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
