### PR TITLE
fix(release): disable issue notification hooks

### DIFF
--- a/.github/tests/test-create-release-config.sh
+++ b/.github/tests/test-create-release-config.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+workflow="$repo_root/.github/workflows/create-release.yaml"
+
+if ! grep -qF \
+  'run: npx semantic-release@25.0.3 --success false --fail false' "$workflow"; then
+  echo "create-release must disable semantic-release success and fail hooks" >&2
+  exit 1
+fi
+
+if ! grep -qF 'permission-contents: write' "$workflow"; then
+  echo "create-release must retain contents:write for tags and releases" >&2
+  exit 1
+fi
+
+if grep -Eq 'permission-(issues|pull-requests):' "$workflow"; then
+  echo "create-release must not request issue or pull-request write access" >&2
+  exit 1
+fi
+
+echo "semantic-release issue side effects are disabled at least privilege"

--- a/.github/tests/test-create-release-config.sh
+++ b/.github/tests/test-create-release-config.sh
@@ -4,21 +4,49 @@ set -euo pipefail
 
 repo_root="$(git rev-parse --show-toplevel)"
 workflow="$repo_root/.github/workflows/create-release.yaml"
+ci="$repo_root/.github/workflows/ci.yaml"
 
-if ! grep -qF \
-  'run: npx semantic-release@25.0.3 --success false --fail false' "$workflow"; then
-  echo "create-release must disable semantic-release success and fail hooks" >&2
+input_default="$(yq -r '.on.workflow_call.inputs."disable-issue-side-effects".default' "$workflow")"
+input_type="$(yq -r '.on.workflow_call.inputs."disable-issue-side-effects".type' "$workflow")"
+if [[ "$input_default" != "false" || "$input_type" != "boolean" ]]; then
+  echo "create-release must keep issue-side-effect suppression opt-in" >&2
   exit 1
 fi
 
-if ! grep -qF 'permission-contents: write' "$workflow"; then
+release_run="$(
+  yq -r '.jobs.release.steps[] | select(.name == "🎉 Release") | .run' "$workflow"
+)"
+expected_run="npx semantic-release@25.0.3 \${{ inputs.disable-issue-side-effects && '--success false --fail false' || '' }} \${{ inputs.dry-run && '--dry-run' || '' }}"
+if [[ "$release_run" != "$expected_run" ]]; then
+  echo "create-release must disable semantic-release success and fail hooks when opted in" >&2
+  exit 1
+fi
+
+contents_permission="$(
+  yq -r '.jobs.release.steps[] | select(.id == "app-token") | .with."permission-contents"' "$workflow"
+)"
+if [[ "$contents_permission" != "write" ]]; then
   echo "create-release must retain contents:write for tags and releases" >&2
   exit 1
 fi
 
-if grep -Eq 'permission-(issues|pull-requests):' "$workflow"; then
-  echo "create-release must not request issue or pull-request write access" >&2
+issues_permission="$(
+  yq -r '.jobs.release.steps[] | select(.id == "app-token") | .with."permission-issues"' "$workflow"
+)"
+prs_permission="$(
+  yq -r '.jobs.release.steps[] | select(.id == "app-token") | .with."permission-pull-requests"' "$workflow"
+)"
+expected_issues="\${{ !inputs.disable-issue-side-effects && 'write' || '' }}"
+if [[ "$issues_permission" != "$expected_issues" || "$prs_permission" != "$expected_issues" ]]; then
+  echo "create-release must drop issue and pull-request write access only when opted in" >&2
   exit 1
 fi
 
