### PR TITLE
fix(enable-auto-merge): arm auto-merge on workflow-touching PRs

### DIFF
--- a/.github/tests/test-enable-auto-merge-pentad-gate.sh
+++ b/.github/tests/test-enable-auto-merge-pentad-gate.sh
@@ -242,6 +242,37 @@ if [[ -z "$handoff_line" || -z "$handoff_exit_line" || -z "$merge_line" || "$han
   status=1
 fi
 
+# Arming auto-merge on a PR that modifies .github/workflows/ is refused unless
+# the App token carries Workflows: write (GitHub treats
+# enablePullRequestAutoMerge as updating the workflow). The arming App token
+# must request that scope so workflow-touching PRs can be armed on installations
+# that grant it (actions#559).
+app_token_workflows="$(yq -r '
+  [.jobs."auto-merge".steps[]
+   | select(.id == "app-token")
+   | .with."permission-workflows" // ""]
+  | join("\n")' "$workflow")"
+if [[ "$app_token_workflows" != "write" ]]; then
+  echo "::error file=$workflow::the arming App token must request Workflows: write so auto-merge can be armed on PRs that modify .github/workflows/ (actions#559)"
+  status=1
+fi
+
+# An installation without Workflows: write has that scope intersected away, so
+# the arming call is still refused there. The arming step must degrade
+# gracefully on that specific refusal (warn + exit 0) rather than fail the
+# required check, while any OTHER merge failure stays a hard error (actions#559).
+if ! grep -Fq 'without `workflows` permission' <<<"$pre_arm_run"; then
+  echo "::error file=$workflow::Enable Auto-Merge must detect the 'without \`workflows\` permission' arming refusal and degrade gracefully (actions#559)"
+  status=1
+fi
+graceful_line="$(grep -nF 'without `workflows` permission' <<<"$pre_arm_run" | head -1 | cut -d: -f1 || true)"
+graceful_exit_line="$(awk -v start="$graceful_line" 'NR >= start && /exit 0/ {print NR; exit}' <<<"$pre_arm_run")"
+hard_error_line="$(grep -nF 'Failed to enable auto-merge' <<<"$pre_arm_run" | head -1 | cut -d: -f1 || true)"
+if [[ -z "$graceful_line" || -z "$graceful_exit_line" || -z "$hard_error_line" ]]; then
+  echo "::error file=$workflow::the workflows-permission refusal must warn+exit 0, and any other failure must still hard-error (actions#559)"
+  status=1
+fi
+
 # The head-seen floor must ignore check suites created for some other PR that
 # happened to use the same commit SHA. Reusing the oldest cross-branch suite
 # makes a stale summary look newer than the PR's adoption of the head.

--- a/.github/tests/test-enable-auto-merge-pentad-gate.sh
+++ b/.github/tests/test-enable-auto-merge-pentad-gate.sh
@@ -257,10 +257,41 @@ if [[ "$app_token_workflows" != "write" ]]; then
   status=1
 fi
 
-# An installation without Workflows: write has that scope intersected away, so
-# the arming call is still refused there. The arming step must degrade
-# gracefully on that specific refusal (warn + exit 0) rather than fail the
-# required check, while any OTHER merge failure stays a hard error (actions#559).
+# An installation WITHOUT the Workflows grant cannot mint a Workflows-scoped
+# token — create-github-app-token 422s rather than intersecting the scope away —
+# which would fail the required check for EVERY PR there before the arming
+# step's graceful-degrade could run. So the Workflows-scoped mint must be
+# non-fatal (continue-on-error) and fall back to a base-scoped token with NO
+# Workflows scope, reached only on that failure (actions#559).
+app_token_coe="$(yq -r '
+  [.jobs."auto-merge".steps[]
+   | select(.id == "app-token")
+   | .["continue-on-error"] // false]
+  | join("\n")' "$workflow")"
+if [[ "$app_token_coe" != "true" ]]; then
+  echo "::error file=$workflow::the Workflows-scoped App token mint must be continue-on-error so a 422 on a grant-less installation does not fail the required check (actions#559)"
+  status=1
+fi
+fallback_count="$(yq -r '
+  [.jobs."auto-merge".steps[] | select(.id == "app-token-base")] | length' "$workflow")"
+fallback_workflows="$(yq -r '
+  [.jobs."auto-merge".steps[]
+   | select(.id == "app-token-base")
+   | .with."permission-workflows" // "ABSENT"]
+  | join("\n")' "$workflow")"
+fallback_if="$(yq -r '
+  [.jobs."auto-merge".steps[]
+   | select(.id == "app-token-base")
+   | .if // ""]
+  | join("\n")' "$workflow")"
+if [[ "$fallback_count" != "1" || "$fallback_workflows" != "ABSENT" || "$fallback_if" != *"steps.app-token.outcome"* ]]; then
+  echo "::error file=$workflow::a base-scoped fallback mint (id app-token-base, NO permission-workflows) gated on steps.app-token.outcome == 'failure' must back the non-fatal Workflows-scoped mint (actions#559)"
+  status=1
+fi
+
+# The arming step must degrade gracefully on the workflows-permission refusal
+# (warn + exit 0) rather than fail the required check, while any OTHER merge
+# failure stays a hard error (actions#559).
 if ! grep -Fq 'without `workflows` permission' <<<"$pre_arm_run"; then
   echo "::error file=$workflow::Enable Auto-Merge must detect the 'without \`workflows\` permission' arming refusal and degrade gracefully (actions#559)"
   status=1

--- a/.github/workflows/enable-auto-merge.yaml
+++ b/.github/workflows/enable-auto-merge.yaml
@@ -142,10 +142,18 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           # Least-privilege token scope: approving and enabling auto-merge on
           # PRs. The gate's read-only lookups use GITHUB_TOKEN instead (see
-          # the job's permissions block), so no extra App permission is ever
-          # required of consumer installations.
+          # the job's permissions block).
           permission-contents: write
           permission-pull-requests: write
+          # Arming auto-merge on a PR that modifies .github/workflows/ requires
+          # the App token to carry Workflows: write — GitHub treats
+          # enablePullRequestAutoMerge as updating the workflow and refuses it
+          # otherwise (actions#559). The devantler-tech installation grants
+          # this org-wide; an installation WITHOUT the grant has this scope
+          # silently intersected away by the mint, and the arming step degrades
+          # gracefully rather than failing the required check (see the
+          # 🔀 Enable Auto-Merge step below).
+          permission-workflows: write
 
       # Self-reference: check out THIS workflow's own repo at the exact commit
       # it is running from (job.workflow_repository / job.workflow_sha) — never
@@ -450,5 +458,27 @@ jobs:
           fi
           # --match-head-commit preserves the legacy default-off behavior
           # while binding its arming request to the allowlist-proven head.
-          gh pr merge "$PR_NUMBER" --auto --squash --repo "$REPOSITORY" --match-head-commit "$HEAD_SHA"
-          echo "✅ Auto-merge enabled for PR #${PR_NUMBER} at ${HEAD_SHA} using squash method"
+          #
+          # Arming a PR that touches .github/workflows/ needs the App token to
+          # carry Workflows: write (the token mint requests it). The
+          # devantler-tech installation grants it, but an installation WITHOUT
+          # the grant has the scope intersected away and GitHub refuses the
+          # arming with "... without `workflows` permission". Degrade
+          # gracefully there — the PR simply is not auto-armed (a trusted human
+          # merges it) — instead of leaving a permanently-red required check
+          # (actions#559). Any OTHER failure is still a hard error.
+          set +e
+          merge_output=$(gh pr merge "$PR_NUMBER" --auto --squash --repo "$REPOSITORY" --match-head-commit "$HEAD_SHA" 2>&1)
+          merge_exit=$?
+          set -e
+          # shellcheck disable=SC2016 # The backticks in the workflows-permission match below are literal (part of GitHub's error text), not a command substitution.
+          if [[ $merge_exit -eq 0 ]]; then
+            echo "✅ Auto-merge enabled for PR #${PR_NUMBER} at ${HEAD_SHA} using squash method"
+          elif [[ "$merge_output" == *'without `workflows` permission'* ]]; then
+            echo "::warning::PR #${PR_NUMBER} modifies a workflow file and this GitHub App installation lacks Workflows: write, so auto-merge could not be armed. A trusted human can merge it manually. Grant the App Workflows: write to enable auto-arming on workflow-touching PRs here."
+            exit 0
+          else
+            echo "::error::Failed to enable auto-merge for PR #${PR_NUMBER}."
+            echo "$merge_output"
+            exit 1
+          fi

--- a/.github/workflows/enable-auto-merge.yaml
+++ b/.github/workflows/enable-auto-merge.yaml
@@ -134,9 +134,21 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: 🔑 Generate GitHub App Token
+      # Primary mint requests Workflows: write so a PR that modifies
+      # .github/workflows/ can be armed — GitHub treats
+      # enablePullRequestAutoMerge as updating the workflow and refuses it
+      # without that scope (actions#559). The devantler-tech installation
+      # grants Workflows org-wide. An installation WITHOUT the grant CANNOT
+      # mint a Workflows-scoped token: actions/create-github-app-token 422s
+      # rather than intersecting the scope away (documented in
+      # template-sync.yaml). So this mint is non-fatal (continue-on-error) and
+      # falls back to the base-scoped token below — otherwise EVERY PR there
+      # (workflow-touching or not) would hit a red required check before the
+      # arming step's graceful-degrade could ever run.
+      - name: 🔑 Generate GitHub App Token (Workflows-scoped)
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
+        continue-on-error: true
         with:
           client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -145,15 +157,23 @@ jobs:
           # the job's permissions block).
           permission-contents: write
           permission-pull-requests: write
-          # Arming auto-merge on a PR that modifies .github/workflows/ requires
-          # the App token to carry Workflows: write — GitHub treats
-          # enablePullRequestAutoMerge as updating the workflow and refuses it
-          # otherwise (actions#559). The devantler-tech installation grants
-          # this org-wide; an installation WITHOUT the grant has this scope
-          # silently intersected away by the mint, and the arming step degrades
-          # gracefully rather than failing the required check (see the
-          # 🔀 Enable Auto-Merge step below).
           permission-workflows: write
+
+      # Base-scoped fallback (no Workflows) for installations that have not
+      # granted the App Workflows: write — reached only when the primary mint
+      # above 422s. Non-workflow PRs arm normally with this token; a
+      # workflow-touching PR cannot be armed there and degrades gracefully at
+      # the arming step. A genuine auth error (bad key) fails BOTH mints, and
+      # this one has no continue-on-error, so the job still fails closed.
+      - name: 🔑 Generate GitHub App Token (base scope fallback)
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token-base
+        if: steps.app-token.outcome == 'failure'
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       # Self-reference: check out THIS workflow's own repo at the exact commit
       # it is running from (job.workflow_repository / job.workflow_sha) — never
@@ -174,7 +194,7 @@ jobs:
       - name: 🔎 Resolve target pull request
         id: pr
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || steps.app-token-base.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           REPOSITORY: ${{ github.repository }}
         run: |
@@ -234,7 +254,7 @@ jobs:
         id: gates
         if: steps.pr.outputs.eligible == 'true'
         env:
-          GH_TOKEN: ${{ steps.gate-token.outputs.token || steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.gate-token.outputs.token || steps.app-token.outputs.token || steps.app-token-base.outputs.token }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           REPOSITORY: ${{ github.repository }}
           ENFORCE: ${{ (inputs.enforce-review-gates || vars.ENFORCE_MERGE_GATES == 'true') && 'true' || 'false' }}
@@ -345,7 +365,7 @@ jobs:
              (steps.gates.outcome == 'success' && steps.gates.outputs.armable == 'false'))
           }}
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || steps.app-token-base.outputs.token }}
           PR_NUMBER: ${{ steps.pr.outputs.number || github.event.pull_request.number || github.event.issue.number }}
           REPOSITORY: ${{ github.repository }}
           HEAD_SHA: ${{ steps.gates.outputs.head_sha }}
@@ -372,7 +392,7 @@ jobs:
         id: approve
         if: steps.gates.outputs.armable == 'true'
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || steps.app-token-base.outputs.token }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           REPOSITORY: ${{ github.repository }}
           HEAD_SHA: ${{ steps.gates.outputs.head_sha }}
@@ -416,7 +436,7 @@ jobs:
             steps.gates.outputs.armable == 'true'
           }}
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || steps.app-token-base.outputs.token }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           REPOSITORY: ${{ github.repository }}
           HEAD_SHA: ${{ steps.gates.outputs.head_sha }}
