### PR TITLE
fix(create-issues-from-todos): preserve retry helper before checkout

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,6 +94,14 @@ jobs:
             echo "::error::create-issues-from-todos must use the bundled retry helper."
             exit 1
           }
+          grep -qF "retry_helper=\"\${RUNNER_TEMP}/devantler-actions-retry.sh\"" "$action_file" || {
+            echo "::error::create-issues-from-todos must preserve retry.sh outside the action checkout."
+            exit 1
+          }
+          grep -qF "retry() { bash \"\${RUNNER_TEMP}/devantler-actions-retry.sh\" \"\$@\"; }" "$action_file" || {
+            echo "::error::create-issues-from-todos must invoke the preserved retry helper."
+            exit 1
+          }
           grep -qF "ghcr.io/alstr/todo-to-issue-action:v5.1.15" "$action_file" || {
             echo "::error::create-issues-from-todos must keep the pinned todo-to-issue container image floor."
             exit 1

--- a/create-issues-from-todos/action.yaml
+++ b/create-issues-from-todos/action.yaml
@@ -30,6 +30,12 @@ runs:
         # to organization projects instead of inheriting the App installation's
         # blanket permissions (zizmor github-app).
         permission-organization-projects: write
+    - name: 🧰 Preserve retry helper
+      shell: bash
+      run: |
+        retry_helper="${RUNNER_TEMP}/devantler-actions-retry.sh"
+        cp "${GITHUB_ACTION_PATH}/../.scripts/retry.sh" "$retry_helper"
+        chmod +x "$retry_helper"
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
@@ -66,7 +72,7 @@ runs:
         INPUT_INSERT_ISSUE_URLS: "false"
         TODO_TO_ISSUE_IMAGE: ghcr.io/alstr/todo-to-issue-action:v5.1.15
       run: |
-        retry() { bash "${GITHUB_ACTION_PATH}/../.scripts/retry.sh" "$@"; }
+        retry() { bash "${RUNNER_TEMP}/devantler-actions-retry.sh" "$@"; }
 
         retry docker run --rm \
           --workdir /github/workspace \


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

The v9.0.6 `create-issues-from-todos` action resolves its retry helper from the
action checkout. Its later same-commit internal checkout cleans that directory,
so the wrapper fails with `retry.sh: No such file or directory` before the TODO
container can run. This breaks TODO scans in consumers such as go-template.

Fixes #526

## What

- Copy `.scripts/retry.sh` into `RUNNER_TEMP` before the internal checkout.
- Make the copied helper executable and invoke the stable temporary path for the
  retry-wrapped TODO scan.
- Preserve the same inputs, outputs, and retry semantics for existing consumers.

## Validation

- `git diff --check`
- `yamllint create-issues-from-todos/action.yaml .github/workflows/scan-for-todo-comments.yaml`
- Ruby YAML parsing for both changed workflow/action files
- `zizmor --config zizmor.yml .github/workflows/scan-for-todo-comments.yaml create-issues-from-todos/action.yaml`
- Failure-mode simulation that copies the helper, removes the original `.scripts`
  directory, and successfully invokes the temporary copy
- Committed `test-create-issues-from-todos` assertions that require both the
  stable `RUNNER_TEMP` copy and its retry invocation
- Current PR CI, including `test-create-issues-from-todos`, is green

`actionlint .github/workflows/scan-for-todo-comments.yaml` remains blocked by the
pre-existing unsupported `job.workflow_repository` and `job.workflow_sha`
contexts; this PR does not change those expressions.

## Downstream plan

After this merges and a patch release is published, bump each TODO consumer to
that exact release SHA. This includes go-template and the newly merged KSail
v9.0.6 pin; platform and homebrew-tap drafts should be refreshed before
promotion if they still reference an older release. Verify each consumer's TODO
workflow after the pin update.

## Notes

The change is additive and backward-compatible. No action inputs or outputs
change.