-echo "semantic-release issue side effects are disabled at least privilege"
+off_state="$(yq -r '.jobs."test-create-release".with."disable-issue-side-effects" // "unset"' "$ci")"
+on_state="$(yq -r '.jobs."test-create-release-no-issue-side-effects".with."disable-issue-side-effects"' "$ci")"
+if [[ "$off_state" != "unset" || "$on_state" != "true" ]]; then
+  echo "create-release CI must exercise the default and opted-in states" >&2
+  exit 1
+fi
+
+echo "semantic-release issue side effects are opt-in disabled at least privilege"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1839,6 +1839,16 @@ jobs:
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 
+  test-create-release-no-issue-side-effects:
+    if: "${{ !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
+    name: "[Test] Create Release - No Issue Side Effects"
+    uses: ./.github/workflows/create-release.yaml
+    with:
+      disable-issue-side-effects: true
+      dry-run: true
+    secrets:
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+
   test-create-release-config:
     if: "${{ !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
     name: "[Test] Create Release - Least Privilege"
@@ -2420,6 +2430,7 @@ jobs:
       - test-enable-auto-merge-pentad-gate
       - test-create-release
       - test-create-release-config
+      - test-create-release-no-issue-side-effects
       - test-deploy-github-pages
       - test-publish-dotnet-library
       - test-publish-app
@@ -2503,6 +2514,7 @@ jobs:
             ${{ needs.test-enable-auto-merge-pentad-gate.result }}
             ${{ needs.test-create-release.result }}
             ${{ needs.test-create-release-config.result }}
