### PR TITLE
fix(ci): cache kubeconform schemas across Test/Coverage jobs

### DIFF
--- a/.github/workflows/validate-go-project.yaml
+++ b/.github/workflows/validate-go-project.yaml
@@ -655,9 +655,9 @@ jobs:
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.cache/ksail/kubeconform
-          key: kubeconform-schema-cache-v1-${{ github.run_id }}
+          key: kubeconform-schema-cache-v1-${{ github.job }}-${{ github.run_id }}
           restore-keys: |
-            kubeconform-schema-cache-v1-
+            kubeconform-schema-cache-v1-${{ github.job }}-
 
       - name: 🧪 Test
         run: |
@@ -725,9 +725,9 @@ jobs:
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.cache/ksail/kubeconform
-          key: kubeconform-schema-cache-v1-${{ github.run_id }}
+          key: kubeconform-schema-cache-v1-${{ github.job }}-${{ github.run_id }}
           restore-keys: |
-            kubeconform-schema-cache-v1-
+            kubeconform-schema-cache-v1-${{ github.job }}-
 
       - name: 👨🏻‍🔧 Enable covdata (temp) see https://github.com/golang/go/issues/75031
         run: go env -w GOTOOLCHAIN=go1.26.0+auto

--- a/.github/workflows/validate-go-project.yaml
+++ b/.github/workflows/validate-go-project.yaml
@@ -648,11 +648,16 @@ jobs:
         # raw.githubusercontent.com/yannh/kubernetes-json-schema on every cold run —
         # with no persistent cache across CI jobs, every job re-fetched every schema,
         # which is what tripped upstream 429 rate-limiting across the whole matrix
-        # (portfolio-wide 2026-07-09 incident). This restores (and, at job end,
-        # re-saves) the local cache dir ksail's own kubeconform client already builds
-        # via `validator.Opts.Cache` — no consumer-side change needed. Harmless no-op
-        # for repos that never populate this path.
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        # (portfolio-wide 2026-07-09 incident). This restores the local cache dir
+        # ksail's own kubeconform client already builds via `validator.Opts.Cache` —
+        # no consumer-side change needed; harmless no-op for repos that never
+        # populate this path. Restore/save are split (rather than a single
+        # `actions/cache` step) so the save below can run with `if: always()` — the
+        # Test step below is exactly what can fail on an uncached/rate-limited
+        # fetch, and a save gated on job success would then never persist the
+        # schemas it did fetch before failing.
+        id: kubeconform-cache
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.cache/ksail/kubeconform
           key: kubeconform-schema-cache-v1-${{ github.job }}-${{ github.run_id }}
@@ -662,6 +667,13 @@ jobs:
       - name: 🧪 Test
         run: |
           go test ./...
+
+      - name: 📤 Save kubeconform schema cache
+        if: always() && steps.kubeconform-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/.cache/ksail/kubeconform
+          key: ${{ steps.kubeconform-cache.outputs.cache-primary-key }}
 
   coverage:
     name: 📊 Code Coverage
@@ -721,8 +733,10 @@ jobs:
 
       - name: 📥 Restore kubeconform schema cache
         # See the identical step in the Test job above for the full rationale
-        # (raw.githubusercontent.com 429 rate-limiting, portfolio-wide 2026-07-09).
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        # (raw.githubusercontent.com 429 rate-limiting, portfolio-wide 2026-07-09;
+        # restore/save split so the save can run with if: always()).
+        id: kubeconform-cache
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.cache/ksail/kubeconform
           key: kubeconform-schema-cache-v1-${{ github.job }}-${{ github.run_id }}
@@ -735,6 +749,13 @@ jobs:
       - name: 📄 Generate coverage
         run: |
           go test -race -coverprofile=coverage.txt -covermode=atomic ./...
+
+      - name: 📤 Save kubeconform schema cache
+        if: always() && steps.kubeconform-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/.cache/ksail/kubeconform
+          key: ${{ steps.kubeconform-cache.outputs.cache-primary-key }}
 
       # best-effort: coverage reporting is a preview feature and must never block a Go PR. This job
       # runs on every Go PR org-wide via the required-workflow ruleset (pinned to this repo's main).

