### PR TITLE
fix(scan-for-todo-comments): restore self-checkout for post-cleanup

### DIFF
--- a/.github/workflows/scan-for-todo-comments.yaml
+++ b/.github/workflows/scan-for-todo-comments.yaml
@@ -53,3 +53,18 @@ jobs:
           client-id: ${{ vars.APP_CLIENT_ID }}
           app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
           project: organization/devantler-tech/5
+
+      # The sibling composite runs its own actions/checkout, whose git clean deletes this
+      # untracked self-checkout mid-job. That is intended (it hides the actions sources from
+      # the todo scan above), but the runner re-reads the composite's action.yaml from disk to
+      # run its post-cleanup steps — which then fails with "Can't find action.yml". Re-materialise
+      # the directory AFTER the scan so the post phase can reload it; the scanner has already run,
+      # so it still never sees the actions repo's own sources.
+      - name: 📥 Restore devantler-tech/actions for post-cleanup
+        if: ${{ always() }}
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
+          path: .devantler-tech-actions
+          persist-credentials: false


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
The TODO-scan reusable workflow (v8.0.1) leaves consumers **red on main**: it self-references the actions repo via a local checkout, and the sibling action's own checkout wipes that directory mid-job, so the job's post-cleanup can no longer find the action and fails — even though issue creation succeeded. Platform is the first repo to hit this (it pins v8.0.1); every consumer would as they upgrade.

## What
Re-materialise the self-checkout after the scan runs, so the post-cleanup phase can reload the action. The scanner still never sees the actions repo's own sources (it has already run). Housekeeping-only change; no behaviour change to issue creation.

## Operational note
Merge → release (v8.0.2) → bump platform's pin to clear platform main. Only self-ref (v8.0.1+) consumers are affected; v8.0.0 consumers are unchanged.