### PR TITLE
fix(auto-merge): complete ineligible required runs

### DIFF
--- a/.github/tests/test-enable-auto-merge-author-gate.sh
+++ b/.github/tests/test-enable-auto-merge-author-gate.sh
@@ -4,15 +4,66 @@ set -euo pipefail
 
 workflow="${1:-.github/workflows/enable-auto-merge.yaml}"
 fixtures="${2:-.github/tests/enable-auto-merge-authors.json}"
-condition="$(yq -r '.jobs."auto-merge".if' "$workflow")"
+condition="$(yq -r '
+  [(.jobs.eligibility.steps // [])[]
+   | select(.id == "classify")
+   | .if // ""]
+  | join("\n")' "$workflow")"
 
 status=0
+
+# A required workflow must complete successfully for ineligible events rather
+# than making its only job SKIPPED. Keep classification in an unconditional,
+# zero-permission job and gate the privileged job on its output.
+eligibility_job_condition="$(yq -r '.jobs.eligibility.if // ""' "$workflow")"
+if [[ -n "$eligibility_job_condition" ]]; then
+  echo "::error file=$workflow::eligibility job must be unconditional so required workflows complete for ineligible events"
+  status=1
+fi
+
+eligibility_permissions="$(yq -r '(.jobs.eligibility.permissions // {}) | keys | join(",")' "$workflow")"
+if [[ -n "$eligibility_permissions" ]]; then
+  echo "::error file=$workflow::eligibility job must not request repository permissions; got: $eligibility_permissions"
+  status=1
+fi
+
+eligibility_output="$(yq -r '.jobs.eligibility.outputs.eligible // ""' "$workflow")"
+# shellcheck disable=SC2016 # GitHub expression is intentionally compared literally.
+if [[ "$eligibility_output" != '${{ steps.classify.outputs.eligible }}' ]]; then
+  echo "::error file=$workflow::eligibility output must be bound to steps.classify.outputs.eligible"
+  status=1
+fi
+
+ineligible_condition="$(yq -r '
+  [(.jobs.eligibility.steps // [])[]
+   | select(.id == "ineligible")
+   | .if // ""]
+  | join("\n")' "$workflow")"
+if [[ "$ineligible_condition" != *"steps.classify.outputs.eligible != 'true'"* ]]; then
+  echo "::error file=$workflow::eligibility job needs an explicit successful ineligible-event step"
+  status=1
+fi
+
+auto_merge_needs="$(yq -r '.jobs."auto-merge".needs // ""' "$workflow")"
+auto_merge_condition="$(yq -r '.jobs."auto-merge".if // ""' "$workflow")"
+if [[ "$auto_merge_needs" != "eligibility" ||
+  "$auto_merge_condition" != *"needs.eligibility.outputs.eligible == 'true'"* ]]; then
+  echo "::error file=$workflow::privileged auto-merge job must depend on the eligibility output"
+  status=1
+fi
+
+eligibility_uses="$(yq -r '[(.jobs.eligibility.steps // [])[] | .uses // ""] | join("\n")' "$workflow")"
+if [[ "$eligibility_uses" == *"create-github-app-token"* ]]; then
+  echo "::error file=$workflow::ineligible events must not mint a privileged GitHub App token"
+  status=1
+fi
+
 for required_fragment in \
   "github.event_name == 'pull_request'" \
   "!github.event.pull_request.draft" \
   "github.event.pull_request.user.login"; do
   if [[ "$condition" != *"$required_fragment"* ]]; then
-    echo "::error file=$workflow::auto-merge job condition is missing: $required_fragment"
+    echo "::error file=$workflow::eligibility classifier is missing: $required_fragment"
     status=1
   fi
 done
@@ -24,7 +75,7 @@ allowlist_json="$({
 } || true)"
 if [[ -z "$allowlist_json" ]] || ! jq -e 'type == "array" and all(.[]; type == "string")' \
   <<<"$allowlist_json" >/dev/null; then
-  echo "::error file=$workflow::auto-merge job condition must use a JSON trusted-author allowlist"
+  echo "::error file=$workflow::eligibility classifier must use a JSON trusted-author allowlist"
   exit 1
 fi
 

--- a/.github/tests/test-enable-auto-merge-author-gate.sh
+++ b/.github/tests/test-enable-auto-merge-author-gate.sh
@@ -55,8 +55,8 @@ fi
 auto_merge_needs="$(yq -r '.jobs."auto-merge".needs // ""' "$workflow")"
 auto_merge_condition="$(yq -r '.jobs."auto-merge".if // ""' "$workflow")"
 if [[ "$auto_merge_needs" != "eligibility" ||
-  "$auto_merge_condition" != *"needs.eligibility.outputs.eligible == 'true'"* ]]; then
-  echo "::error file=$workflow::privileged auto-merge job must depend on the eligibility output"
+  "$auto_merge_condition" != "needs.eligibility.outputs.eligible == 'true'" ]]; then
+  echo "::error file=$workflow::privileged auto-merge job must depend only on an exactly-true eligibility output"
   status=1
 fi
 

