### PR TITLE
fix(auto-merge): restrict the privileged merge workflow to trusted bots

### DIFF
--- a/.github/workflows/enable-auto-merge.yaml
+++ b/.github/workflows/enable-auto-merge.yaml
@@ -20,7 +20,17 @@ jobs:
       pull-requests: write
       contents: write
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.draft }}
+    # Auto-merge is reserved for trusted single-author bots: an App approval
+    # plus --auto on a human-authored PR would satisfy the required-review
+    # gate and merge it on green CI, bypassing the review a human PR must
+    # get first. Human-authored promoted PRs are merged directly instead
+    # (exact-login match; a skipped job satisfies the required workflow the
+    # same way the draft/merge_group skips already do).
+    if: >-
+      ${{ github.event_name == 'pull_request' &&
+          !github.event.pull_request.draft &&
+          contains(fromJSON('["dependabot[bot]", "renovate[bot]", "github-actions[bot]", "ksail-bot[bot]"]'),
+                   github.event.pull_request.user.login) }}
 
     steps:
       - name: 🛡️ Harden runner

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ jobs:
 <details>
 <summary>Click to expand</summary>
 
-[.github/workflows/enable-auto-merge.yaml](.github/workflows/enable-auto-merge.yaml) is a workflow that approves and enables auto-merge on pull requests from trusted bots and maintainers.
+[.github/workflows/enable-auto-merge.yaml](.github/workflows/enable-auto-merge.yaml) is a workflow that approves and enables auto-merge on non-draft pull requests authored by trusted single-author bots (dependabot, renovate, github-actions, ksail-bot). Human-authored PRs are excluded by design — they are merged directly after review instead, so the App approval can never satisfy a human PR's required-review gate.
 
 #### Usage
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why
The shared `enable-auto-merge.yaml` App-approves and arms `--auto` on **every** non-draft PR, including human-authored ones — so a human PR could merge on green CI with the App's own approval satisfying its required-review gate, bypassing review entirely (live case: ksail#6042 auto-merged with no fresh green review).

## What
The job now runs only for the four trusted single-author bot logins (exact match: dependabot, renovate, github-actions, ksail-bot); skipped jobs satisfy the required workflow exactly like the existing draft/merge_group skips. Human-authored promoted PRs get merged directly after review instead.

**Operational note:** goreleaser's homebrew-tap cask PRs are `devantler`-authored, so after this lands they no longer self-merge on promotion — the hourly engineer sweep merges them directly once promoted and green. If you'd rather keep cask self-merge, say so and I'll scope an allowance for `goreleaser/*` head branches instead.

Fixes #545

@codex review