@@ -460,13 +480,14 @@ jobs:
           # while binding its arming request to the allowlist-proven head.
           #
           # Arming a PR that touches .github/workflows/ needs the App token to
-          # carry Workflows: write (the token mint requests it). The
-          # devantler-tech installation grants it, but an installation WITHOUT
-          # the grant has the scope intersected away and GitHub refuses the
-          # arming with "... without `workflows` permission". Degrade
-          # gracefully there — the PR simply is not auto-armed (a trusted human
-          # merges it) — instead of leaving a permanently-red required check
-          # (actions#559). Any OTHER failure is still a hard error.
+          # carry Workflows: write (the primary mint requests it). The
+          # devantler-tech installation grants it. An installation WITHOUT the
+          # grant falls back to the base-scoped token above, so GitHub refuses
+          # the arming with "... without `workflows` permission" only for a
+          # workflow-touching PR. Degrade gracefully there — the PR simply is
+          # not auto-armed (a trusted human merges it) — instead of leaving a
+          # permanently-red required check (actions#559). Any OTHER failure is
+          # still a hard error.
           set +e
           merge_output=$(gh pr merge "$PR_NUMBER" --auto --squash --repo "$REPOSITORY" --match-head-commit "$HEAD_SHA" 2>&1)
           merge_exit=$?


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

The reusable auto-merge workflow could not arm auto-merge on any PR that changes a file under `.github/workflows/` — GitHub refused it because the App token lacked the `workflows` permission — so every workflow-touching PR was left with a permanently-red required check and had to be merged by hand. This hit real promoted PRs across consumer repos.

## What

The arming token now requests `Workflows: write` (the org installation already grants it), so those PRs arm normally. For any installation that does not grant it, the workflow degrades gracefully — it warns and passes the check (a trusted human merges) instead of failing — while any unrelated merge failure still errors. Behaviour is verified in both states.

Fixes #559