### PR TITLE
docs(codeql): correct the stale advanced-setup rationale

### DIFF
--- a/.github/workflows/active-codeql.yaml
+++ b/.github/workflows/active-codeql.yaml
@@ -1,9 +1,14 @@
 name: 🔍 CodeQL
 
-# Advanced setup (replaces CodeQL default setup) so a custom config can exclude
-# the actions/unpinned-tag query that duplicates the zizmor unpinned-uses gate.
-# See .github/codeql/codeql-config.yml. CodeQL default setup must be DISABLED for
-# this to run (the two are mutually exclusive).
+# Advanced setup (replaces CodeQL default setup), running the same extended suite
+# with NO query exclusions — see .github/codeql/codeql-config.yml.
+#
+# The actions/unpinned-tag exclusion that originally justified this setup was
+# reverted in #426, once first-party self-references stopped being tag-pinned.
+# Advanced setup is retained only because default setup is disabled in the repo
+# settings (the two are mutually exclusive); returning to default setup is an
+# equivalent settings-side alternative. CodeQL default setup must stay DISABLED
+# for this to run.
 
 on:
   push:

--- a/.github/workflows/active-codeql.yaml
+++ b/.github/workflows/active-codeql.yaml
@@ -4,7 +4,7 @@ name: 🔍 CodeQL
 # with NO query exclusions — see .github/codeql/codeql-config.yml.
 #
 # The actions/unpinned-tag exclusion that originally justified this setup was
-# reverted in #426, once first-party self-references stopped being tag-pinned.
+# reverted in #541, once first-party self-references stopped being tag-pinned.
 # Advanced setup is retained only because default setup is disabled in the repo
 # settings (the two are mutually exclusive); returning to default setup is an
 # equivalent settings-side alternative. CodeQL default setup must stay DISABLED


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

`active-codeql.yaml`'s header still says the custom CodeQL config exists "so a custom config can exclude the actions/unpinned-tag query". It doesn't — that exclusion was reverted in #426, and `codeql-config.yml` now runs the extended suite with **no** query exclusions and says so explicitly.

So the two files contradict each other, and the workflow's stated reason for existing is no longer true. Anyone reading it goes looking for an exclusion that isn't there.

## What

Corrects the header to state the actual reason advanced setup is retained: default setup is disabled in the repo settings, and the two are mutually exclusive.

Comment-only — no behaviour change.

Found while verifying #426, which I'm closing as complete.
