### PR TITLE
fix(validate-go-project): make the concurrency group invocation-aware

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2390,6 +2390,45 @@ jobs:
           fi
           echo "validate-go-project.yaml pins the self-tested lint action + test command ✅"
 
+  test-validate-go-project-concurrency-key:
+    if: "${{ !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
+    name: "[Test] Validate Go Project - Invocation-Aware Concurrency Key"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: 📄 Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # The org-required direct run of validate-go-project.yaml and this repo's
+      # ci.yaml self-test (which calls it as a reusable workflow) run on the same
+      # repository + ref. If the concurrency group is not invocation-aware they share
+      # one group and cancel each other, failing CI - Required Checks nondeterministically
+      # (devantler-tech/actions#587). A reusable workflow inherits the CALLER's
+      # github.workflow, so keying the group on github.workflow keeps the two
+      # invocations in separate groups while runs of the same invocation still
+      # supersede. This guard goes red if that discriminator is ever dropped. The
+      # grep is a regex (not -F) so the group's own ${{ … }} expressions are matched
+      # as literals here rather than being evaluated in this workflow.
+      - name: 🔒 Assert the concurrency group keys on github.workflow
+        shell: bash
+        env:
+          GATE: .github/workflows/validate-go-project.yaml
+        run: |
+          set -euo pipefail
+          if ! grep -Eq 'group: "validate-go-project-.*github\.workflow' "$GATE"; then
+            echo "::error::$GATE concurrency group is no longer invocation-aware. Keep github.workflow in the group (devantler-tech/actions#587) so the org-required direct run and the ci.yaml reusable-workflow self-test do not cancel each other."
+            exit 1
+          fi
+          echo "validate-go-project.yaml concurrency group is invocation-aware ✅"
+
   # ── gate ────────────────────────────────────────────────────
   ci-required-checks:
     name: CI - Required Checks
@@ -2465,6 +2504,7 @@ jobs:
       - test-validate-go-lint-blocks
       - test-validate-go-test-blocks
       - test-validate-go-gate-lockstep
+      - test-validate-go-project-concurrency-key
       - test-run-dotnet-tests-blocks
       - test-run-dotnet-tests-gate-lockstep
       - test-run-dotnet-tests-coverage-inline-lockstep
@@ -2550,6 +2590,7 @@ jobs:
             ${{ needs.test-validate-go-lint-blocks.result }}
             ${{ needs.test-validate-go-test-blocks.result }}
             ${{ needs.test-validate-go-gate-lockstep.result }}
+            ${{ needs.test-validate-go-project-concurrency-key.result }}
             ${{ needs.test-run-dotnet-tests-blocks.result }}
             ${{ needs.test-run-dotnet-tests-gate-lockstep.result }}
             ${{ needs.test-run-dotnet-tests-coverage-inline-lockstep.result }}

--- a/.github/workflows/validate-go-project.yaml
+++ b/.github/workflows/validate-go-project.yaml
@@ -21,8 +21,15 @@ on:
   merge_group:
   ##################################
 
+# Invocation-aware concurrency: keying on github.workflow keeps this workflow's
+# two invocations on the same ref in separate groups — the org-required direct
+# run (github.workflow == this workflow's name) versus a caller's reusable-workflow
+# self-test (a reusable workflow inherits the CALLER's github.workflow, e.g. the CI
+# workflow). Without it both share one group on the same repository+ref and
+# cancel each other, failing the aggregate required check nondeterministically
+# (devantler-tech/actions#587). Runs of the same logical invocation still supersede.
 concurrency:
-  group: "validate-go-project-${{ github.repository }}-${{ github.ref }}"
+  group: "validate-go-project-${{ github.repository }}-${{ github.ref }}-${{ github.workflow }}"
   cancel-in-progress: true
 
 permissions: {}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why
In this repo, `validate-go-project.yaml` runs twice on the same pull request — once as the org-required workflow and once as the CI self-test that calls it as a reusable workflow. Both shared a single concurrency group, so they cancelled each other and made an otherwise-green PR fail the aggregate required check at random. That flakiness costs a rerun on every affected PR portfolio-wide.

## What
Key the concurrency group on the running workflow so the two invocations no longer collide, while newer runs of the same invocation still supersede older ones. A CI guard locks the fix in so it can't silently regress.

Fixes #587