### PR TITLE
feat(diagnose-flux): add shared composite action for Flux failure diagnostics

### DIFF
--- a/.github/tests/diagnose-flux/bin/kubectl
+++ b/.github/tests/diagnose-flux/bin/kubectl
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Fake `kubectl` for the diagnose-flux self-test. Lets the composite run
+# hermetically (no real cluster) while still exercising its REAL jq-based
+# failing-pod selection: it returns a fixture pod list with one CrashLoopBackOff
+# pod, one healthy pod, and one Job pod, and records every `logs <pod>` call to
+# $RUNNER_TEMP/logged-pods.txt so the test can assert which pods were dumped.
+set -euo pipefail
+
+record_dir="${RUNNER_TEMP:-/tmp}"
+
+case "${1:-}" in
+  get)
+    if [[ "$*" == *"pods -A -o json"* ]]; then
+      cat <<'JSON'
+{"items":[
+  {"metadata":{"namespace":"demo","name":"crasher"},"status":{"phase":"Running","containerStatuses":[{"restartCount":5,"state":{"waiting":{"reason":"CrashLoopBackOff"}}}]}},
+  {"metadata":{"namespace":"demo","name":"healthy"},"status":{"phase":"Running","containerStatuses":[{"restartCount":0,"state":{"running":{}}}]}}
+]}
+JSON
+    elif [[ "$*" == *"pods -A -l job-name"* ]]; then
+      printf 'demo\tjobpod\n'
+    elif [[ "$*" == *"jobs -A -o json"* ]]; then
+      echo '{"items":[]}'
+    fi
+    # all other `get` reads (nodes, kustomizations, helmreleases, ocirepositories,
+    # events, controller pods) are benign — emit nothing, exit 0.
+    ;;
+  logs)
+    # Args look like: logs -n <ns> <pod> --all-containers [--previous] --tail=N
+    pod=""
+    for a in "$@"; do
+      case "$a" in crasher|healthy|jobpod) pod="$a" ;; esac
+    done
+    if [[ -n "$pod" ]]; then
+      echo "$pod" >> "$record_dir/logged-pods.txt"
+    fi
+    echo "fake log output for ${pod:-unknown}"
+    ;;
+  describe|version|"")
+    : # no-op, exit 0
+    ;;
+esac

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -122,6 +122,45 @@ jobs:
           fi
           echo "Dependency review ran; dependency-changes=${CHANGES}"
 
+  # ── diagnose-flux ───────────────────────────────────────────
+  test-diagnose-flux:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: 📑 Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # Put the committed fake kubectl on PATH so the composite runs hermetically
+      # (no real cluster). Its REAL jq failing-pod selection then runs against the
+      # fixture pod list, so a regression in that logic fails this test.
+      - name: 🔧 Put fake kubectl on PATH
+        shell: bash
+        run: echo "$GITHUB_WORKSPACE/.github/tests/diagnose-flux/bin" >> "$GITHUB_PATH"
+
+      - name: 🧪 Run diagnose-flux against the fake cluster
+        uses: ./diagnose-flux
+
+      - name: ✅ Assert crash + Job pods were dumped, healthy was not
+        shell: bash
+        run: |
+          logged="$RUNNER_TEMP/logged-pods.txt"
+          if [[ ! -f "$logged" ]]; then
+            echo "::error::diagnose-flux dumped no pod logs — the jq failing-pod selection is broken"
+            exit 1
+          fi
+          for want in crasher jobpod; do
+            if ! grep -qx "$want" "$logged"; then
+              echo "::error::expected pod '$want' to be dumped but it was not"; cat "$logged"; exit 1
+            fi
+          done
+          if grep -qx healthy "$logged"; then
+            echo "::error::healthy pod was dumped — the failing-pod selection is too broad"; cat "$logged"; exit 1
+          fi
+          echo "diagnose-flux dumped crasher + jobpod and skipped healthy — OK"
   # ── enable-auto-merge-on-pr ─────────────────────────────────
   test-enable-auto-merge-on-pr:
     runs-on: ubuntu-latest
@@ -1958,6 +1997,7 @@ jobs:
       - test-cleanup-ghcr-packages
       - test-create-issues-from-todos
       - test-dependency-review