--- a/.github/tests/test-enable-auto-merge-author-gate.sh
+++ b/.github/tests/test-enable-auto-merge-author-gate.sh
@@ -27,6 +27,14 @@ if [[ -n "$eligibility_permissions" ]]; then
   status=1
 fi
 
+eligibility_first_uses="$(yq -r '.jobs.eligibility.steps[0].uses // ""' "$workflow")"
+eligibility_first_egress="$(yq -r '.jobs.eligibility.steps[0].with."egress-policy" // ""' "$workflow")"
+if [[ "$eligibility_first_uses" != "step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920" ||
+  "$eligibility_first_egress" != "audit" ]]; then
+  echo "::error file=$workflow::eligibility must begin with the pinned harden-runner action in audit mode"
+  status=1
+fi
+
 eligibility_output="$(yq -r '.jobs.eligibility.outputs.eligible // ""' "$workflow")"
 # shellcheck disable=SC2016 # GitHub expression is intentionally compared literally.
 if [[ "$eligibility_output" != '${{ steps.classify.outputs.eligible }}' ]]; then
@@ -58,33 +66,17 @@ if [[ "$eligibility_uses" == *"create-github-app-token"* ]]; then
   status=1
 fi
 
-for required_fragment in \
-  "github.event_name == 'pull_request'" \
-  "!github.event.pull_request.draft" \
-  "github.event.pull_request.user.login"; do
-  if [[ "$condition" != *"$required_fragment"* ]]; then
-    echo "::error file=$workflow::eligibility classifier is missing: $required_fragment"
-    status=1
-  fi
-done
-
-allowlist_json="$({
-  printf '%s\n' "$condition" |
-    tr -d '[:space:]' |
-    sed -nE "s/.*contains\(fromJSON\('([^']+)'\),github\.event\.pull_request\.user\.login\).*/\1/p"
-} || true)"
-if [[ -z "$allowlist_json" ]] || ! jq -e 'type == "array" and all(.[]; type == "string")' \
-  <<<"$allowlist_json" >/dev/null; then
-  echo "::error file=$workflow::eligibility classifier must use a JSON trusted-author allowlist"
-  exit 1
-fi
-
-actual_allowlist="$(jq -c 'sort' <<<"$allowlist_json")"
-expected_allowlist="$(jq -c '[.[] | select(.eligible) | .login] | sort' "$fixtures")"
-if [[ "$actual_allowlist" != "$expected_allowlist" ]]; then
-  echo "::error file=$workflow::trusted-author allowlist differs from the eligible fixture authors"
-  echo "expected: $expected_allowlist"
-  echo "actual:   $actual_allowlist"
+# Match the complete classifier shape rather than checking that a few strings
+# occur somewhere. This proves each allowlist is attached to the correct event
+# actor and rejects extra OR branches that could bypass the privileged gate.
+allowlist_json="$(jq -c '[.[] | select(.eligible) | .login]' "$fixtures")"
+reviewers_json='["coderabbitai[bot]","chatgpt-codex-connector[bot]"]'
+normalized_condition="$(tr -d '[:space:]' <<<"$condition")"
+expected_condition="\${{(github.event_name=='pull_request'&&!github.event.pull_request.draft&&contains(fromJSON('$allowlist_json'),github.event.pull_request.user.login))||(github.event_name=='pull_request_review'&&contains(fromJSON('$reviewers_json'),github.event.review.user.login)&&!github.event.pull_request.draft&&contains(fromJSON('$allowlist_json'),github.event.pull_request.user.login))||(github.event_name=='issue_comment'&&github.event.issue.pull_request&&github.event.issue.state=='open'&&contains(fromJSON('$reviewers_json'),github.event.comment.user.login)&&contains(fromJSON('$allowlist_json'),github.event.issue.user.login))}}"
+if [[ "$normalized_condition" != "$expected_condition" ]]; then
+  echo "::error file=$workflow::eligibility classifier must exactly preserve the pull_request, pull_request_review, and issue_comment trust branches"
+  echo "expected: $expected_condition"
+  echo "actual:   $normalized_condition"
   status=1
 fi
 

--- a/.github/tests/test-enable-auto-merge-pentad-gate.sh
+++ b/.github/tests/test-enable-auto-merge-pentad-gate.sh
@@ -121,8 +121,14 @@ classifier_condition="$(yq -r '
    | select(.id == "classify")
    | .if // ""]
   | join("\n")' "$workflow")"
