### PR TITLE
feat(setup-agent-skills): add opt-in widened retry envelope for rate-limit bursts

### DIFF
--- a/.github/tests/agent-skills-retry-env.sh
+++ b/.github/tests/agent-skills-retry-env.sh
@@ -63,4 +63,22 @@ if [ "$(cat "$counter")" != "5" ]; then
 fi
 echo "✅ on: retry.sh rides out a 4-failure burst (5 attempts) with the widened envelope"
 
+# ── action↔helper wiring (lockstep) — the unit checks above prove the helper, but
+#    would stay green if setup-agent-skills stopped forwarding the input,
+#    misspelled the env var, or dropped the `source` call, leaving consumers who
+#    enable the opt-in silently on the defaults. Pin that wiring here. ──
+ay="$repo_root/setup-agent-skills/action.yaml"
+fwd="$(yq -r '.runs.steps[] | select(.id=="install") | .env.INPUT_EXPERIMENTAL_RATE_LIMIT_RETRY' "$ay")"
+case "$fwd" in
+  *inputs.experimental-rate-limit-retry*) : ;;
+  *) echo "::error::setup-agent-skills must forward the experimental-rate-limit-retry input into INPUT_EXPERIMENTAL_RATE_LIMIT_RETRY (got: $fwd)"; exit 1 ;;
+esac
+# shellcheck disable=SC2016  # match the literal source line, not an expansion
+if ! yq -r '.runs.steps[] | select(.id=="install") | .run' "$ay" \
+  | grep -qF 'source "${GITHUB_ACTION_PATH}/../.scripts/agent-skills-retry-env.sh" "${INPUT_EXPERIMENTAL_RATE_LIMIT_RETRY:-false}"'; then
+  echo "::error::setup-agent-skills must source agent-skills-retry-env.sh with INPUT_EXPERIMENTAL_RATE_LIMIT_RETRY"
+  exit 1
+fi
+echo "✅ wiring: setup-agent-skills forwards the opt-in input and sources the helper"
+
 echo "all agent-skills-retry-env checks passed"

--- a/.github/tests/agent-skills-retry-env.sh
+++ b/.github/tests/agent-skills-retry-env.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Both-states test for the .scripts/agent-skills-retry-env.sh opt-in that
+# setup-agent-skills sources to widen the retry.sh envelope (devantler-tech/actions#514).
+# Feature-flag-first requires the flag to be exercised on AND off, so this pins
+# both: off leaves retry.sh's defaults untouched, on exports the widened envelope
+# and retry.sh honours it.
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+script="$repo_root/.scripts/agent-skills-retry-env.sh"
+retry="$repo_root/.scripts/retry.sh"
+
+# ── off (explicit) → envelope vars stay unset ──
+(
+  unset RETRY_MAX_ATTEMPTS RETRY_BASE_DELAY RETRY_MAX_DELAY
+  # shellcheck source=/dev/null
+  source "$script" "false"
+  [ -z "${RETRY_MAX_ATTEMPTS:-}${RETRY_BASE_DELAY:-}${RETRY_MAX_DELAY:-}" ]
+) || { echo "::error::flag off must not set the retry envelope"; exit 1; }
+echo "✅ off: envelope untouched (retry.sh fast-fail defaults apply)"
+
+# ── missing arg → treated as off ──
+(
+  unset RETRY_MAX_ATTEMPTS
+  # shellcheck source=/dev/null
+  source "$script"
+  [ -z "${RETRY_MAX_ATTEMPTS:-}" ]
+) || { echo "::error::a missing flag must default to off"; exit 1; }
+echo "✅ default (no arg): envelope untouched"
+
+# ── on → widened envelope exported with the documented values ──
+(
+  # shellcheck source=/dev/null
+  source "$script" "true"
+  [ "${RETRY_MAX_ATTEMPTS:-}" = "5" ] &&
+    [ "${RETRY_BASE_DELAY:-}" = "10" ] &&
+    [ "${RETRY_MAX_DELAY:-}" = "45" ]
+) || { echo "::error::flag on must export the widened envelope (5 / 10 / 45)"; exit 1; }
+echo "✅ on: widened envelope exported (5 attempts, 10s→45s)"
+
+# ── on → retry.sh actually HONORS the widened envelope: a 4-failure burst that
+#    the default 3-attempt envelope could never survive succeeds on the 5th try. ──
+counter=$(mktemp)
+flaky=$(mktemp)
+trap 'rm -f "$counter" "$flaky"' EXIT
+printf '0' > "$counter"
+cat > "$flaky" <<EOF
+#!/usr/bin/env bash
+n=\$(( \$(cat "$counter") + 1 )); printf '%s' "\$n" > "$counter"
+[ "\$n" -ge 5 ]
+EOF
+chmod +x "$flaky"
+(
+  # shellcheck source=/dev/null
+  source "$script" "true"
+  # Collapse the backoff so the test is instant; the attempt COUNT (from the
+  # sourced RETRY_MAX_ATTEMPTS=5) is the behaviour under test.
+  export RETRY_BASE_DELAY=0 RETRY_MAX_DELAY=0
+  bash "$retry" "$flaky"
+) || { echo "::error::widened envelope should ride out a 4-failure burst"; cat "$counter"; exit 1; }
+if [ "$(cat "$counter")" != "5" ]; then
+  echo "::error::expected retry.sh to make 5 attempts, got $(cat "$counter")"; exit 1
+fi
+echo "✅ on: retry.sh rides out a 4-failure burst (5 attempts) with the widened envelope"
+
+echo "all agent-skills-retry-env checks passed"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -997,6 +997,22 @@ jobs:
         shell: bash
         run: bash .github/tests/gh-skill-install-script.sh
 
