### PR TITLE
fix(setup-agent-skills): recover already-installed retries

### DIFF
--- a/.github/tests/gh-skill-install-script.sh
+++ b/.github/tests/gh-skill-install-script.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+script="$repo_root/.scripts/gh-skill-install.sh"
+
+fakebin=$(mktemp -d)
+log=$(mktemp)
+export FAKE_GH_LOG="$log"
+trap 'rm -rf "$fakebin"; rm -f "$log"' EXIT
+
+cat > "$fakebin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+{
+  printf 'call:'
+  for arg in "$@"; do
+    printf ' <%s>' "$arg"
+  done
+  printf '\n'
+} >> "$FAKE_GH_LOG"
+
+case "${FAKE_GH_MODE:-already-installed}" in
+  hard-fail)
+    echo "could not fetch blob: HTTP 403: API rate limit exceeded for installation" >&2
+    exit 42
+    ;;
+  success)
+    echo "installed"
+    exit 0
+    ;;
+esac
+
+case " $* " in
+  *" --force "*)
+    echo "installed with force"
+    ;;
+  *)
+    echo "skills already installed: git-commit (use --force to overwrite)" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "$fakebin/gh"
+
+PATH="$fakebin:$PATH" bash "$script" github/awesome-copilot git-commit --agent github-copilot --scope project
+
+if [ "$(grep -c '^call:' "$log")" -ne 2 ]; then
+  echo "::error::expected gh to be called twice for already-installed recovery"
+  cat "$log"
+  exit 1
+fi
+if ! tail -n 1 "$log" | grep -q -- '--force'; then
+  echo "::error::expected second gh call to add --force"
+  cat "$log"
+  exit 1
+fi
+echo "already-installed recovery adds --force"
+
+: > "$log"
+if FAKE_GH_MODE=hard-fail PATH="$fakebin:$PATH" \
+  bash "$script" github/awesome-copilot git-commit --agent github-copilot --scope project; then
+  status=0
+else
+  status=$?
+fi
+
+if [ "$status" -ne 42 ]; then
+  echo "::error::expected hard failure status 42, got $status"
+  exit 1
+fi
+if [ "$(grep -c '^call:' "$log")" -ne 1 ]; then
+  echo "::error::expected hard failure to avoid force retry"
+  cat "$log"
+  exit 1
+fi
+echo "non-idempotency failures keep their original exit status"
+
+: > "$log"
+FAKE_GH_MODE=success PATH="$fakebin:$PATH" \
+  bash "$script" github/awesome-copilot git-commit --agent github-copilot --scope project
+
+if [ "$(grep -c '^call:' "$log")" -ne 1 ]; then
+  echo "::error::expected successful install to call gh once"
+  cat "$log"
+  exit 1
+fi
+if grep -q -- '--force' "$log"; then
+  echo "::error::expected successful install to avoid --force"
+  cat "$log"
+  exit 1
+fi
+echo "immediate success does not retry"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -956,6 +956,22 @@ jobs:
 
           rm -rf "$okbin" "$badver" "$noskill" "$win" "$badarch" "$oldskill" "$nounzip"
 
+  # ── .scripts/gh-skill-install.sh (shared idempotent install helper) ─
+  test-gh-skill-install-script:
+    if: "${{ !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: 📑 Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: 🧪 Exercise gh-skill-install.sh (already-installed recovery)
+        shell: bash
+        run: bash .github/tests/gh-skill-install-script.sh
+
   # ── update-agent-skills ───────────────────────────────────
   test-update-agent-skills-noop:
     if: "${{ !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
@@ -2259,6 +2275,7 @@ jobs:
       - test-setup-ksail-cli
       - test-retry-script
       - test-ensure-gh-skill-script
+      - test-gh-skill-install-script
       - test-update-agent-skills-noop
       - test-update-agent-skills-dry-run
       - test-update-agent-skills-missing-dir
@@ -2337,6 +2354,7 @@ jobs:
             ${{ needs.test-setup-ksail-cli.result }}
             ${{ needs.test-retry-script.result }}
             ${{ needs.test-ensure-gh-skill-script.result }}
+            ${{ needs.test-gh-skill-install-script.result }}
             ${{ needs.test-update-agent-skills-noop.result }}
             ${{ needs.test-update-agent-skills-dry-run.result }}
             ${{ needs.test-update-agent-skills-missing-dir.result }}

