### PR TITLE
test(retry): assert exponential backoff doubling and RETRY_MAX_DELAY cap

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -645,7 +645,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: 🧪 Exercise retry.sh (success, retry-then-succeed, exhaust, no-arg)
+      - name: 🧪 Exercise retry.sh (success, retry-then-succeed, exhaust, no-arg, backoff)
         shell: bash
         env:
           RETRY_BASE_DELAY: "0" # keep the test fast — no real backoff sleeps
@@ -695,6 +695,32 @@ jobs:
             echo "::error::expected exit 2 for missing command, got $status"; exit 1
           fi
           echo "✅ no-arg: exit 2 as expected"
+
+          # 5. Backoff doubles each retry then clamps at RETRY_MAX_DELAY, and the
+          #    final (exhausting) attempt does not sleep. Cases 1-4 run with the
+          #    step-level RETRY_BASE_DELAY=0, so the doubling (retry.sh L50) and the
+          #    cap clamp (L51-53) are otherwise never exercised. Intercept `sleep`
+          #    with a fake on PATH that records its argument and returns instantly,
+          #    so the real backoff sequence is asserted without any wall-clock wait.
+          fakebin="$(mktemp -d)"
+          sleeplog="$(mktemp)"
+          cat > "$fakebin/sleep" <<EOF
+          #!/usr/bin/env bash
+          printf '%s\n' "\$1" >> "$sleeplog"
+          EOF
+          chmod +x "$fakebin/sleep"
+          set +e
+          PATH="$fakebin:$PATH" RETRY_MAX_ATTEMPTS=5 RETRY_BASE_DELAY=10 RETRY_MAX_DELAY=30 \
+            bash "$retry" false
+          set -e
+          got="$(tr '\n' ' ' < "$sleeplog")"
+          # 5 attempts → 4 sleeps: 10, 20 (doubling), then 40→30 and 60→30 (clamped).
+          if [ "$got" != "10 20 30 30 " ]; then
+            echo "::error::expected backoff '10 20 30 30 ', got '$got'"; exit 1
+          fi
+          echo "✅ backoff: doubles 10→20 then clamps at RETRY_MAX_DELAY=30 (no sleep on last attempt)"
+          rm -rf "$fakebin"
+          rm -f "$sleeplog"
 
           rm -f "$counter" "$flaky"
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

`test-retry-script` (`.github/workflows/ci.yaml`) exercises `.scripts/retry.sh` with **`RETRY_BASE_DELAY: "0"`** (line 651, *"keep the test fast — no real backoff sleeps"*). That shortcut means the script's **whole reason for existing** is never actually tested:

- The **doubling** — `delay=$((delay * 2))` (`retry.sh:50`) — with `base=0`, `0*2=0` forever, so it is structurally dead in every run.
- The **`RETRY_MAX_DELAY` cap clamp** (`retry.sh:51-53`) — `RETRY_MAX_DELAY` appears **exactly zero times** in `ci.yaml`; the cap is never set, never observed.

The four existing assertions (success-first-try, retry-then-succeed, exhaust-and-fail, no-arg) only check exit codes and attempt **counts** — none observes the **delay sequence**. A regression that broke the doubling (e.g. `delay=delay+2`) or dropped the cap (letting the delay grow unbounded) would keep all four green.

## Change

Test-only — `retry.sh` is **not modified**. Add **case 5** to the existing `test-retry-script` job: intercept `sleep` with a fake on `PATH` that records its argument and returns instantly, then run `RETRY_MAX_ATTEMPTS=5 RETRY_BASE_DELAY=10 RETRY_MAX_DELAY=30` against an always-failing command and assert the captured delay sequence is **`10 20 30 30`**. That single assertion pins three currently-unprotected behaviours:

1. the **doubling** (`10 → 20`),
2. the **`RETRY_MAX_DELAY` clamp** (`40 → 30`, `60 → 30`), and
3. that the **final, exhausting attempt does not sleep** (4 sleeps for 5 attempts).

The fake `sleep` keeps the job instant — no real backoff waits are reintroduced.

## Validation

- Ran the full step (all 5 cases) locally → green; the backoff case emits `retrying in 10s → 20s → 30s → 30s`.
- Mutation-checked: removing the clamp yields `10 20 40 80` → the new assertion **fails** (non-vacuous).
- `actionlint` clean on the added block (the only diagnostics are pre-existing `code-quality` permission-scope warnings unrelated to this change).
- No new job → `lint-ci-coverage-parity` (needs↔job-results parity) is unaffected.