+  # ── .scripts/agent-skills-retry-env.sh (rate-limit-retry opt-in) ─
+  test-agent-skills-retry-env:
+    if: "${{ !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: 📑 Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: 🧪 Exercise agent-skills-retry-env.sh (opt-in off AND on)
+        shell: bash
+        run: bash .github/tests/agent-skills-retry-env.sh
+
   # ── update-agent-skills ───────────────────────────────────
   test-update-agent-skills-noop:
     if: "${{ !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
@@ -2404,6 +2420,7 @@ jobs:
       - test-retry-script
       - test-ensure-gh-skill-script
       - test-gh-skill-install-script
+      - test-agent-skills-retry-env
       - test-update-agent-skills-noop
       - test-update-agent-skills-dry-run
       - test-update-agent-skills-missing-dir
@@ -2488,6 +2505,7 @@ jobs:
             ${{ needs.test-retry-script.result }}
             ${{ needs.test-ensure-gh-skill-script.result }}
             ${{ needs.test-gh-skill-install-script.result }}
+            ${{ needs.test-agent-skills-retry-env.result }}
             ${{ needs.test-update-agent-skills-noop.result }}
             ${{ needs.test-update-agent-skills-dry-run.result }}
             ${{ needs.test-update-agent-skills-missing-dir.result }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1009,7 +1009,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: 🧪 Exercise agent-skills-retry-env.sh (opt-in off AND on)
+      - name: 🧪 Exercise agent-skills-retry-env.sh (opt-in off AND on) + action wiring
         shell: bash
         run: bash .github/tests/agent-skills-retry-env.sh
 

--- a/.scripts/agent-skills-retry-env.sh
+++ b/.scripts/agent-skills-retry-env.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Enable the widened retry.sh envelope for the agent-skills registry pulls when
+# the experimental rate-limit-retry opt-in is on (default off). The opt-in lives
+# in this one shared, tested place so both states are covered in CI rather than
+# buried in an action's inline `run:` block. See devantler-tech/actions#514.
+#
+# SOURCE this script (don't execute it) so the exports land in the caller's
+# shell:
+#   source "${GITHUB_ACTION_PATH}/../.scripts/agent-skills-retry-env.sh" "<true|false>"
+#
+# When the first argument is exactly "true", it widens the shared retry.sh
+# envelope (5 attempts on a 10s→45s backoff ≈ 115s of retry) so a transient
+# GitHub rate-limit 403 during a Dependabot burst — which clears as the burst
+# subsides — does not red a required check. Any other value is a no-op, leaving
+# retry.sh's fast-fail defaults in place, so no consumer's behaviour changes
+# until the opt-in is deliberately enabled.
+#
+# No `set -e`/`pipefail` here: this is sourced into the caller, so it must not
+# alter the caller's shell options.
+if [ "${1:-false}" = "true" ]; then
+  export RETRY_MAX_ATTEMPTS=5
+  export RETRY_BASE_DELAY=10
+  export RETRY_MAX_DELAY=45
+fi

--- a/setup-agent-skills/README.md
+++ b/setup-agent-skills/README.md
@@ -13,6 +13,7 @@ Install agent skills with the [`gh skill`](https://github.blog/changelog/2026-04
 | `scope` | Value passed to `gh skill install --scope` (`project` or `user`) | ❌ | `project` |
 | `gh-version` | Minimum required `gh` version (must support `gh skill`) | ❌ | `2.90.0` |
 | `github-token` | GitHub token exposed to `gh` as `GH_TOKEN` | ❌ | `${{ github.token }}` |
+| `experimental-rate-limit-retry` | Opt in (default off) to a widened retry envelope for the `gh skill install` registry pulls, to ride out a transient GitHub rate-limit 403 during a burst ([#514](https://github.com/devantler-tech/actions/issues/514)). Off keeps the shared retry defaults; activation is a deliberate, reversible step. | ❌ | `false` |
 
 ## Outputs
 

--- a/setup-agent-skills/action.yaml
+++ b/setup-agent-skills/action.yaml
@@ -55,16 +55,20 @@ runs:
         INPUT_AGENTS: ${{ inputs.agents }}
         INPUT_SCOPE: ${{ inputs.scope }}
         # Widen the shared retry.sh envelope for these registry pulls. `gh skill
-        # install` fetches skill blobs from the GitHub API, which trips a
-        # *secondary* rate-limit (HTTP 403 "API rate limit exceeded for
-        # installation") during Dependabot bursts. The default 3-attempt / ~15s
-        # window regularly outlasts the reset; 6 attempts with a 10s→60s backoff
-        # keep retrying for ~190s, past a typical secondary-limit reset window,
-        # so a burst no longer reds a required check (#514). Only the failure
-        # path pays this cost — a first-try install still returns immediately.
-        RETRY_MAX_ATTEMPTS: "6"
+        # install` fetches skill blobs from the GitHub API; during a Dependabot
+        # burst many concurrent jobs hit it at once and trip a rate-limit 403
+        # ("API rate limit exceeded for installation") that clears once the
+        # burst subsides — reruns minutes later succeed. The default 3-attempt /
+        # ~15s window is too short to ride that out; 5 attempts on a 10s→45s
+        # backoff spread retries across ~115s so a transient burst no longer
+        # reds a required check (#514). Only the failure path pays this cost — a
+        # first-try install still returns immediately, and a genuinely broken
+        # install (bad pin/token) still fails, just ~115s later. Cutting the
+        # burst's request load (matrix dedupe / audit gating) is the root-cause
+        # follow-up tracked on #514.
+        RETRY_MAX_ATTEMPTS: "5"
         RETRY_BASE_DELAY: "10"
-        RETRY_MAX_DELAY: "60"
+        RETRY_MAX_DELAY: "45"
       run: |
         set -euo pipefail
 

--- a/setup-agent-skills/action.yaml
+++ b/setup-agent-skills/action.yaml
@@ -28,6 +28,16 @@ inputs:
     description: GitHub token exposed to `gh` as `GH_TOKEN`
     required: false
     default: ${{ github.token }}
+  experimental-rate-limit-retry:
+    description: |
+      Opt in (default off) to a widened retry envelope for the `gh skill install` registry pulls, to
+      ride out a transient GitHub rate-limit 403 during a burst (devantler-tech/actions#514). Off
+      keeps the shared retry.sh fast-fail defaults, so this changes no existing consumer's behaviour.
+      Activation is a deliberate, reversible step — validate that the widened envelope actually clears
+      the burst before flipping it on for a consumer; cutting the burst's request load is the
+      root-cause follow-up on #514.
+    required: false
+    default: "false"
 outputs:
   installed-skills:
     description: Newline-separated list of `source/skill-name[@pin]` entries that were installed
@@ -54,23 +64,19 @@ runs:
         INPUT_SKILLS: ${{ inputs.skills }}
         INPUT_AGENTS: ${{ inputs.agents }}
         INPUT_SCOPE: ${{ inputs.scope }}
-        # Widen the shared retry.sh envelope for these registry pulls. `gh skill
-        # install` fetches skill blobs from the GitHub API; during a Dependabot
-        # burst many concurrent jobs hit it at once and trip a rate-limit 403
-        # ("API rate limit exceeded for installation") that clears once the
-        # burst subsides — reruns minutes later succeed. The default 3-attempt /
-        # ~15s window is too short to ride that out; 5 attempts on a 10s→45s
-        # backoff spread retries across ~115s so a transient burst no longer
-        # reds a required check (#514). Only the failure path pays this cost — a
-        # first-try install still returns immediately, and a genuinely broken
-        # install (bad pin/token) still fails, just ~115s later. Cutting the
-        # burst's request load (matrix dedupe / audit gating) is the root-cause
-        # follow-up tracked on #514.
-        RETRY_MAX_ATTEMPTS: "5"
-        RETRY_BASE_DELAY: "10"
-        RETRY_MAX_DELAY: "45"
+        INPUT_EXPERIMENTAL_RATE_LIMIT_RETRY: ${{ inputs.experimental-rate-limit-retry }}
       run: |
         set -euo pipefail
+
+        # Opt-in (default-off, #514): widen the shared retry.sh envelope for the
+        # `gh skill install` registry pulls below so a transient rate-limit 403
+        # during a Dependabot burst — which clears as the burst subsides — does
+        # not red a required check. Default keeps retry.sh's fast-fail defaults,
+        # so no existing consumer's behaviour changes until this is deliberately
+        # enabled. 5 attempts on a 10s→45s backoff spread retries across ~115s.
+        if [ "${INPUT_EXPERIMENTAL_RATE_LIMIT_RETRY:-false}" = "true" ]; then
+          export RETRY_MAX_ATTEMPTS=5 RETRY_BASE_DELAY=10 RETRY_MAX_DELAY=45
+        fi
 
         # Bounded retry for the registry pulls below — `gh skill install` fetches
         # each skill over the network, so a transient flake must not red a required

--- a/setup-agent-skills/action.yaml
+++ b/setup-agent-skills/action.yaml
@@ -54,6 +54,17 @@ runs:
         INPUT_SKILLS: ${{ inputs.skills }}
         INPUT_AGENTS: ${{ inputs.agents }}
         INPUT_SCOPE: ${{ inputs.scope }}
+        # Widen the shared retry.sh envelope for these registry pulls. `gh skill
+        # install` fetches skill blobs from the GitHub API, which trips a
+        # *secondary* rate-limit (HTTP 403 "API rate limit exceeded for
+        # installation") during Dependabot bursts. The default 3-attempt / ~15s
+        # window regularly outlasts the reset; 6 attempts with a 10s→60s backoff
+        # keep retrying for ~190s, past a typical secondary-limit reset window,
+        # so a burst no longer reds a required check (#514). Only the failure
+        # path pays this cost — a first-try install still returns immediately.
+        RETRY_MAX_ATTEMPTS: "6"
+        RETRY_BASE_DELAY: "10"
+        RETRY_MAX_DELAY: "60"
       run: |
         set -euo pipefail
 

--- a/setup-agent-skills/action.yaml
+++ b/setup-agent-skills/action.yaml
@@ -70,13 +70,12 @@ runs:
 
         # Opt-in (default-off, #514): widen the shared retry.sh envelope for the
         # `gh skill install` registry pulls below so a transient rate-limit 403
-        # during a Dependabot burst — which clears as the burst subsides — does
-        # not red a required check. Default keeps retry.sh's fast-fail defaults,
-        # so no existing consumer's behaviour changes until this is deliberately
-        # enabled. 5 attempts on a 10s→45s backoff spread retries across ~115s.
-        if [ "${INPUT_EXPERIMENTAL_RATE_LIMIT_RETRY:-false}" = "true" ]; then
-          export RETRY_MAX_ATTEMPTS=5 RETRY_BASE_DELAY=10 RETRY_MAX_DELAY=45
-        fi
+        # during a Dependabot burst does not red a required check. The opt-in
+        # lives in a shared, tested script so both states are covered in CI
+        # (test-agent-skills-retry-env); default keeps retry.sh's fast-fail
+        # defaults, so no existing consumer's behaviour changes until enabled.
+        # shellcheck source=/dev/null
+        source "${GITHUB_ACTION_PATH}/../.scripts/agent-skills-retry-env.sh" "${INPUT_EXPERIMENTAL_RATE_LIMIT_RETRY:-false}"
 
         # Bounded retry for the registry pulls below — `gh skill install` fetches
         # each skill over the network, so a transient flake must not red a required

--- a/update-agent-skills/action.yaml
+++ b/update-agent-skills/action.yaml
@@ -51,21 +51,6 @@ runs:
         INPUT_DIR: ${{ inputs.dir }}
         INPUT_DRY_RUN: ${{ inputs.dry-run }}
         INPUT_UNPIN: ${{ inputs.unpin }}
-        # Widen the shared retry.sh envelope for these registry pulls. `gh skill
-        # update` re-fetches each skill's source over the GitHub API; during a
-        # Dependabot burst many concurrent jobs hit it at once and trip a
-        # rate-limit 403 ("API rate limit exceeded for installation") that clears
-        # once the burst subsides — reruns minutes later succeed. The default
-        # 3-attempt / ~15s window is too short to ride that out; 5 attempts on a
-        # 10s→45s backoff spread retries across ~115s so a transient burst no
-        # longer reds a required check (#514). Only the failure path pays this
-        # cost — a first-try update still returns immediately, and a genuinely
-        # broken update still fails, just ~115s later. Cutting the burst's
-        # request load (matrix dedupe / audit gating) is the root-cause
-        # follow-up tracked on #514.
-        RETRY_MAX_ATTEMPTS: "5"
-        RETRY_BASE_DELAY: "10"
-        RETRY_MAX_DELAY: "45"
       run: |
         set -euo pipefail
 

--- a/update-agent-skills/action.yaml
+++ b/update-agent-skills/action.yaml
@@ -52,16 +52,20 @@ runs:
         INPUT_DRY_RUN: ${{ inputs.dry-run }}
         INPUT_UNPIN: ${{ inputs.unpin }}
         # Widen the shared retry.sh envelope for these registry pulls. `gh skill
-        # update` re-fetches each skill's source over the GitHub API, which trips
-        # a *secondary* rate-limit (HTTP 403 "API rate limit exceeded for
-        # installation") during Dependabot bursts. The default 3-attempt / ~15s
-        # window regularly outlasts the reset; 6 attempts with a 10s→60s backoff
-        # keep retrying for ~190s, past a typical secondary-limit reset window,
-        # so a burst no longer reds a required check (#514). Only the failure
-        # path pays this cost — a first-try update still returns immediately.
-        RETRY_MAX_ATTEMPTS: "6"
+        # update` re-fetches each skill's source over the GitHub API; during a
+        # Dependabot burst many concurrent jobs hit it at once and trip a
+        # rate-limit 403 ("API rate limit exceeded for installation") that clears
+        # once the burst subsides — reruns minutes later succeed. The default
+        # 3-attempt / ~15s window is too short to ride that out; 5 attempts on a
+        # 10s→45s backoff spread retries across ~115s so a transient burst no
+        # longer reds a required check (#514). Only the failure path pays this
+        # cost — a first-try update still returns immediately, and a genuinely
+        # broken update still fails, just ~115s later. Cutting the burst's
+        # request load (matrix dedupe / audit gating) is the root-cause
+        # follow-up tracked on #514.
+        RETRY_MAX_ATTEMPTS: "5"
         RETRY_BASE_DELAY: "10"
-        RETRY_MAX_DELAY: "60"
+        RETRY_MAX_DELAY: "45"
       run: |
         set -euo pipefail
 

--- a/update-agent-skills/action.yaml
+++ b/update-agent-skills/action.yaml
@@ -51,6 +51,17 @@ runs:
         INPUT_DIR: ${{ inputs.dir }}
         INPUT_DRY_RUN: ${{ inputs.dry-run }}
         INPUT_UNPIN: ${{ inputs.unpin }}
+        # Widen the shared retry.sh envelope for these registry pulls. `gh skill
+        # update` re-fetches each skill's source over the GitHub API, which trips
+        # a *secondary* rate-limit (HTTP 403 "API rate limit exceeded for
+        # installation") during Dependabot bursts. The default 3-attempt / ~15s
+        # window regularly outlasts the reset; 6 attempts with a 10s→60s backoff
+        # keep retrying for ~190s, past a typical secondary-limit reset window,
+        # so a burst no longer reds a required check (#514). Only the failure
+        # path pays this cost — a first-try update still returns immediately.
+        RETRY_MAX_ATTEMPTS: "6"
+        RETRY_BASE_DELAY: "10"
+        RETRY_MAX_DELAY: "60"
       run: |
         set -euo pipefail
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why
During a Dependabot burst, the agent-skills install jobs all hit the GitHub API at once and can trip a rate-limit 403 that reds a required check on infra noise rather than a real defect. #514 asked for the install pulls to ride that out.

## What
Adds a **default-off** `experimental-rate-limit-retry` opt-in to `setup-agent-skills` that widens the retry envelope (~15s → ~115s) only when a caller enables it. Off by default, so **no existing consumer's behaviour changes** — the capability lands latent and flipping it on is a separate, reversible step, per feature-flag-first. Both states are tested.

Deliberately scoped to the install path (which runs in PR-CI bursts); the scheduled update action is unchanged. Validating that the widened envelope actually clears a real burst (the 403's exact limit class is unconfirmed) and cutting the burst's request load remain the root-cause follow-ups.

Part of #514.