### PR TITLE
fix(create-issues-from-todos): re-pin todo-to-issue-action to v5.1.15

### DIFF
--- a/create-issues-from-todos/action.yaml
+++ b/create-issues-from-todos/action.yaml
@@ -33,7 +33,10 @@ runs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
-    - uses: alstr/todo-to-issue-action@c45b007d85c8edf3365b139a9d4c65793e7c674f # v5.1.13
+    # Floor is v5.1.15: earlier releases crash the whole workflow with
+    # `KeyError: 'web_url'` when a removed TODO matches multiple existing issues
+    # (GitLab-only field in the ambiguous-match diagnostic). Never downgrade past it.
+    - uses: alstr/todo-to-issue-action@37bb7b56e58569ef273b60678048030a7f0c261a # v5.1.15
       with:
         AUTO_ASSIGN: true
         CLOSE_ISSUES: true


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
The `TODOs` workflow crashed portfolio-wide whenever a removed TODO matched more than one existing issue — a hard red on `main` for that commit, on every repo that runs it. The root cause was a one-line upstream bug.

## What
The upstream fix (submitted from our side) merged and shipped in `v5.1.15`; this re-pins our composite action to that fixed release, so the crash can no longer occur. Closes out the last remaining step of this issue.

Fixes #222