--- a/.github/workflows/validate-go-project.yaml
+++ b/.github/workflows/validate-go-project.yaml
@@ -669,7 +669,7 @@ jobs:
           go test ./...
 
       - name: 📤 Save kubeconform schema cache
-        if: always() && steps.kubeconform-cache.outputs.cache-hit != 'true'
+        if: "!cancelled() && steps.kubeconform-cache.outputs.cache-hit != 'true'"
         uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.cache/ksail/kubeconform
@@ -751,7 +751,7 @@ jobs:
           go test -race -coverprofile=coverage.txt -covermode=atomic ./...
 
       - name: 📤 Save kubeconform schema cache
-        if: always() && steps.kubeconform-cache.outputs.cache-hit != 'true'
+        if: "!cancelled() && steps.kubeconform-cache.outputs.cache-hit != 'true'"
         uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.cache/ksail/kubeconform

--- a/.github/workflows/validate-go-project.yaml
+++ b/.github/workflows/validate-go-project.yaml
@@ -642,6 +642,23 @@ jobs:
           go-version-file: ${{ inputs.working-directory || '.' }}/go.mod
           cache: true
 
+      - name: 📥 Restore kubeconform schema cache
+        # A consumer whose Go tests exercise kubeconform-based schema validation (e.g.
+        # ksail's pkg/client/kubeconform) fetches JSON schemas from
+        # raw.githubusercontent.com/yannh/kubernetes-json-schema on every cold run —
+        # with no persistent cache across CI jobs, every job re-fetched every schema,
+        # which is what tripped upstream 429 rate-limiting across the whole matrix
+        # (portfolio-wide 2026-07-09 incident). This restores (and, at job end,
+        # re-saves) the local cache dir ksail's own kubeconform client already builds
+        # via `validator.Opts.Cache` — no consumer-side change needed. Harmless no-op
+        # for repos that never populate this path.
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/.cache/ksail/kubeconform
+          key: kubeconform-schema-cache-v1-${{ github.run_id }}
+          restore-keys: |
+            kubeconform-schema-cache-v1-
+
       - name: 🧪 Test
         run: |
           go test ./...
@@ -701,6 +718,16 @@ jobs:
         with:
           go-version-file: ${{ inputs.working-directory || '.' }}/go.mod
           cache: true
+
+      - name: 📥 Restore kubeconform schema cache
+        # See the identical step in the Test job above for the full rationale
+        # (raw.githubusercontent.com 429 rate-limiting, portfolio-wide 2026-07-09).
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/.cache/ksail/kubeconform
+          key: kubeconform-schema-cache-v1-${{ github.run_id }}
+          restore-keys: |
+            kubeconform-schema-cache-v1-
 
       - name: 👨🏻‍🔧 Enable covdata (temp) see https://github.com/golang/go/issues/75031
         run: go env -w GOTOOLCHAIN=go1.26.0+auto


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
A portfolio-wide `raw.githubusercontent.com` 429 rate-limit is currently failing the `🧪 Test` / `📊 Code Coverage` jobs (and ksail's own System-Test matrix) on effectively every open ksail PR, including two of the Daily AI Assistant's own promoted PRs. Root cause: ksail's Go tests exercise real kubeconform schema validation with no cache persisted across CI jobs, so every job re-fetches every JSON schema from GitHub's raw CDN — heavy, repeated traffic across the whole matrix is what trips the upstream rate limit.

## What
Adds an `actions/cache` step to this reusable workflow's `test` and `coverage` jobs that restores/persists `~/.cache/ksail/kubeconform` — the local schema-cache directory ksail's kubeconform client already builds internally (`validator.Opts.Cache`), just never had anywhere to persist between ephemeral runners. Purely additive; a harmless no-op for any consumer repo that doesn't exercise this code path.

Fixes the recurring rate-limit breakage blocking `ksail#5950`/`ksail#5951` (both CI-blocked, otherwise merge-ready) and the wider dependabot/system-test queue.