### PR TITLE
test(ensure-gh-skill): cover the too-old-gh version-gate branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -820,7 +820,38 @@ jobs:
           fi
           echo "✅ unsupported-arch: errored before download"
 
-          rm -rf "$okbin" "$badver" "$noskill" "$win" "$badarch"
+          # 7. gh present and skill-capable but OLDER than REQUIRED → must NOT
+          #    fast-return; falls through the `sort -V -C` version gate into the
+          #    install path (asserted by reaching the arch check, which errors
+          #    before any network download). Cases 5/6 force the install path with a
+          #    skill-LESS gh, so this "present, skill-capable, but stale" branch was
+          #    otherwise unexercised — a broken comparison that fast-returned a
+          #    too-old gh would silently skip the required upgrade and stay green.
+          oldskill=$(mktemp -d)
+          cat > "$oldskill/gh" <<'EOF'
+          #!/usr/bin/env bash
+          case "$1" in
+            --version) echo "gh version 2.0.0 (2026-01-01)"; echo "https://github.com/cli/cli/releases/tag/v2.0.0" ;;
+            skill) exit 0 ;;
+            *) exit 0 ;;
+          esac
+          EOF
+          chmod +x "$oldskill/gh"
+          cat > "$oldskill/uname" <<'EOF'
+          #!/usr/bin/env bash
+          [ "$1" = "-s" ] && { echo Linux; exit 0; }
+          echo sparc64
+          EOF
+          chmod +x "$oldskill/uname"
+          set +e
+          out=$(PATH="$oldskill:$PATH" REQUIRED=999.0.0 INSTALL_NAMESPACE=t bash "$script" 2>&1); status=$?
+          set -e
+          if [ "$status" -eq 0 ] || printf '%s' "$out" | grep -q "already supports" || ! printf '%s' "$out" | grep -q "Unsupported arch"; then
+            echo "::error::expected too-old skill-capable gh to bypass fast-return and reach the arch check; status=$status out=$out"; exit 1
+          fi
+          echo "✅ stale-but-skill-capable: bypassed fast-return into install path"
+
+          rm -rf "$okbin" "$badver" "$noskill" "$win" "$badarch" "$oldskill"
 
   # ── sync-github-labels ─────────────────────────────────────
   test-sync-github-labels:


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Adds **case 7** to the existing `test-ensure-gh-skill-script` CI job, covering a structurally-untested branch of `.scripts/ensure-gh-skill.sh`: a `gh` that **already exposes `gh skill` but is OLDER than `REQUIRED`** must *not* fast-return — it has to fall through the `sort -V -C` version gate into the install path.

## Why

The job already exercises the guards, the *satisfied* fast-return (case 3), and the skill-LESS → install fall-through (cases 5/6). But cases 5/6 reach the install path via a gh that *lacks* `skill` (the outer `gh skill --help` guard fails), so they never traverse the **version comparison** itself. The "present, skill-capable, but stale" branch — the negative of:

```sh
if printf '%s\n%s\n' "$REQUIRED" "$current" | sort -V -C; then
  echo "Installed gh ($current) already supports 'gh skill'."
  exit 0
fi
```

was unexercised. A broken/inverted comparison that fast-returned a too-old `gh` would silently skip the required upgrade and **stay green**. This mirrors the gap fixed for `retry.sh` in #365 (a branch unreachable under the existing cases).

## How

Hermetic, no network: a fake skill-capable `gh` reporting `2.0.0` plus a fake `uname` returning an unsupported arch, run with `REQUIRED=999.0.0`. Because the gh is too old it must bypass the fast-return and reach the arch validation, erroring with `Unsupported arch` *before* any download. The case asserts non-zero exit, **no** `already supports`, and presence of `Unsupported arch`.

- **Test-only** — `ensure-gh-skill.sh` is unchanged.
- **No new job** — extends the existing `test-ensure-gh-skill-script`, so `ci-required-checks` / `aggregate-job-checks` / `lint-ci-coverage-parity` are unaffected.
- **Mutation-checked (non-vacuous):** replacing the version gate with `if true` (always fast-return) makes the new case fail with `already supports` / exit 0; the unmodified script passes (`rc=1`, `Unsupported arch`). Verified locally.
- `actionlint` clean (only the pre-existing `code-quality`-scope warnings, unrelated).

Fixes nothing user-facing; pins a reliability branch of the shared agent-skills bootstrap so a future regression can't pass silently.