### PR TITLE
fix(enable-auto-merge-on-pr): retry-harden the gh API/merge network calls

### DIFF
--- a/enable-auto-merge-on-pr/action.yaml
+++ b/enable-auto-merge-on-pr/action.yaml
@@ -32,7 +32,15 @@ runs:
         GH_TOKEN: ${{ inputs.token }}
         REPOSITORY: ${{ github.repository }}
       run: |
-        REPO_INFO=$(gh api "repos/$REPOSITORY" --jq '.allow_auto_merge')
+        # A transient GitHub API blip (5xx/DNS/TLS) must not red this required
+        # auto-merge step on infra noise; bound the network read with retry +
+        # backoff via the shared .scripts/retry.sh helper — see the reliability
+        # pillar of the actions roadmap (devantler-tech/actions#247). A genuine
+        # `allow_auto_merge: false` returns "false" with exit 0, so it is not
+        # retried — only an actual command failure is.
+        retry() { bash "${GITHUB_ACTION_PATH}/../.scripts/retry.sh" "$@"; }
+
+        REPO_INFO=$(retry gh api "repos/$REPOSITORY" --jq '.allow_auto_merge')
         echo "auto-merge-enabled=${REPO_INFO}" >> "$GITHUB_OUTPUT"
 
         if [[ "$REPO_INFO" != "true" ]]; then
@@ -53,7 +61,12 @@ runs:
           exit 1
         fi
 
-        gh pr merge "$PR_NUMBER" --auto --"$MERGE_METHOD" --repo "$REPOSITORY"
+        # Arming auto-merge is idempotent (re-arming with the same method is a
+        # no-op), so wrap the network call in retry + backoff so a transient API
+        # blip does not red this required step (#247 reliability pillar).
+        retry() { bash "${GITHUB_ACTION_PATH}/../.scripts/retry.sh" "$@"; }
+
+        retry gh pr merge "$PR_NUMBER" --auto --"$MERGE_METHOD" --repo "$REPOSITORY"
         echo "✅ Auto-merge enabled for PR #${PR_NUMBER} using ${MERGE_METHOD} method"
 
     - name: 🔎 Dry-run notice


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #401 · child of the reliability pillar in #247.

## Problem

`enable-auto-merge-on-pr` makes two **unguarded** GitHub-API network calls in `run:` steps — `gh api repos/<repo>` (read `allow_auto_merge`) and `gh pr merge --auto` (arm auto-merge). A transient API blip (5xx/DNS/TLS) on either reds this **required** auto-merge step on infra noise, so a trusted bot/own PR silently fails to get auto-merge armed. The sibling network-pull composites (`setup-ksail-cli`, `setup-agent-skills`, `update-agent-skills`) already wrap their pulls with the shared `.scripts/retry.sh` helper — this composite was the remaining `gh`-API gap.

## Change

Wrap both `gh` calls in `.scripts/retry.sh` (bounded retry + exponential backoff), mirroring `setup-ksail-cli`:

- **`gh api` read** — a genuine `allow_auto_merge: false` returns `"false"` with exit 0, so it is **not** retried; only an actual command failure is. Behaviour preserved.
- **`gh pr merge --auto`** — idempotent (re-arming with the same method is a no-op), so safe to retry.

## Why it's safe

- **No input/output/contract change** → README↔`action.yaml` parity guard unaffected.
- `enable-auto-merge` is a **non-gating** action (per `AGENTS.md`), so the existing happy-path `[Test]` job in `ci.yaml` remains complete coverage — no new test needed.
- Reuses the established, already-tested `.scripts/retry.sh` helper resolved via `${GITHUB_ACTION_PATH}/../.scripts/` (same top-level-action path resolution as `setup-ksail-cli`).

Validated: YAML parses (3 steps + inputs preserved); diff is +15/-2 in one file.