### PR TITLE
docs: record Marketplace distribution policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@ Full detail in [CONTRIBUTING.md](CONTRIBUTING.md). Key rules:
 - **Action type:** Prefer **composite** over JavaScript/Docker
 - **External action pinning:** Pin third-party actions (non-`actions/*`, non-`github/*`, non-`devantler-tech/*`) to commit SHAs with a `# v<version>` comment — enforced by `zizmor.yml`. For a main-tracked dep with no releases, use `# <branch> (no upstream releases)`.
 - **`action.yaml`:** Always set `author: devantler-tech`
+- **Distribution / Marketplace:** Keep this portfolio-first catalogue directly reusable but intentionally unlisted in GitHub Marketplace while it contains multiple subdirectory actions and reusable workflows. Marketplace does not automatically list nested action metadata, so do not add `branding:` blocks as a proxy for publication. Revisit only when an action is extracted into its own single-action repository with an independent release lifecycle.
 
 ## Self-references within this repo (read before referencing one part of the repo from another)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,19 @@ steps:
 
 Prefer **composite actions** over JavaScript or Docker actions unless complexity demands otherwise.
 
+## Distribution and Marketplace
+
+The action suite is portfolio-first and publicly reusable by direct path, but it
+is intentionally not published as a family of GitHub Marketplace listings in its
+current multi-action repository layout. Marketplace publishing requires a root
+`action.yml` or `action.yaml`; metadata in subdirectories is not automatically
+listed. Do not add `branding:` to nested action metadata as a proxy for
+publication.
+
+If an action develops enough independent demand to justify its own repository,
+extract it deliberately and give that single-action repository its own branding,
+release lifecycle, and Marketplace listing.
+
 ## Testing
 
 Every action must have a corresponding test workflow at `.github/workflows/test-<action-name>.yaml` that:

--- a/README.md
+++ b/README.md
@@ -42,6 +42,23 @@ flowchart TD
 | [upload-coverage](upload-coverage/README.md) | Upload a Cobertura coverage report to GitHub Code Quality |
 | [upsert-issue](upsert-issue/README.md) | Create, update, reopen, or close a GitHub issue by title |
 
+### Distribution
+
+This repository is a portfolio-first, publicly reusable catalogue. Consumers call
+an action directly as `devantler-tech/actions/<action-name>@<ref>`; the suite is
+intentionally not published as a family of GitHub Marketplace listings in its
+current multi-action layout.
+
+[GitHub Marketplace publishing requires a root action metadata file](https://docs.github.com/en/actions/how-tos/create-and-publish-actions/publish-in-github-marketplace),
+and action metadata in subdirectories is not automatically listed. This repository
+instead contains multiple subdirectory actions and reusable workflows under one
+release stream, so adding `branding:` to the nested `action.yaml` files would not
+make them independently discoverable and is deliberately omitted.
+
+Revisit Marketplace publication only when an action has enough independent demand
+to justify extraction into its own single-action repository. That repository should
+then carry its own branding and Marketplace release lifecycle.
+
 ## Reusable Workflows
 
 [Reusable workflows](https://docs.github.com/en/actions/how-tos/sharing-automations/reuse-workflows#creating-a-reusable-workflow) are designed to encapsulate common CI/CD patterns that can be shared across multiple repositories. They allow you to define a workflow once and reuse it in the job-scope of other workflows. This reduces duplication and enables building generic workflows for common tasks.


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

The final open pillar in #247 was the distribution decision for this multi-action library. GitHub Marketplace requires an action metadata file at the repository root and does not automatically list actions defined only in subdirectories. This repository intentionally co-locates 16 composite actions and reusable workflows under one release stream, so adding `branding:` to the nested metadata would not provide the proposed discoverability.

## What

- document the suite as a portfolio-first, publicly reusable direct-path catalogue
- record that the current multi-action repository is intentionally not Marketplace-listed
- prohibit nested `branding:` blocks from being added as a publication proxy
- define the revisit trigger: extract a sufficiently independent action into its own repository, then brand and publish that repository

This keeps the existing release and consumption model intact while turning the absence of Marketplace branding into an explicit product decision.

## Validation

- `git diff --check`
- markdownlint on the changed lines (no new findings; whole-file lint still reports pre-existing table/emphasis findings outside this diff)
- verified the linked GitHub Marketplace publishing documentation
- confirmed the current structure remains 16 nested action metadata files, no root action metadata, and zero `branding:` blocks
- independent read-only review: no findings

Fixes #247
