### PR TITLE
fix(validate-go-project): raise govulncheck timeout to survive cold-cache scans

### DIFF
--- a/.github/tests/test-govulncheck-timeout.sh
+++ b/.github/tests/test-govulncheck-timeout.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Guards the govulncheck job's runtime safety controls in
+# validate-go-project.yaml (actions#593). A cold-cache scan of a large module
+# runs ~14 min and a clean run crossed the old 15-min bound, so Actions
+# cancelled a passing scan and failed the required check. The floor below keeps
+# headroom over that observed runtime while preserving a *finite* ceiling and
+# the GOMEMLIMIT heap cap — so neither control can silently regress.
+
+set -euo pipefail
+
+workflow="${1:-.github/workflows/validate-go-project.yaml}"
+min_timeout="${2:-20}"
+
+status=0
+
+timeout="$(yq -r '.jobs.govulncheck."timeout-minutes" // ""' "$workflow")"
+if [[ -z "$timeout" || "$timeout" == "null" ]]; then
+  echo "::error file=$workflow::govulncheck job must set a finite timeout-minutes (found none)"
+  status=1
+elif ((timeout < min_timeout)); then
+  echo "::error file=$workflow::govulncheck timeout-minutes must be >= $min_timeout to survive a cold-cache scan (actions#593); got $timeout"
+  status=1
+fi
+
+gomemlimit="$(yq -r '.jobs.govulncheck.env.GOMEMLIMIT // ""' "$workflow")"
+if [[ -z "$gomemlimit" || "$gomemlimit" == "null" ]]; then
+  echo "::error file=$workflow::govulncheck job must keep the GOMEMLIMIT heap cap so the GC stays under the host RAM ceiling"
+  status=1
+fi
+
+if [[ "$status" -eq 0 ]]; then
+  echo "govulncheck timeout ($timeout min) and GOMEMLIMIT ($gomemlimit) safety controls present"
+fi
+
+exit "$status"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2059,6 +2059,26 @@ jobs:
           fi
           echo "validate-go-project.yaml pins the self-tested govulncheck action ✅"
 
+  test-govulncheck-timeout:
+    if: "${{ !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
+    name: "[Test] Govulncheck - Timeout & Memory Safety Controls"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: 📄 Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: 🧪 Assert govulncheck keeps a cold-cache-safe finite timeout + GOMEMLIMIT
+        run: bash .github/tests/test-govulncheck-timeout.sh
+
   # ── Zizmor gate failure-mode self-test (generalizes the govulncheck guard; #313) ──
   # scan-for-workflow-vulnerabilities.yaml is a SECURITY GATE: its job is to FAIL a PR
   # when a workflow has a finding. The happy-path test-zizmor job only proves the gate
@@ -2390,6 +2410,7 @@ jobs:
       - test-govulncheck-allowlist-honored
       - test-govulncheck-strict-blocks
       - test-govulncheck-action-lockstep
+      - test-govulncheck-timeout
       - test-zizmor-blocks
       - test-zizmor-action-lockstep
       - test-validate-go-lint-blocks

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2492,6 +2492,7 @@ jobs:
             ${{ needs.test-govulncheck-allowlist-honored.result }}
             ${{ needs.test-govulncheck-strict-blocks.result }}
             ${{ needs.test-govulncheck-action-lockstep.result }}
+            ${{ needs.test-govulncheck-timeout.result }}
             ${{ needs.test-zizmor-blocks.result }}
             ${{ needs.test-zizmor-action-lockstep.result }}
             ${{ needs.test-validate-go-lint-blocks.result }}

--- a/.github/workflows/validate-go-project.yaml
+++ b/.github/workflows/validate-go-project.yaml
@@ -374,7 +374,13 @@ jobs:
     # the Go runtime's heap so the GC reclaims aggressively and stays under the host
     # ceiling instead of OOM-killing; timeout-minutes bounds the worst case to a clear,
     # fast failure rather than a hung runner.
-    timeout-minutes: 15
+    #
+    # 20 (not 15): a cold-cache scan of a large module (no setup-go cache) legitimately
+    # runs ~14 min and a clean run has crossed the old 15-min bound — Actions cancelled
+    # a scan one second after it printed "No blocking vulnerabilities", failing the
+    # required check on a passing result (actions#593). 20 keeps a finite ceiling with
+    # headroom over the observed cold-cache runtime. Guarded by test-govulncheck-timeout.
+    timeout-minutes: 20
     env:
       # ubuntu-latest provides 16 GiB RAM; leave headroom for the OS, the Go toolchain
       # subprocesses and harden-runner.


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why
The reusable Go validation caps its vulnerability scan at 15 minutes. On a cold cache (no build cache), a scan of a large module legitimately runs ~14 minutes — and a clean run has crossed the bound: Actions cancelled a scan one second after it reported "No blocking vulnerabilities", failing the required check on a *passing* result. This flakes the required gate on every consumer repo's PRs.

## What
Raise the scan timeout to 20 minutes (keeping a finite ceiling and the memory-cap safety control). Adds a small structural self-test — wired into the required checks — so the timeout floor and memory cap can't silently regress back into this failure.

Fixes #593