### PR TITLE
fix(create-issues-from-todos): stash retry helper so the composite's own checkout can't wipe it

### DIFF
--- a/create-issues-from-todos/action.yaml
+++ b/create-issues-from-todos/action.yaml
@@ -30,6 +30,16 @@ runs:
         # to organization projects instead of inheriting the App installation's
         # blanket permissions (zizmor github-app).
         permission-organization-projects: write
+    # The checkout below re-syncs the workspace, and its git clean deletes the
+    # untracked self-checkout dir the caller placed at ${GITHUB_ACTION_PATH}/..
+    # (that deletion is intended — it hides the actions sources from the scan), but
+    # it also removes the shared .scripts/retry.sh the scan step sources. Copy the
+    # helper OUT of the workspace first (RUNNER_TEMP is never git-cleaned nor mounted
+    # into the scan container) so the retry wrapper still resolves after the checkout
+    # (devantler-tech/actions#526).
+    - name: 🧰 Stash retry helper before the checkout below wipes it
+      shell: bash
+      run: cp "${GITHUB_ACTION_PATH}/../.scripts/retry.sh" "${RUNNER_TEMP}/create-issues-retry.sh"
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
@@ -66,7 +76,7 @@ runs:
         INPUT_INSERT_ISSUE_URLS: "false"
         TODO_TO_ISSUE_IMAGE: ghcr.io/alstr/todo-to-issue-action:v5.1.15
       run: |
-        retry() { bash "${GITHUB_ACTION_PATH}/../.scripts/retry.sh" "$@"; }
+        retry() { bash "${RUNNER_TEMP}/create-issues-retry.sh" "$@"; }
 
         retry docker run --rm \
           --workdir /github/workspace \


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

The `📝 TODOs` workflow is red on `main` across the portfolio — every repo that calls `scan-for-todo-comments.yaml` fails with exit 127 once on v9.0.6. The `create-issues-from-todos` composite is the only shared action that runs its own `actions/checkout`, whose git clean deletes the self-checkout dir (intended — to hide actions' sources from the scan) but also the shared `retry.sh` the scan step needs.

## What

Stash the shared retry helper to `${RUNNER_TEMP}` before that checkout and source it from there. Minimal, scoped to this one action; the shared `.scripts/retry.sh` stays the single source of truth. Restores green TODOs everywhere.

## Follow-up (operational)

After this releases as **v9.0.7**, the pending consumer TODOs-pin bumps (ksail#5995, platform#2553, homebrew-tap#1139) must target v9.0.7 — v9.0.6 carries this break, so promoting those as-is would keep TODOs red.

Fixes #526