+      - test-diagnose-flux
       - test-enable-auto-merge-on-pr
       - test-free-disk-space
       - test-free-disk-space-keep
@@ -2033,6 +2073,7 @@ jobs:
             ${{ needs.test-cleanup-ghcr-packages.result }}
             ${{ needs.test-create-issues-from-todos.result }}
             ${{ needs.test-dependency-review.result }}
+            ${{ needs.test-diagnose-flux.result }}
             ${{ needs.test-enable-auto-merge-on-pr.result }}
             ${{ needs.test-free-disk-space.result }}
             ${{ needs.test-free-disk-space-keep.result }}

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ flowchart TD
 | [cleanup-ghcr-packages](cleanup-ghcr-packages/README.md) | Clean up old GHCR packages |
 | [create-issues-from-todos](create-issues-from-todos/README.md) | Create GitHub issues from TODO comments |
 | [dependency-review](dependency-review/README.md) | Scan a PR's dependency changes for vulnerabilities and disallowed licenses |
+| [diagnose-flux](diagnose-flux/README.md) | Dump Flux reconcile state, controller logs, and failing pod logs on a stuck deploy |
 | [enable-auto-merge-on-pr](enable-auto-merge-on-pr/README.md) | Enable auto-merge on a pull request |
 | [free-disk-space](free-disk-space/README.md) | Reclaim runner disk by removing large preinstalled toolchains |
 | [login-to-ghcr](login-to-ghcr/README.md) | Login to GitHub Container Registry |

--- a/diagnose-flux/README.md
+++ b/diagnose-flux/README.md
@@ -1,0 +1,49 @@
+# Diagnose Flux on failure
+
+Dump Flux reconcile state, controller logs, and failing/CrashLooping pod logs to
+debug a stuck Flux deploy in CI/CD. When a system-test or prod deploy fails, the
+useful signal is spread across the Flux CRs (`Kustomization` / `HelmRelease` /
+`OCIRepository` status), the `flux-system` controller logs, and the logs of
+whatever pod is actually crash-looping — and a `CrashLoopBackOff` pod stays in
+`phase=Running` with `waiting.reason=CrashLoopBackOff`, so naively filtering on
+phase misses it. This action gathers all of that into grouped log sections in
+one step.
+
+It is **best-effort** (`set +e`): it never fails the calling step itself, so a
+transient `kubectl`/`jq` hiccup can't mask the original failure. Gate it with
+`if: failure()` on the caller so it only runs when the deploy/test step failed.
+
+> **Assumes `kubectl` is already configured** for the target cluster (the calling
+> job has set up the kubeconfig/context) and that `jq` is available — both are
+> present on the GitHub-hosted `ubuntu-latest` runner image.
+
+## Inputs
+
+| Name | Description | Required | Default |
+|------|-------------|----------|---------|
+| `kustomizations` | Space-separated Flux Kustomization names (in `flux-system`) to `describe` on failure | ❌ | `infrastructure-controllers infrastructure apps` |
+
+## Usage
+
+### Diagnose a failed Flux deploy
+
+```yaml
+steps:
+  - name: 🚀 Deploy
+    run: ksail up # …or whatever drives the Flux reconcile
+
+  - name: 🩺 Diagnose Flux on failure
+    if: failure()
+    uses: devantler-tech/actions/diagnose-flux@main
+```
+
+### Describe a different set of Kustomizations
+
+```yaml
+steps:
+  - name: 🩺 Diagnose Flux on failure
+    if: failure()
+    uses: devantler-tech/actions/diagnose-flux@main
+    with:
+      kustomizations: infrastructure apps tenants
+```

