### PR TITLE
docs: repoint update-agent-skills link off reusable-workflows

### DIFF
--- a/update-agent-skills/README.md
+++ b/update-agent-skills/README.md
@@ -64,7 +64,7 @@ jobs:
           labels: dependencies,automation
 ```
 
-For a batteries-included version of the above, use the reusable workflow [`devantler-tech/reusable-workflows/.github/workflows/update-agent-skills.yaml`](https://github.com/devantler-tech/reusable-workflows/blob/main/.github/workflows/update-agent-skills.yaml).
+For a batteries-included version of the above, use the reusable workflow [`devantler-tech/actions/.github/workflows/update-agent-skills.yaml`](https://github.com/devantler-tech/actions/blob/main/.github/workflows/update-agent-skills.yaml).
 
 ### Plugin directory layout
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
The reusable-workflow library was merged into this repo (#314) and `reusable-workflows` is being retired, but a doc link still pointed consumers at the old repo — a dead pointer once it's archived.

## What
Repoints the `update-agent-skills` README's batteries-included link to the workflow's current home in `devantler-tech/actions`. Docs-only, no behaviour change.

Part of #425 (the workflow-level consumer repoint is already complete across all consumers; this clears a remaining stale doc pointer).