+            ${{ needs.test-create-release-no-issue-side-effects.result }}
             ${{ needs.test-deploy-github-pages.result }}
             ${{ needs.test-publish-dotnet-library.result }}
             ${{ needs.test-publish-app.result }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1839,6 +1839,26 @@ jobs:
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 
+  test-create-release-config:
+    if: "${{ !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
+    name: "[Test] Create Release - Least Privilege"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: 📑 Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: 🧪 Verify issue side effects stay disabled
+        run: bash .github/tests/test-create-release-config.sh
+
   test-deploy-github-pages:
     if: "${{ !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
     name: "[Test] Deploy GitHub Pages - Dry Run"
@@ -2399,6 +2419,7 @@ jobs:
       - test-enable-auto-merge-author-gate
       - test-enable-auto-merge-pentad-gate
       - test-create-release
+      - test-create-release-config
       - test-deploy-github-pages
       - test-publish-dotnet-library
       - test-publish-app
@@ -2481,6 +2502,7 @@ jobs:
             ${{ needs.test-enable-auto-merge-author-gate.result }}
             ${{ needs.test-enable-auto-merge-pentad-gate.result }}
             ${{ needs.test-create-release.result }}
+            ${{ needs.test-create-release-config.result }}
             ${{ needs.test-deploy-github-pages.result }}
             ${{ needs.test-publish-dotnet-library.result }}
             ${{ needs.test-publish-app.result }}

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -29,11 +29,10 @@ jobs:
         with:
           client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          # Least-privilege token scope for semantic-release: publish releases/tags
-          # (contents) and comment on released issues/PRs (issues, pull-requests).
+          # semantic-release only publishes tags and GitHub Releases. Its optional
+          # success/fail notification hooks are disabled below, so issue and pull-
+          # request write access would be unnecessary standing privilege.
           permission-contents: write
-          permission-issues: write
-          permission-pull-requests: write
 
       - name: 📑 Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -48,6 +47,9 @@ jobs:
           node-version: 22
 
       - name: 🎉 Release
-        run: npx semantic-release@25.0.3 ${{ inputs.dry-run && '--dry-run' || '' }}
+        # GitHub already closes local issues from merge keywords. Disable the
+        # nonessential notification hooks so a bare issue reference intended for
+        # another repository cannot turn an otherwise-published release red.
+        run: npx semantic-release@25.0.3 --success false --fail false ${{ inputs.dry-run && '--dry-run' || '' }}
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -2,6 +2,11 @@ name: 🎉 Create Release
 on:
   workflow_call:
     inputs:
+      disable-issue-side-effects:
+        description: "Disable semantic-release success/fail hooks and their issue/PR permissions"
+        required: false
+        default: false
+        type: boolean
       dry-run:
         description: "Run semantic-release in dry-run mode (no tags, releases, or publishes)"
         required: false
@@ -29,10 +34,11 @@ jobs:
         with:
           client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          # semantic-release only publishes tags and GitHub Releases. Its optional
-          # success/fail notification hooks are disabled below, so issue and pull-
-          # request write access would be unnecessary standing privilege.
+          # Keep existing notification-hook permissions by default for compatibility.
+          # Opted-in callers omit them alongside the disabled hooks below.
           permission-contents: write
+          permission-issues: ${{ !inputs.disable-issue-side-effects && 'write' || '' }}
+          permission-pull-requests: ${{ !inputs.disable-issue-side-effects && 'write' || '' }}
 
       - name: 📑 Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -50,6 +56,9 @@ jobs:
         # GitHub already closes local issues from merge keywords. Disable the
         # nonessential notification hooks so a bare issue reference intended for
         # another repository cannot turn an otherwise-published release red.
-        run: npx semantic-release@25.0.3 --success false --fail false ${{ inputs.dry-run && '--dry-run' || '' }}
+        run: >-
+          npx semantic-release@25.0.3
+          ${{ inputs.disable-issue-side-effects && '--success false --fail false' || '' }}
+          ${{ inputs.dry-run && '--dry-run' || '' }}
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ then carry its own branding and Marketplace release lifecycle.
 
 [.github/workflows/create-release.yaml](.github/workflows/create-release.yaml) is a workflow used to create releases using semantic-release.
 
-The release is published with a GitHub App token, so the caller must set the `APP_CLIENT_ID` repository/organization **variable** alongside the `APP_PRIVATE_KEY` **secret**. The App needs `contents: write` (tags/releases) and `issues: write` + `pull-requests: write` (release comments).
+The release is published with a GitHub App token, so the caller must set the `APP_CLIENT_ID` repository/organization **variable** alongside the `APP_PRIVATE_KEY` **secret**. The App always needs `contents: write` (tags/releases). By default it also needs `issues: write` + `pull-requests: write` for semantic-release success/fail hooks. Set `disable-issue-side-effects: true` to suppress those hooks and mint the token with `contents: write` only.
 
 #### Usage
 
@@ -78,17 +78,20 @@ The release is published with a GitHub App token, so the caller must set the `AP
 jobs:
   release:
     uses: devantler-tech/actions/.github/workflows/create-release.yaml@{ref} # ref
+    with:
+      disable-issue-side-effects: true
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 ```
 
 #### Secrets and Inputs
 
-| Key               | Type            | Default | Required | Description                                                       |
-|-------------------|-----------------|---------|----------|-------------------------------------------------------------------|
-| `APP_CLIENT_ID`   | Variable        | -       | Yes      | GitHub App client ID used to mint the release token               |
-| `APP_PRIVATE_KEY` | Secret          | -       | Yes      | GitHub App private key (paired with the `APP_CLIENT_ID` variable) |
-| `dry-run`         | Input (boolean) | `false` | No       | Run semantic-release in dry-run mode (no tags or publishes)       |
+| Key                          | Type            | Default | Required | Description                                                               |
+|------------------------------|-----------------|---------|----------|---------------------------------------------------------------------------|
+| `APP_CLIENT_ID`              | Variable        | -       | Yes      | GitHub App client ID used to mint the release token                       |
+| `APP_PRIVATE_KEY`            | Secret          | -       | Yes      | GitHub App private key (paired with the `APP_CLIENT_ID` variable)         |
+| `disable-issue-side-effects` | Input (boolean) | `false` | No       | Disable success/fail hooks and omit issue/pull-request token permissions  |
+| `dry-run`                    | Input (boolean) | `false` | No       | Run semantic-release in dry-run mode (no tags or publishes)               |
 
 </details>
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

The shared release workflow can publish a tag and GitHub Release successfully, then finish red when a notification hook treats a bare issue reference intended for another repository as local. Those issue and pull-request side effects are optional, but changing every consumer at once would be a compatibility break.

## What

- add a documented, default-off input for disabling semantic-release success/fail hooks
- reduce the GitHub App token to release-content access only when callers opt in
- exercise the default and hardened paths separately in required CI
- lock the public input, command, and permission contract with an exact-node regression

Fixes #611
Part of #610
