### PR TITLE
docs: correct run-dotnet-tests SDK list (provisions .NET 9 + 10)

### DIFF
--- a/run-dotnet-tests/README.md
+++ b/run-dotnet-tests/README.md
@@ -1,6 +1,6 @@
 # Run Dotnet Tests
 
-Test .NET solutions or projects across multiple platforms with code coverage reporting. Sets up the .NET 9 SDK, configures NuGet sources (including GHCR for private packages), runs tests with coverage collection, and uploads the report to **GitHub Code Quality** (native PR coverage).
+Test .NET solutions or projects across multiple platforms with code coverage reporting. Sets up the .NET 9 (STS) and .NET 10 (LTS) SDKs side-by-side, configures NuGet sources (including GHCR for private packages), runs tests with coverage collection, and uploads the report to **GitHub Code Quality** (native PR coverage).
 
 > **Permissions:** the calling job must grant `code-quality: write` for the GitHub Code Quality upload. The coverage is merged into a single Cobertura report (via ReportGenerator) and uploaded once, from the Linux matrix leg only. The upload is best-effort (it never fails the build) and requires the repo's **Code Quality** to be enabled (_Settings → Code quality_).
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

`run-dotnet-tests/README.md` line 3 states the action *"Sets up the .NET 9 SDK"*, but `run-dotnet-tests/action.yaml` (L18-22) provisions **both** SDKs side-by-side:

```yaml
# Provision both the previous STS (9) and the current LTS (10) so callers can
# target either TFM. Multiple lines install side-by-side SDKs.
dotnet-version: |
  9
  10
```

So a consumer reading the README would wrongly conclude .NET 10 TFMs are not available. The repo's `lint-readme-parity` gate only checks input/output *names*, not prose, so it does not catch this.

## Change

Docs-only: `the .NET 9 SDK` → `the .NET 9 (STS) and .NET 10 (LTS) SDKs side-by-side`, matching `action.yaml`. No behaviour change.

## Validation

Docs-only edit; `lint-readme-parity` (input/output name parity) is unaffected.