-if [[ "$(grep -oF 'chatgpt-codex-connector[bot]' <<<"$classifier_condition" | wc -l | tr -d ' ')" -lt 2 ]]; then
-  echo "::error file=$workflow::pull_request_review runs must include chatgpt-codex-connector[bot] so findings actively disarm"
+normalized_classifier="$(tr -d '[:space:]' <<<"$classifier_condition")"
+reviewers_json='["coderabbitai[bot]","chatgpt-codex-connector[bot]"]'
+review_branch="github.event_name=='pull_request_review'&&contains(fromJSON('$reviewers_json'),github.event.review.user.login)"
+comment_branch="github.event_name=='issue_comment'&&github.event.issue.pull_request&&github.event.issue.state=='open'&&contains(fromJSON('$reviewers_json'),github.event.comment.user.login)"
+if [[ "$normalized_classifier" != *"$review_branch"* ||
+  "$normalized_classifier" != *"$comment_branch"* ||
+  "$(grep -oF 'chatgpt-codex-connector[bot]' <<<"$normalized_classifier" | wc -l | tr -d ' ')" -ne 2 ]]; then
+  echo "::error file=$workflow::both reviewer-driven branches must bind CodeRabbit and Codex to their event-specific actor"
   status=1
 fi
 

--- a/.github/tests/test-enable-auto-merge-pentad-gate.sh
+++ b/.github/tests/test-enable-auto-merge-pentad-gate.sh
@@ -113,10 +113,15 @@ if [[ "$documented_review_types" != *"edited"* ]]; then
 fi
 
 # Codex findings are submitted as pull-request reviews, not issue comments.
