### PR TITLE
fix(upsert-issue): fail with a clear error when body-file is missing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1249,6 +1249,35 @@ jobs:
             exit 1
           fi
 
+  test-upsert-issue-missing-body-file:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: 📑 Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: 🧪 Run upsert-issue with a non-existent body-file (expected to fail)
+        id: upsert
+        continue-on-error: true
+        uses: ./upsert-issue
+        with:
+          title: "[test] upsert-issue missing-body-file negative test"
+          body-file: does-not-exist.md
+
+      - name: ✅ Verify step failed as expected
+        shell: bash
+        env:
+          OUTCOME: ${{ steps.upsert.outcome }}
+        run: |
+          if [[ "$OUTCOME" != "failure" ]]; then
+            echo "::error::Expected the action to fail when body-file does not exist, got: $OUTCOME"
+            exit 1
+          fi
+
   # ── run-dotnet-tests (negative path) ───────────────────────
   test-run-dotnet-tests-missing-working-directory:
     if: ${{ !startsWith(github.head_ref, 'release-please--') }}
@@ -2202,6 +2231,7 @@ jobs:
       - test-login-to-ghcr-empty-token
       - test-setup-go-toolchain-invalid-version
       - test-upsert-issue-missing-body
+      - test-upsert-issue-missing-body-file
       - test-run-dotnet-tests-missing-working-directory
       - zizmor
       - lint-readme-parity
@@ -2280,6 +2310,7 @@ jobs:
             ${{ needs.test-login-to-ghcr-empty-token.result }}
             ${{ needs.test-setup-go-toolchain-invalid-version.result }}
             ${{ needs.test-upsert-issue-missing-body.result }}
+            ${{ needs.test-upsert-issue-missing-body-file.result }}
             ${{ needs.test-run-dotnet-tests-missing-working-directory.result }}
             ${{ needs.zizmor.result }}
             ${{ needs.lint-readme-parity.result }}

--- a/upsert-issue/action.yaml
+++ b/upsert-issue/action.yaml
@@ -59,6 +59,10 @@ runs:
 
         # Resolve body content
         if [ -n "$BODY_FILE" ]; then
+          if [ ! -f "$BODY_FILE" ]; then
+            echo "::error::'body-file' not found: $BODY_FILE"
+            exit 1
+          fi
           BODY=$(cat "$BODY_FILE")
         fi
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

`upsert-issue/action.yaml` resolves the issue body from a file with `BODY=$(cat "$BODY_FILE")` under `set -euo pipefail`, with **no existence check**. When a caller passes a `body-file` path that doesn't exist (a typo, a generator that didn't run, a wrong `working-directory`), the action aborts on the raw shell error:

```
cat: does-not-exist.md: No such file or directory
```

That's a cryptic failure for a common, actionable caller mistake — and inconsistent with the action's sibling guard, which already emits a clean `::error::Either 'body' or 'body-file' input must be provided` when neither input is given.

## Change

- **`upsert-issue/action.yaml`** — add a `[ ! -f "$BODY_FILE" ]` guard before the `cat`, emitting an actionable annotation and exiting `1`:

  ```bash
  if [ -n "$BODY_FILE" ]; then
    if [ ! -f "$BODY_FILE" ]; then
      echo "::error::'body-file' not found: $BODY_FILE"
      exit 1
    fi
    BODY=$(cat "$BODY_FILE")
  fi
  ```
  Behaviour-preserving for valid inputs; only upgrades the failure message for a missing file.

- **`.github/workflows/ci.yaml`** — add `test-upsert-issue-missing-body-file`, a negative-input self-test mirroring the existing `test-upsert-issue-missing-body`: it runs the action with `body-file: does-not-exist.md` under `continue-on-error` and asserts the step **failed**. Wired into the `aggregate-job-checks` `needs:` list and `job-results` (keeps `lint-ci-coverage-parity` green).

## Scope / honest note

This extends the action's **negative-input** coverage to the `body-file` branch (previously only the no-body case had a negative test). Like its `test-upsert-issue-missing-body` sibling, the self-test asserts the *outcome* (`failure`) — it pins that a non-existent `body-file` is **rejected**, not the exact message text (a composite action invoked via `uses:` doesn't expose its stdout to a later step for grepping, the way `test-zizmor-blocks` reads the gate's tee'd report file). The user-facing improvement — the actionable `::error::` instead of a raw `cat` error — lives in the source guard.

## Validation

- `actionlint .github/workflows/ci.yaml` — clean (only the pre-existing `code-quality:` permission-scope warnings on unchanged lines, which actionlint 1.7.12 doesn't yet recognise).
- `action.yaml` + `ci.yaml` parse as valid YAML.
- Diff is +35 / -0, additive only.