### PR TITLE
fix(approve-pr,upsert-issue): retry-harden unguarded gh network calls

### DIFF
--- a/approve-pr/action.yaml
+++ b/approve-pr/action.yaml
@@ -44,7 +44,14 @@ runs:
         PR_NUMBER: ${{ inputs.pr-number }}
         REPOSITORY: ${{ github.repository }}
       run: |
-        gh pr review "$PR_NUMBER" --approve --repo "$REPOSITORY"
+        # A transient GitHub API blip (5xx/secondary-rate-limit/DNS-TLS) must not
+        # red this required approval step on infra noise. Submitting the review is
+        # idempotent-in-effect (the PR stays approved), so bound the network call
+        # with retry + backoff via the shared .scripts/retry.sh helper — see the
+        # reliability pillar of the actions roadmap (devantler-tech/actions#247).
+        retry() { bash "${GITHUB_ACTION_PATH}/../.scripts/retry.sh" "$@"; }
+
+        retry gh pr review "$PR_NUMBER" --approve --repo "$REPOSITORY"
         echo "✅ PR #${PR_NUMBER} approved"
 
     - name: 🔎 Dry-run notice

--- a/upsert-issue/action.yaml
+++ b/upsert-issue/action.yaml
@@ -57,6 +57,16 @@ runs:
       run: |
         set -euo pipefail
 
+        # A transient GitHub API blip (5xx/secondary-rate-limit/DNS-TLS) must not
+        # red this step on infra noise — the title search hits the rate-limit-prone
+        # Search API. Bound the retry-SAFE network calls with retry + backoff via
+        # the shared .scripts/retry.sh helper (reliability pillar
+        # devantler-tech/actions#247). NOTE: `gh issue create` is deliberately NOT
+        # wrapped — it is not idempotent, so retrying a partially-succeeded create
+        # would open duplicate issues. Idempotent reads/edits (list/edit/view/close)
+        # are safe; `gh issue reopen` keeps its existing `|| true` best-effort guard.
+        retry() { bash "${GITHUB_ACTION_PATH}/../.scripts/retry.sh" "$@"; }
+
         # Resolve body content
         if [ -n "$BODY_FILE" ]; then
           if [ ! -f "$BODY_FILE" ]; then
@@ -74,7 +84,7 @@ runs:
         # Search for existing issue by exact title (any state).
         # Prefer an open issue; fall back to the most recent closed one.
         ISSUE_NUMBER=$(
-          gh issue list \
+          retry gh issue list \
             --repo "$REPO" \
             --state all \
             --search "in:title \"${TITLE}\"" \
@@ -91,9 +101,9 @@ runs:
         if [ "$OPEN" = "true" ]; then
           if [ -n "$ISSUE_NUMBER" ]; then
             echo "Updating issue #${ISSUE_NUMBER} and ensuring it is open"
-            gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --body "$BODY"
+            retry gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --body "$BODY"
             if [ -n "$LABELS" ]; then
-              gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "$LABELS"
+              retry gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "$LABELS"
             fi
             gh issue reopen "$ISSUE_NUMBER" --repo "$REPO" 2>/dev/null || true
           else
@@ -108,11 +118,11 @@ runs:
         else
           if [ -n "$ISSUE_NUMBER" ]; then
             ISSUE_STATE=$(
-              gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json state --jq .state
+              retry gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json state --jq .state
             )
             if [ "$ISSUE_STATE" = "OPEN" ]; then
               echo "Closing issue #${ISSUE_NUMBER}"
-              gh issue close "$ISSUE_NUMBER" --repo "$REPO" --comment "$CLOSE_COMMENT"
+              retry gh issue close "$ISSUE_NUMBER" --repo "$REPO" --comment "$CLOSE_COMMENT"
             else
               echo "Issue #${ISSUE_NUMBER} is already closed — nothing to do"
             fi


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #404. Child of the reliability pillar **#247**; sibling of #401/#402 (which hardens `enable-auto-merge-on-pr`).

## What

After #402, a scan of the composite suite for unguarded network calls not wrapped in `.scripts/retry.sh` left exactly two: **`approve-pr`** and **`upsert-issue`**. This routes their **retry-safe** `gh` network calls through the shared bounded-retry helper so a transient GitHub API blip (5xx / secondary-rate-limit / DNS-TLS) doesn't red a required step on infra noise.

- **`approve-pr`** — wrap the single `gh pr review --approve` (idempotent-in-effect: the PR stays approved).
- **`upsert-issue`** — wrap the idempotent reads/edits: `gh issue list --search` (hits the rate-limit-prone **Search API** — the highest-value call), `gh issue edit` (×2), `gh issue view`, `gh issue close`.

## Correctness — what is deliberately NOT retried

Applying the review lesson from #402 (scope retry to retry-safe calls):

- **`gh issue create` stays direct** — it is **not idempotent**, so retrying a partially-succeeded create would open **duplicate issues**. Documented inline.
- **`gh issue reopen` keeps its existing `|| true`** best-effort guard (an already-open reopen is a benign non-zero — retrying it would just waste backoff).

`retry.sh` has no `set -e` and returns the failing command's last exit status, so a *genuine* failure still reds the step (no masking); under the caller's `set -euo pipefail` a `$(retry …)` that exhausts attempts still aborts exactly as before.

## Scope / safety

- **Pure reliability hardening** — no input/output/behaviour change; backward-compatible for every consumer (blast-radius-safe per the composite-action rule).
- Wrapper resolved relative to `${GITHUB_ACTION_PATH}` (same pattern as `setup-ksail-cli` / #402) so local `uses: ./<action>` and external `uses: devantler-tech/actions/<action>@<ref>` callers both work.

## Validation

- `yq` parse of both `action.yaml` — OK.
- `shellcheck -S warning` on the embedded run scripts — clean (only the extraction-artifact SC2148 "missing shebang", supplied by `shell: bash` in-action).
- Existing self-tests `test-approve-pr` and `test-upsert-issue-create` / `-close` / negative-path exercise the changed paths — left green.
