### PR TITLE
fix(create-issues-from-todos): stop the action self-matching its own comment

### DIFF
--- a/create-issues-from-todos/action.yaml
+++ b/create-issues-from-todos/action.yaml
@@ -34,8 +34,9 @@ runs:
       with:
         persist-credentials: false
     # Floor is v5.1.15: earlier releases crash the whole workflow with
-    # `KeyError: 'web_url'` when a removed TODO matches multiple existing issues
-    # (GitLab-only field in the ambiguous-match diagnostic). Never downgrade past it.
+    # `KeyError: 'web_url'` when a removed to-do marker matches multiple existing
+    # issues (GitLab-only field in the ambiguous-match diagnostic). Never downgrade
+    # past it. (Lowercase "to-do" avoids this action self-matching its own comment.)
     - uses: alstr/todo-to-issue-action@37bb7b56e58569ef273b60678048030a7f0c261a # v5.1.15
       with:
         AUTO_ASSIGN: true


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

Our own TODO-scanner action self-matched an explanatory comment in its definition (it mentioned the literal token `TODO`), auto-creating a junk issue (#453) titled "matches multiple existing issues" — and it would recreate one on every scan.

## What

Rewords the comment to lowercase "to-do marker" so it no longer trips the scanner. Meaning unchanged; removes the recurring backlog noise at the root.

Fixes #453