-# The job must therefore re-evaluate for both supported reviewer bots; parsing
-# Codex review objects is ineffective if their submitted event never runs it.
-job_condition="$(yq -r '.jobs."auto-merge".if // ""' "$workflow")"
-if [[ "$(grep -oF 'chatgpt-codex-connector[bot]' <<<"$job_condition" | wc -l | tr -d ' ')" -lt 2 ]]; then
+# The classifier must therefore re-evaluate for both supported reviewer bots;
+# parsing Codex review objects is ineffective if their submitted event never
+# reaches the privileged job.
+classifier_condition="$(yq -r '
+  [(.jobs.eligibility.steps // [])[]
+   | select(.id == "classify")
+   | .if // ""]
+  | join("\n")' "$workflow")"
+if [[ "$(grep -oF 'chatgpt-codex-connector[bot]' <<<"$classifier_condition" | wc -l | tr -d ' ')" -lt 2 ]]; then
   echo "::error file=$workflow::pull_request_review runs must include chatgpt-codex-connector[bot] so findings actively disarm"
   status=1
 fi

--- a/.github/workflows/enable-auto-merge.yaml
+++ b/.github/workflows/enable-auto-merge.yaml
@@ -55,6 +55,11 @@ jobs:
     outputs:
       eligible: ${{ steps.classify.outputs.eligible }}
     steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
       - name: 🔎 Classify privileged auto-merge trigger
         id: classify
         if: >-

--- a/.github/workflows/enable-auto-merge.yaml
+++ b/.github/workflows/enable-auto-merge.yaml
@@ -45,7 +45,66 @@ on:
 permissions: {}
 
 jobs:
+  # Required-workflow rules treat a workflow whose only job is SKIPPED as
+  # unsatisfied. Classify every trigger in an unconditional, unprivileged job
+  # so human, draft, external-author, and merge-group runs complete green as a
+  # deliberate no-op while the privileged path remains bot-only.
+  eligibility:
+    permissions: {}
+    runs-on: ubuntu-latest
+    outputs:
+      eligible: ${{ steps.classify.outputs.eligible }}
+    steps:
+      - name: 🔎 Classify privileged auto-merge trigger
+        id: classify
+        if: >-
+          ${{
+            (
+              github.event_name == 'pull_request' &&
+              !github.event.pull_request.draft &&
+              contains(
+                fromJSON('["dependabot[bot]","renovate[bot]","github-actions[bot]","ksail-bot[bot]","coderabbitai[bot]"]'),
+                github.event.pull_request.user.login
+              )
+            ) ||
+            (
+              github.event_name == 'pull_request_review' &&
+              contains(
+                fromJSON('["coderabbitai[bot]","chatgpt-codex-connector[bot]"]'),
+                github.event.review.user.login
+              ) &&
+              !github.event.pull_request.draft &&
+              contains(
+                fromJSON('["dependabot[bot]","renovate[bot]","github-actions[bot]","ksail-bot[bot]","coderabbitai[bot]"]'),
+                github.event.pull_request.user.login
+              )
+            ) ||
+            (
+              github.event_name == 'issue_comment' &&
+              github.event.issue.pull_request &&
+              github.event.issue.state == 'open' &&
+              contains(
+                fromJSON('["coderabbitai[bot]","chatgpt-codex-connector[bot]"]'),
+                github.event.comment.user.login
+              ) &&
+              contains(
+                fromJSON('["dependabot[bot]","renovate[bot]","github-actions[bot]","ksail-bot[bot]","coderabbitai[bot]"]'),
+                github.event.issue.user.login
+              )
+            )
+          }}
+        run: echo "eligible=true" >> "$GITHUB_OUTPUT"
+
+      - name: ✅ Complete ineligible required-workflow run
+        id: ineligible
+        if: steps.classify.outputs.eligible != 'true'
+        run: >-
+          echo "::notice::This event is not eligible for privileged bot auto-merge;
+          completing the required workflow as a safe no-op."
+
   auto-merge:
+    needs: eligibility
+    if: needs.eligibility.outputs.eligible == 'true'
     # Legacy documented minimum ONLY — a called workflow's GITHUB_TOKEN
     # permissions must be a subset of what every caller grants (they can only
     # be downgraded, never elevated), so adding scopes here would fail
@@ -63,42 +122,6 @@ jobs:
       group: enable-auto-merge-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
       cancel-in-progress: false
     runs-on: ubuntu-latest
-    if: >-
-      ${{
-        (
-          github.event_name == 'pull_request' &&
-          !github.event.pull_request.draft &&
-          contains(
-            fromJSON('["dependabot[bot]","renovate[bot]","github-actions[bot]","ksail-bot[bot]","coderabbitai[bot]"]'),
-            github.event.pull_request.user.login
-          )
-        ) ||
-        (
-          github.event_name == 'pull_request_review' &&
-          contains(
-            fromJSON('["coderabbitai[bot]","chatgpt-codex-connector[bot]"]'),
-            github.event.review.user.login
-          ) &&
-          !github.event.pull_request.draft &&
-          contains(
-            fromJSON('["dependabot[bot]","renovate[bot]","github-actions[bot]","ksail-bot[bot]","coderabbitai[bot]"]'),
-            github.event.pull_request.user.login
-          )
-        ) ||
-        (
-          github.event_name == 'issue_comment' &&
-          github.event.issue.pull_request &&
-          github.event.issue.state == 'open' &&
-          contains(
-            fromJSON('["coderabbitai[bot]","chatgpt-codex-connector[bot]"]'),
-            github.event.comment.user.login
-          ) &&
-          contains(
-            fromJSON('["dependabot[bot]","renovate[bot]","github-actions[bot]","ksail-bot[bot]","coderabbitai[bot]"]'),
-            github.event.issue.user.login
-          )
-        )
-      }}
 
     steps:
       - name: 🛡️ Harden runner


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer (Codex instance)

## Problem

After the organization required `enable-auto-merge.yaml`, every human-authored PR became unmergeable: the workflow intentionally gates its only job to trusted bots, and GitHub does not accept an all-skipped required workflow.

This is the repository root fix for the portfolio-wide blocker recorded in `devantler-tech/monorepo#2184`.

## Change

- Add an unconditional, zero-permission eligibility job so every required-workflow run has an explicit successful path.
- Keep the existing trusted-author/reviewer expression as the classifier.
- Run the privileged App-token/approval/auto-merge job only when that classifier returns `true`.
- Complete human, draft, external-author, unsupported-review, and merge-group events as a safe no-op without minting an App token.

## Safety

- Trusted-bot arming behavior and the fail-closed pentad/disarm steps are unchanged.
- Human and external authors remain ineligible for privileged auto-merge.
- The classifier job requests no repository permissions and checks out no code.

## Validation

- RED: the updated author-gate and pentad tests failed against `main` because the unconditional classifier did not exist.
- GREEN: `bash .github/tests/test-enable-auto-merge-author-gate.sh`.
- GREEN: `bash .github/tests/test-enable-auto-merge-pentad-gate.sh` (all 53 gate fixtures).
- `shellcheck` on both changed test scripts.
- `yamllint` on the changed workflow and CI wiring.
- `actionlint` on the changed workflow with only the two documented `job.workflow_*` parser gaps ignored.
- `zizmor --config zizmor.yml` on the changed workflow and CI wiring: no findings.
- `git diff --check`.
- Independent review: no P0/P1 functional or security concern.

Part of devantler-tech/monorepo#2184.

The parent remains open until this lands and a currently blocked promoted human PR proves the required-workflow rollout end to end.
