### PR TITLE
test(ci): exercise ensure-gh-skill.sh macOS unzip-missing guard

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -916,7 +916,44 @@ jobs:
           fi
           echo "✅ stale-but-skill-capable: bypassed fast-return into install path"
 
-          rm -rf "$okbin" "$badver" "$noskill" "$win" "$badarch" "$oldskill"
+          # 8. macOS (ext=zip) with unzip absent → the zip-needs-unzip guard fires
+          #    BEFORE any network download. A skill-LESS gh forces the install path;
+          #    uname is faked to Darwin/arm64 (valid arch → passes the arch check);
+          #    and PATH is a CURATED stub dir holding only the stubs plus the real
+          #    tools the pre-guard path needs (bash for the stubs' `env` shebang,
+          #    mktemp for the tmp dir) — but NOT unzip — so `! command -v unzip` is
+          #    true even on a runner that ships unzip. (Cases 5-7 keep the full PATH,
+          #    so this "ext=zip but no unzip" guard — dead on Linux, where ext=tar.gz
+          #    — was otherwise unexercised; a refactor dropping it would let the
+          #    script fall through to a cryptic `unzip` failure instead of the
+          #    actionable error.) The curated PATH means the stubs' `#!/usr/bin/env
+          #    bash` shebang must resolve `bash`, so it is symlinked in too.
+          nounzip=$(mktemp -d)
+          cat > "$nounzip/gh" <<'EOF'
+          #!/usr/bin/env bash
+          case "$1" in
+            skill) exit 1 ;;
+            *) exit 0 ;;
+          esac
+          EOF
+          chmod +x "$nounzip/gh"
+          cat > "$nounzip/uname" <<'EOF'
+          #!/usr/bin/env bash
+          [ "$1" = "-s" ] && { echo Darwin; exit 0; }
+          echo arm64
+          EOF
+          chmod +x "$nounzip/uname"
+          ln -s "$(command -v bash)" "$nounzip/bash"
+          ln -s "$(command -v mktemp)" "$nounzip/mktemp"
+          set +e
+          out=$(PATH="$nounzip" REQUIRED=999.0.0 INSTALL_NAMESPACE=t "$nounzip/bash" "$script" 2>&1); status=$?
+          set -e
+          if [ "$status" -eq 0 ] || ! printf '%s' "$out" | grep -q "unzip is required"; then
+            echo "::error::expected unzip-missing guard to fire on the macOS zip path; status=$status out=$out"; exit 1
+          fi
+          echo "✅ macos-missing-unzip: guarded before download as expected"
+
+          rm -rf "$okbin" "$badver" "$noskill" "$win" "$badarch" "$oldskill" "$nounzip"
 
   # ── sync-github-labels ─────────────────────────────────────
   test-sync-github-labels:


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What & why

`.scripts/ensure-gh-skill.sh` carries a defensive guard that fails early — **before** any network download — when the runner needs the macOS `zip` release asset but has no `unzip`:

```bash
if [ "$ext" = "zip" ] && ! command -v unzip >/dev/null 2>&1; then
  echo "::error::unzip is required to extract the macOS gh release archive but is not available on PATH."
  exit 1
fi
```

The `test-ensure-gh-skill-script` self-test job already covers the guards, fast-return, unparseable-version, unsupported-OS/arch, and the stale-but-skill-capable branches (cases 1–7) — but this one was the **last unexercised branch**. It only triggers on macOS (`ext=zip`); the self-test runs on `ubuntu-latest` (`ext=tar.gz`), so a refactor dropping it would go unnoticed and let the script fall through to a cryptic `unzip: command not found` instead of the actionable error.

## How

Adds **case 8** to the existing job, mirroring cases 5–7:

- a skill-LESS fake `gh` forces the install path;
- `uname` is faked to **Darwin/arm64** (valid arch → passes the arch check, so execution reaches the unzip guard);
- PATH is a **curated stub dir** holding only the stubs plus the real tools the pre-guard path needs (`bash` for the stubs' `#!/usr/bin/env bash` shebang, `mktemp` for the temp dir) — **but not `unzip`** — so `! command -v unzip` is true *even on a runner that ships unzip*.

The curated-PATH idiom (vs. cases 5–7's `PATH="$dir:$PATH"`) is what lets this hide a system `unzip`; the guard fires before any `curl`, so no network is touched.

## Validation

- `actionlint` clean for this change (only pre-existing `code-quality` permission-scope warnings remain, unrelated).
- Ran the **full extracted job** (all 8 cases, exactly as YAML hands the `run:` block to bash) in an `ubuntu:24.04` mirror **with `unzip` + `curl` installed** → all green, including the new case.
- **Mutation-checked:** removing the guard from the script makes the new case go red (the script proceeds past `Downloading …` and never emits `unzip is required`).

Test-only; no behaviour change to the script or any consumer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new test case covering macOS installation when the `unzip` tool is not available.
  * Verified the script stops early with a clear error message instead of attempting a download.
  * Improved test cleanup to remove temporary files created by the new scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->