--- a/.scripts/gh-skill-install.sh
+++ b/.scripts/gh-skill-install.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Idempotent wrapper around `gh skill install`.
+#
+# A transient GitHub API failure can leave the target skill directory present
+# even though `gh skill install` exits non-zero. A plain retry then fails with
+# "skills already installed" instead of retrying the incomplete install. Recover
+# only from that exact state by retrying once with --force; preserve every other
+# failure as-is so real install errors still fail the calling check.
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+  echo "::error::gh-skill-install.sh: no install arguments given" >&2
+  exit 2
+fi
+
+has_force=false
+for arg in "$@"; do
+  if [ "$arg" = "--force" ]; then
+    has_force=true
+    break
+  fi
+done
+
+stdout=$(mktemp)
+stderr=$(mktemp)
+out=$(mktemp)
+trap 'rm -f "$stdout" "$stderr" "$out"' EXIT
+
+if gh skill install "$@" >"$stdout" 2>"$stderr"; then
+  cat "$stdout"
+  cat "$stderr" >&2
+  exit 0
+else
+  status=$?
+fi
+
+cat "$stdout"
+cat "$stderr" >&2
+cat "$stdout" "$stderr" >"$out"
+
+if [ "$has_force" = false ] && grep -Eq '^skills already installed: .*\(use --force to overwrite\)' "$out"; then
+  echo "::warning::gh skill install reported an already-installed skill; retrying once with --force." >&2
+  gh skill install "$@" --force
+  exit $?
+fi
+
+exit "$status"

--- a/setup-agent-skills/action.yaml
+++ b/setup-agent-skills/action.yaml
@@ -62,6 +62,7 @@ runs:
         # check (reliability pillar, #247). Same shared helper + path resolution as
         # the gh bootstrap above.
         retry() { bash "${GITHUB_ACTION_PATH}/../.scripts/retry.sh" "$@"; }
+        install_script="${GITHUB_ACTION_PATH}/../.scripts/gh-skill-install.sh"
 
         if [ -z "${INPUT_SKILLS//[[:space:]]/}" ]; then
           echo "::error::'skills' input is empty. Provide a newline-separated list of '<owner/repo> <skill>[@pin]' entries."
@@ -106,10 +107,10 @@ runs:
           for agent in "${agents[@]}"; do
             if [ -n "$pin" ]; then
               echo "Installing ${src}/${name}@${pin} (agent=${agent}, scope=${INPUT_SCOPE})..."
-              retry gh skill install "$src" "$name" --agent "$agent" --scope "$INPUT_SCOPE" --pin "$pin"
+              retry bash "$install_script" "$src" "$name" --agent "$agent" --scope "$INPUT_SCOPE" --pin "$pin"
             else
               echo "Installing ${src}/${name} (agent=${agent}, scope=${INPUT_SCOPE})..."
-              retry gh skill install "$src" "$name" --agent "$agent" --scope "$INPUT_SCOPE"
+              retry bash "$install_script" "$src" "$name" --agent "$agent" --scope "$INPUT_SCOPE"
             fi
           done
           # Record each skill once, regardless of how many agents it was installed for.


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Summary
- add an idempotent `gh skill install` wrapper used by `setup-agent-skills`
- recover only the `skills already installed ... use --force` retry state by rerunning once with `--force`
- add a regression test for the partial-install retry path and wire it into `CI - Required Checks`

## Why
The latest `main` CI run failed after a transient GitHub API 403 left a skill marked installed; the retry then failed with `skills already installed` instead of recovering.

## Validation
- `bash .github/tests/gh-skill-install-script.sh`
- `bash -n .scripts/gh-skill-install.sh .scripts/retry.sh .scripts/ensure-gh-skill.sh`
- `bash -n .github/tests/gh-skill-install-script.sh`
- `yamllint .github/workflows/ci.yaml setup-agent-skills/action.yaml`
- `actionlint -ignore 'unknown permission scope "code-quality"' .github/workflows/ci.yaml`\n- `ci-required-checks` needs/job-results parity checked with `yq` + `diff`\n\nRefs: https://github.com/devantler-tech/actions/actions/runs/29030150199