### PR TITLE
fix(create-issues-from-todos): avoid unpinned retry wrapper

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,6 +82,23 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: 🔒 Assert TODO action retries locally
+        shell: bash
+        run: |
+          action_file="$GITHUB_WORKSPACE/create-issues-from-todos/action.yaml"
+          if grep -qF "Wandalen/wretry.action" "$action_file"; then
+            echo "::error::create-issues-from-todos must not depend on the external retry wrapper; it expands to an unpinned nested action ref in consumers with full-SHA policies."
+            exit 1
+          fi
+          grep -qF ".scripts/retry.sh" "$action_file" || {
+            echo "::error::create-issues-from-todos must use the bundled retry helper."
+            exit 1
+          }
+          grep -qF "ghcr.io/alstr/todo-to-issue-action:v5.1.15" "$action_file" || {
+            echo "::error::create-issues-from-todos must keep the pinned todo-to-issue container image floor."
+            exit 1
+          }
+
       - name: 🧪 Run create-issues-from-todos
         uses: ./create-issues-from-todos
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,7 +86,7 @@ jobs:
         shell: bash
         run: |
           action_file="$GITHUB_WORKSPACE/create-issues-from-todos/action.yaml"
-          if grep -qF "Wandalen/wretry.action" "$action_file"; then
+          if grep -Eq '^[[:space:]]*-[[:space:]]*uses:[[:space:]]*Wandalen/wretry\.action@' "$action_file"; then
             echo "::error::create-issues-from-todos must not depend on the external retry wrapper; it expands to an unpinned nested action ref in consumers with full-SHA policies."
             exit 1
           fi

--- a/create-issues-from-todos/action.yaml
+++ b/create-issues-from-todos/action.yaml
@@ -40,14 +40,55 @@ runs:
     # Wrapped in a retry: alstr/todo-to-issue-action does an UNAUTHENTICATED fetch of
     # github/linguist's languages.yml/syntax.json from raw.githubusercontent.com on
     # every run and aborts the whole step on any non-200 (devantler-tech/actions#483)
-    # — a transient CDN 429/5xx must not fail the job outright.
-    - uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
-      with:
-        action: alstr/todo-to-issue-action@37bb7b56e58569ef273b60678048030a7f0c261a # v5.1.15
-        attempt_limit: 3
-        attempt_delay: 5000
-        with: |
-          AUTO_ASSIGN: true
-          CLOSE_ISSUES: true
-          PROJECT: ${{ inputs.project }}
-          PROJECTS_SECRET: ${{ steps.app-token.outputs.token }}
+    # — a transient CDN 429/5xx must not fail the job outright. Keep the retry
+    # local instead of wrapping a docker action with another marketplace action:
+    # some consumers reject the wrapper's unpinned nested implementation ref at
+    # job setup under full-SHA policies.
+    - name: 📝 Create issues from TODOs
+      shell: bash
+      env:
+        INPUT_REPO: ${{ github.repository }}
+        INPUT_BEFORE: ${{ github.event.before || github.base_ref }}
+        INPUT_COMMITS: ${{ toJSON(github.event.commits) }}
+        INPUT_DIFF_URL: ${{ github.event.pull_request.diff_url }}
+        INPUT_SHA: ${{ github.sha }}
+        INPUT_TOKEN: ${{ github.token }}
+        INPUT_CLOSE_ISSUES: "true"
+        INPUT_AUTO_P: "true"
+        INPUT_PROJECT: ${{ inputs.project }}
+        INPUT_PROJECTS_SECRET: ${{ steps.app-token.outputs.token }}
+        INPUT_AUTO_ASSIGN: "true"
+        INPUT_ACTOR: ${{ github.actor }}
+        INPUT_GITHUB_URL: ${{ github.api_url }}
+        INPUT_GITHUB_SERVER_URL: ${{ github.server_url }}
+        INPUT_ESCAPE: "true"
+        INPUT_NO_STANDARD: "false"
+        INPUT_INSERT_ISSUE_URLS: "false"
+        TODO_TO_ISSUE_IMAGE: ghcr.io/alstr/todo-to-issue-action:v5.1.15
+      run: |
+        retry() { bash "${GITHUB_ACTION_PATH}/../.scripts/retry.sh" "$@"; }
+
+        retry docker run --rm \
+          --workdir /github/workspace \
+          --volume "$GITHUB_WORKSPACE:/github/workspace" \
+          --env GITHUB_ACTIONS=true \
+          --env GITHUB_WORKSPACE=/github/workspace \
+          --env CI=true \
+          --env INPUT_REPO \
+          --env INPUT_BEFORE \
+          --env INPUT_COMMITS \
+          --env INPUT_DIFF_URL \
+          --env INPUT_SHA \
+          --env INPUT_TOKEN \
+          --env INPUT_CLOSE_ISSUES \
+          --env INPUT_AUTO_P \
+          --env INPUT_PROJECT \
+          --env INPUT_PROJECTS_SECRET \
+          --env INPUT_AUTO_ASSIGN \
+          --env INPUT_ACTOR \
+          --env INPUT_GITHUB_URL \
+          --env INPUT_GITHUB_SERVER_URL \
+          --env INPUT_ESCAPE \
+          --env INPUT_NO_STANDARD \
+          --env INPUT_INSERT_ISSUE_URLS \
+          "$TODO_TO_ISSUE_IMAGE"


### PR DESCRIPTION
## Summary

- replace the external `Wandalen/wretry.action` wrapper with the bundled `.scripts/retry.sh` helper
- run the pinned `ghcr.io/alstr/todo-to-issue-action:v5.1.15` container directly under retry
- add a CI regression guard so the TODO composite does not reintroduce the wrapper

## Why

`devantler-tech/platform` is currently failing the shared TODO scan at job setup because the retry wrapper expands to an internal `wandalen/wretry.action@v3.8.0_js_action` ref. Consumers that require all actions to be pinned to a full-length commit SHA reject that nested ref before the TODO scan can run.

This keeps the reliability fix from actions#483 while removing the marketplace wrapper that breaks strict full-SHA consumers.

## Validation

- red: local regression guard failed on the existing `Wandalen/wretry.action` use
- green: local regression guard passes after the replacement
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file("create-issues-from-todos/action.yaml"); YAML.load_file(".github/workflows/ci.yaml"); puts "YAML parsed"'`
- `zizmor create-issues-from-todos/action.yaml .github/workflows/ci.yaml`

`actionlint` was also run, but it still reports pre-existing repository issues unrelated to this change: the `code-quality` permission scope and `job.workflow_repository` / `job.workflow_sha` contexts.
