### PR TITLE
fix(auto-merge): restrict privileged workflow to trusted bots

### DIFF
--- a/.github/tests/enable-auto-merge-authors.json
+++ b/.github/tests/enable-auto-merge-authors.json
@@ -1,0 +1,72 @@
+[
+  {
+    "name": "human maintainer",
+    "event_name": "pull_request",
+    "draft": false,
+    "login": "devantler",
+    "eligible": false
+  },
+  {
+    "name": "Dependabot",
+    "event_name": "pull_request",
+    "draft": false,
+    "login": "dependabot[bot]",
+    "eligible": true
+  },
+  {
+    "name": "Renovate",
+    "event_name": "pull_request",
+    "draft": false,
+    "login": "renovate[bot]",
+    "eligible": true
+  },
+  {
+    "name": "GitHub Actions",
+    "event_name": "pull_request",
+    "draft": false,
+    "login": "github-actions[bot]",
+    "eligible": true
+  },
+  {
+    "name": "KSail bot",
+    "event_name": "pull_request",
+    "draft": false,
+    "login": "ksail-bot[bot]",
+    "eligible": true
+  },
+  {
+    "name": "CodeRabbit",
+    "event_name": "pull_request",
+    "draft": false,
+    "login": "coderabbitai[bot]",
+    "eligible": true
+  },
+  {
+    "name": "unknown bot",
+    "event_name": "pull_request",
+    "draft": false,
+    "login": "unknown-automation[bot]",
+    "eligible": false
+  },
+  {
+    "name": "external human",
+    "event_name": "pull_request",
+    "draft": false,
+    "login": "octocat",
+    "eligible": false
+  },
+  {
+    "name": "draft trusted bot",
+    "event_name": "pull_request",
+    "draft": true,
+    "login": "dependabot[bot]",
+    "eligible": false
+  },
+  {
+    "name": "merge group",
+    "event_name": "merge_group",
+    "draft": false,
+    "login": "dependabot[bot]",
+    "eligible": false
+  }
+]

--- a/.github/tests/test-enable-auto-merge-author-gate.sh
+++ b/.github/tests/test-enable-auto-merge-author-gate.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+workflow="${1:-.github/workflows/enable-auto-merge.yaml}"
+fixtures="${2:-.github/tests/enable-auto-merge-authors.json}"
+condition="$(yq -r '.jobs."auto-merge".if' "$workflow")"
+
+status=0
+for required_fragment in \
+  "github.event_name == 'pull_request'" \
+  "!github.event.pull_request.draft" \
+  "github.event.pull_request.user.login"; do
+  if [[ "$condition" != *"$required_fragment"* ]]; then
+    echo "::error file=$workflow::auto-merge job condition is missing: $required_fragment"
+    status=1
+  fi
+done
+
+allowlist_json="$({
+  printf '%s\n' "$condition" |
+    tr -d '[:space:]' |
+    sed -nE "s/.*contains\(fromJSON\('([^']+)'\),github\.event\.pull_request\.user\.login\).*/\1/p"
+} || true)"
+if [[ -z "$allowlist_json" ]] || ! jq -e 'type == "array" and all(.[]; type == "string")' \
+  <<<"$allowlist_json" >/dev/null; then
+  echo "::error file=$workflow::auto-merge job condition must use a JSON trusted-author allowlist"
+  exit 1
+fi
+
+actual_allowlist="$(jq -c 'sort' <<<"$allowlist_json")"
+expected_allowlist="$(jq -c '[.[] | select(.eligible) | .login] | sort' "$fixtures")"
+if [[ "$actual_allowlist" != "$expected_allowlist" ]]; then
+  echo "::error file=$workflow::trusted-author allowlist differs from the eligible fixture authors"
+  echo "expected: $expected_allowlist"
+  echo "actual:   $actual_allowlist"
+  status=1
+fi
+
+while IFS= read -r fixture; do
+  name="$(jq -r '.name' <<<"$fixture")"
+  event_name="$(jq -r '.event_name' <<<"$fixture")"
+  draft="$(jq -r '.draft' <<<"$fixture")"
+  login="$(jq -r '.login' <<<"$fixture")"
+  expected="$(jq -r '.eligible' <<<"$fixture")"
+  actual=false
+
+  if [[ "$event_name" == "pull_request" && "$draft" == "false" ]] &&
+    jq -e --arg login "$login" 'index($login) != null' <<<"$allowlist_json" >/dev/null; then
+    actual=true
+  fi
+
+  if [[ "$actual" != "$expected" ]]; then
+    echo "::error file=$fixtures::fixture '$name' expected eligible=$expected, got $actual"
+    status=1
+  else
+    echo "fixture '$name': eligible=$actual"
+  fi
+done < <(jq -c '.[]' "$fixtures")
+
+exit "$status"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1777,6 +1777,26 @@ jobs:
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 
+  test-enable-auto-merge-author-gate:
+    if: "${{ !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
+    name: "[Test] Enable Auto-Merge - Author Gate"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: 📑 Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: 🧪 Verify privileged author gate
+        run: bash .github/tests/test-enable-auto-merge-author-gate.sh
+
   test-create-release:
     if: "${{ !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
     name: "[Test] Create Release - Dry Run"