--- a/diagnose-flux/action.yaml
+++ b/diagnose-flux/action.yaml
@@ -1,0 +1,94 @@
+name: Diagnose Flux on failure
+description: Dump Flux reconcile state, controller logs, and failing/CrashLooping pod logs to debug a stuck Flux deploy in CI/CD.
+author: devantler-tech
+inputs:
+  kustomizations:
+    description: Space-separated Flux Kustomization names (in flux-system) to `describe` on failure.
+    required: false
+    default: infrastructure-controllers infrastructure apps
+runs:
+  using: composite
+  steps:
+    - name: 🩺 Diagnose Flux on failure
+      shell: bash
+      # Best-effort diagnostics (`set +e`): never fail the calling step itself —
+      # the caller gates this with `if: failure()`, so a kubectl/jq hiccup here
+      # must not mask the original failure. CrashLoopBackOff pods stay in
+      # phase=Running with waiting.reason=CrashLoopBackOff, so we inspect
+      # containerStatuses (not just phase) to find pods worth dumping.
+      env:
+        KUSTOMIZATIONS: ${{ inputs.kustomizations }}
+      run: |
+        set +e
+        echo "::group::Nodes"
+        kubectl get nodes -o wide
+        echo "::endgroup::"
+        echo "::group::Flux Kustomizations"
+        kubectl get kustomizations.kustomize.toolkit.fluxcd.io -A -o wide
+        echo "::endgroup::"
+        echo "::group::Flux HelmReleases"
+        kubectl get helmreleases.helm.toolkit.fluxcd.io -A -o wide
+        echo "::endgroup::"
+        echo "::group::Flux OCIRepositories"
+        kubectl get ocirepositories.source.toolkit.fluxcd.io -A -o wide
+        echo "::endgroup::"
+        echo "::group::Failing Kustomizations describe"
+        for k in $KUSTOMIZATIONS; do
+          echo "--- $k ---"
+          kubectl describe kustomizations.kustomize.toolkit.fluxcd.io "$k" -n flux-system 2>&1 | tail -80
+        done
+        echo "::endgroup::"
+        echo "::group::Flux controller pods"
+        kubectl get pods -n flux-system -o wide
+        echo "::endgroup::"
+        echo "::group::kustomize-controller logs"
+        kubectl logs -n flux-system -l app=kustomize-controller --tail=300
+        echo "::endgroup::"
+        echo "::group::helm-controller logs"
+        kubectl logs -n flux-system -l app=helm-controller --tail=300
+        echo "::endgroup::"
+        echo "::group::source-controller logs"
+        kubectl logs -n flux-system -l app=source-controller --tail=200
+        echo "::endgroup::"
+        echo "::group::All pods"
+        kubectl get pods -A -o wide
+        echo "::endgroup::"
+        echo "::group::Recent events (warnings)"
+        kubectl get events -A --field-selector type=Warning --sort-by=.lastTimestamp | tail -100
+        echo "::endgroup::"
+        echo "::group::Failed/CrashLooping pod logs"
+        # Dump previous + current logs from any pod that's not Running OR
+        # has containers in a waiting/terminated-error state. CrashLoopBackOff
+        # pods stay in phase=Running with waiting.reason=CrashLoopBackOff,
+        # so we must inspect containerStatuses, not just phase.
+        pods_to_dump=$(kubectl get pods -A -o json 2>/dev/null | jq -r '
+          .items[]
+          | select(
+              .status.phase != "Running" and .status.phase != "Succeeded"
+              or ((.status.containerStatuses // [])[]? | (.restartCount // 0) > 0)
+              or ((.status.containerStatuses // [])[]? | (.state.waiting.reason // "") | test("CrashLoopBackOff|Error|ImagePullBackOff|ErrImagePull|CreateContainerError"))
+              or ((.status.containerStatuses // [])[]? | (.state.terminated.reason // "") == "Error")
+            )
+          | "\(.metadata.namespace)\t\(.metadata.name)"
+        ' | sort -u)
+        while IFS=$'\t' read -r ns name; do
+          [ -z "$ns" ] && continue
+          echo "--- $ns/$name (previous + current) ---"
+          kubectl logs -n "$ns" "$name" --all-containers --previous --tail=200 2>&1 | sed 's/^/  /'
+          echo "  --- current ---"
+          kubectl logs -n "$ns" "$name" --all-containers --tail=200 2>&1 | sed 's/^/  /'
+        done <<< "$pods_to_dump"
+        # Also dump logs from any Job pods (these often complete then disappear from "not Running")
+        while IFS=$'\t' read -r ns name; do
+          [ -z "$ns" ] && continue
+          echo "--- Job pod $ns/$name ---"
+          kubectl logs -n "$ns" "$name" --all-containers --tail=200 2>&1 | sed 's/^/  /'
+        done < <(kubectl get pods -A -l job-name -o jsonpath='{range .items[*]}{.metadata.namespace}{"\t"}{.metadata.name}{"\n"}{end}' 2>/dev/null)
+        echo "::endgroup::"
+        echo "::group::Failing Jobs describe"
+        kubectl get jobs -A -o json 2>/dev/null | jq -r '.items[] | select(.status.failed > 0 or (.status.conditions // [])[]?.type == "Failed") | "\(.metadata.namespace)/\(.metadata.name)"' | while read -r job; do
+          ns="${job%%/*}"; name="${job##*/}"
+          echo "--- $ns/$name ---"
+          kubectl describe job -n "$ns" "$name" 2>&1 | tail -50
+        done
+        echo "::endgroup::"


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

**Part of #367** (first installment — additive, no consumer changes).

## What

Adds a `devantler-tech/actions/diagnose-flux` composite action that dumps Flux reconcile state, controller logs, and failing/CrashLooping pod logs to debug a stuck Flux deploy in CI/CD.

## Why

The `🩺 Diagnose Flux on failure` step is currently copy-pasted across **four** jobs portfolio-wide, and the copies have **already drifted**:

| Repo | File | Where | Notes |
|---|---|---|---|
| `platform-template` | `.github/workflows/ci.yaml` | `system-test` (L99, ~77 lines) | **richest** — dumps logs from any non-Running / CrashLoopBackOff / ImagePullBackOff pod via `containerStatuses`; `--tail=300/300/200` |
| `platform-template` | `.github/workflows/ci.yaml` | `deploy-prod` (L365, ~37 lines) | **lacks** the failing-pod log-dump; `--tail=200/200/100` |
| `platform-template` | `.github/workflows/cd.yaml` | `deploy-prod` (L273) | same reduced variant |
| `platform` | `.github/actions/deploy-prod/action.yml` | L290 | portfolio-wide confirmation |

So the prod-deploy failure paths emit **strictly worse diagnostics** than system-test — exactly when good diagnostics matter most. The maintainer already flagged the adjacent extraction in-code (`platform-template/.github/workflows/ci.yaml` L307–312): *"…extracting … into a shared composite action so the two paths can never drift again."*

## This PR

The composite + its self-test only — built from the **richest** (system-test) variant so consumers inherit the best diagnostics:

- `diagnose-flux/action.yaml` — the `set +e` grouped dump (Flux CR status + `describe`, controller logs, all-pods, the `containerStatuses`-based failing/Job-pod previous+current log dump, warning events, failing-Jobs describe). Single input `kustomizations` (default `infrastructure-controllers infrastructure apps`) for the `describe` list; the `for k in $KUSTOMIZATIONS` word-split is the only behavioural delta from the inline block.
- `diagnose-flux/README.md` + a root-README `## Actions` row.
- `test-diagnose-flux` CI job + a committed fake-`kubectl` fixture (`.github/tests/diagnose-flux/bin/kubectl`), satisfying the `lint-ci-coverage-parity` invariant (every action has a test job wired into `ci-required-checks.needs` + `aggregate-job-checks` job-results).

No workflow **consumer** is changed here, so nothing can regress. Migrating the three `platform-template` callsites is the next installment (and `platform`'s is a maintainer-sequenced follow-up, that repo being maintainer-hot) — both tracked in #367.

## Validation

- `action.yaml` parses as a valid `using: composite` action (`yq`); the script body is **verbatim** from the production `system-test` block (already green in `platform-template` CI), so behaviour is proven.
- README ↔ action.yaml input parity passes (`lint-readme-parity`): `kustomizations` documented, no outputs.
- `lint-ci-coverage-parity` passes (verified locally): every action has a test job; `needs` ↔ `job-results` in sync.
- The self-test is **hermetic and meaningful** — the fake kubectl emits one CrashLoopBackOff pod, one healthy pod, and one Job pod; the action's **real** jq selection runs against it and the test asserts the crash + Job pods were dumped and the healthy one was **not** (so a regression in the `containerStatuses`-based selection fails the build).
- `shellcheck -s bash` clean on the composite run script, the fake-kubectl stub, and the test-job scripts.