@@ -2323,6 +2343,7 @@ jobs:
       - test-validate-go-project
       - test-run-dotnet-tests-workflow
       - test-enable-auto-merge
+      - test-enable-auto-merge-author-gate
       - test-create-release
       - test-deploy-github-pages
       - test-publish-dotnet-library
@@ -2402,6 +2423,7 @@ jobs:
             ${{ needs.test-validate-go-project.result }}
             ${{ needs.test-run-dotnet-tests-workflow.result }}
             ${{ needs.test-enable-auto-merge.result }}
+            ${{ needs.test-enable-auto-merge-author-gate.result }}
             ${{ needs.test-create-release.result }}
             ${{ needs.test-deploy-github-pages.result }}
             ${{ needs.test-publish-dotnet-library.result }}

--- a/.github/workflows/enable-auto-merge.yaml
+++ b/.github/workflows/enable-auto-merge.yaml
@@ -20,7 +20,15 @@ jobs:
       pull-requests: write
       contents: write
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.draft }}
+    if: >-
+      ${{
+        github.event_name == 'pull_request' &&
+        !github.event.pull_request.draft &&
+        contains(
+          fromJSON('["dependabot[bot]","renovate[bot]","github-actions[bot]","ksail-bot[bot]","coderabbitai[bot]"]'),
+          github.event.pull_request.user.login
+        )
+      }}
 
     steps:
       - name: 🛡️ Harden runner


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant.

## What changed

- restrict the privileged approval and auto-merge job to the five trusted bot logins from the portfolio merge policy
- deny human, external, unknown, draft, and non-pull-request events before GitHub App credentials are generated
- add a table-driven fixture covering every allowed bot and the denied paths
- wire the regression into the required CI aggregate

## Why

The required workflow previously armed auto-merge for every non-draft pull request. That let its GitHub App auto-arm human-authored PRs, bypassing the direct-merge path and its agent-side current-head gate. This PR closes that author-boundary defect.

The separate timing defect remains intentionally out of scope: eligible trusted bots can still be armed before their current-head review and pre-merge surfaces are green. #548 tracks that state-machine change with live proof from KSail #6058.

## Validation

- failing-first author-gate fixture reproduced the missing allowlist
- `bash .github/tests/test-enable-auto-merge-author-gate.sh`
- `yamllint .github/workflows/`
- `actionlint .github/workflows/enable-auto-merge.yaml`
- `zizmor --config zizmor.yml .github/workflows/` (no findings; 109 existing suppressions)
- `shellcheck .github/tests/test-enable-auto-merge-author-gate.sh`
- CI aggregate `needs` and `job-results` parity check
- signed commit verified with `git verify-commit HEAD`

Full-repository `actionlint` still reports the documented pre-existing `code-quality` scope warnings and unsupported `job.workflow_repository` / `job.workflow_sha` context warnings; the changed reusable workflow is clean.

## Rollout

The organization required-workflow ruleset remains unchanged here. `devantler-tech/.github#87` owns repointing it from the archived repository after this author-gate fix lands. Repointing #546 improves the human-PR boundary immediately; #548 must then land before trusted-bot auto-merge satisfies the complete current-head gate.

Fixes #545
Related: #548, devantler-tech/.github#87, devantler-tech/monorepo#2128
