### PR TITLE
ci(zizmor): deduplicate full-repository scans

### DIFF
--- a/.github/tests/test-zizmor-routing.sh
+++ b/.github/tests/test-zizmor-routing.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ci="${1:-.github/workflows/ci.yaml}"
+standalone="${2:-.github/workflows/scan-for-workflow-vulnerabilities.yaml}"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+standalone_triggers="$(yq -r '.on | keys | .[]' "$standalone" | sort | paste -sd, -)"
+[[ "$standalone_triggers" == "merge_group,pull_request,workflow_call" ]] ||
+  fail "standalone Zizmor gate must keep workflow_call, pull_request, and merge_group only; got: $standalone_triggers"
+
+standalone_scan_count="$(
+  yq -r \
+    '[.jobs[].steps[]? | select((.uses // "") | test("^zizmorcore/zizmor-action@"))] | length' \
+    "$standalone"
+)"
+[[ "$standalone_scan_count" == "1" ]] ||
+  fail "standalone Zizmor gate must contain exactly one full-repository scan; found: $standalone_scan_count"
+
+eligibility_has_condition="$(yq -r '.jobs.eligibility | has("if")' "$standalone")"
+[[ "$eligibility_has_condition" == "false" ]] ||
+  fail "standalone eligibility job must be unconditional"
+
+eligibility_permissions="$(yq -r '(.jobs.eligibility.permissions // {}) | keys | join(",")' "$standalone")"
+[[ -z "$eligibility_permissions" ]] ||
+  fail "standalone eligibility job must have zero repository permissions; got: $eligibility_permissions"
+
+eligibility_first_uses="$(yq -r '.jobs.eligibility.steps[0].uses // ""' "$standalone")"
+eligibility_first_egress="$(yq -r '.jobs.eligibility.steps[0].with."egress-policy" // ""' "$standalone")"
+[[ "$eligibility_first_uses" == "step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920" &&
+  "$eligibility_first_egress" == "audit" ]] ||
+  fail "standalone eligibility job must begin with the pinned harden-runner action in audit mode"
+
+eligibility_output="$(yq -r '.jobs.eligibility.outputs.scan // ""' "$standalone")"
+# shellcheck disable=SC2016 # GitHub expression is intentionally compared literally.
+[[ "$eligibility_output" == '${{ steps.classify.outputs.scan }}' ]] ||
+  fail "standalone eligibility output must be bound to steps.classify.outputs.scan"
+
+classify_condition="$(yq -r '.jobs.eligibility.steps[] | select(.id == "classify") | .if // ""' "$standalone")"
+[[ "$classify_condition" == "github.event_name != 'merge_group'" ]] ||
+  fail "standalone scan classifier must exclude merge-group events; got: $classify_condition"
+
+classify_run="$(yq -r '.jobs.eligibility.steps[] | select(.id == "classify") | .run // ""' "$standalone")"
+# shellcheck disable=SC2016 # GitHub output path is intentionally compared literally.
+[[ "$classify_run" == 'echo "scan=true" >> "$GITHUB_OUTPUT"' ]] ||
+  fail "standalone scan classifier must explicitly emit scan=true; got: $classify_run"
+
+no_op_condition="$(yq -r '.jobs.eligibility.steps[] | select(.id == "no-op") | .if // ""' "$standalone")"
+[[ "$no_op_condition" == "steps.classify.outputs.scan != 'true'" ]] ||
+  fail "standalone eligibility job must explicitly complete ineligible events as a successful no-op"
+
+standalone_needs="$(yq -r '.jobs.zizmor.needs // ""' "$standalone")"
+standalone_condition="$(yq -r '.jobs.zizmor.if // ""' "$standalone")"
+[[ "$standalone_needs" == "eligibility" && "$standalone_condition" == "needs.eligibility.outputs.scan == 'true'" ]] ||
+  fail "standalone privileged scan must depend on an exactly-true eligibility output"
+
+ci_push_branches="$(yq -r '.on.push.branches | join(",")' "$ci")"
+[[ "$ci_push_branches" == "main" ]] ||
+  fail "CI must keep its main-push trigger for the default-branch Zizmor scan; got: $ci_push_branches"
+
+reusable_scan_count="$(
+  yq -r \
+    '[.jobs[] | select(.uses == "./.github/workflows/scan-for-workflow-vulnerabilities.yaml")] | length' \
+    "$ci"
+)"
+[[ "$reusable_scan_count" == "1" ]] ||
+  fail "CI must contain exactly one reusable Zizmor workflow call; found: $reusable_scan_count"
+
+test_zizmor_uses="$(yq -r '.jobs.test-zizmor.uses // ""' "$ci")"
+[[ "$test_zizmor_uses" == "./.github/workflows/scan-for-workflow-vulnerabilities.yaml" ]] ||
+  fail "test-zizmor must remain the reusable Zizmor workflow caller"
+
+expected_test_condition="\${{ github.event_name == 'push' && !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
+test_zizmor_condition="$(yq -r '.jobs.test-zizmor.if // ""' "$ci")"
+[[ "$test_zizmor_condition" == "$expected_test_condition" ]] ||
+  fail "test-zizmor must be push-only with the release exclusions intact; got: $test_zizmor_condition"
+
+direct_scan_jobs="$(
+  yq -r '
+    .jobs | to_entries[]
+    | select([.value.steps[]? | select((.uses // "") | test("^zizmorcore/zizmor-action@"))] | length > 0)
+    | .key
+  ' "$ci" | sort
+)"
+[[ "$direct_scan_jobs" == "test-zizmor-blocks" ]] ||
+  fail "CI's only direct Zizmor action must be the targeted failure-mode fixture; found jobs: ${direct_scan_jobs//$'\n'/,}"
+
+fixture_scan_count="$(
+  yq -r \
+    '[.jobs.test-zizmor-blocks.steps[]? | select((.uses // "") | test("^zizmorcore/zizmor-action@"))] | length' \
+    "$ci"
+)"
+[[ "$fixture_scan_count" == "1" ]] ||
+  fail "test-zizmor-blocks must keep exactly one direct fixture scan; found: $fixture_scan_count"
+
+fixture_inputs="$(
+  yq -r \
+    '.jobs.test-zizmor-blocks.steps[] | select((.uses // "") | test("^zizmorcore/zizmor-action@")) | .with.inputs // ""' \
+    "$ci"
+)"
+fixture_continue="$(
+  yq -r \
+    '.jobs.test-zizmor-blocks.steps[] | select((.uses // "") | test("^zizmorcore/zizmor-action@")) | .["continue-on-error"] // false' \
+    "$ci"
+)"
+fixture_advanced_security="$(
+  yq -r \
+    '.jobs.test-zizmor-blocks.steps[] | select((.uses // "") | test("^zizmorcore/zizmor-action@")) | .with["advanced-security"]' \
+    "$ci"
+)"
+[[ "$fixture_inputs" == ".github/tests/zizmor-fixture/template-injection.yml" ]] ||
+  fail "fixture scan must remain scoped to the deliberately vulnerable workflow; got: $fixture_inputs"
+[[ "$fixture_continue" == "true" ]] ||
+  fail "fixture scan must continue after the expected finding so its assertion can run"
+[[ "$fixture_advanced_security" == "false" ]] ||
+  fail "fixture finding must stay out of repository code scanning"
+
+fixture_assertion="$(
+  yq -r \
+    '.jobs.test-zizmor-blocks.steps[] | select(.name == "✅ Assert the gate blocked on the vulnerable fixture") | .run // ""' \
+    "$ci"
+)"
+# shellcheck disable=SC2016 # Match the literal workflow shell, not this test's variables.
+grep -qF 'if [ "$OUTCOME" != "failure" ]' <<<"$fixture_assertion" ||
+  fail "fixture assertion must prove the Zizmor action failed"
+grep -qF 'template-injection' <<<"$fixture_assertion" ||
+  fail "fixture assertion must distinguish a real finding from an operational failure"
+
+expected_aggregate=$'test-zizmor\ntest-zizmor-action-lockstep\ntest-zizmor-blocks'
+aggregate_needs="$(
+  yq -r '.jobs.ci-required-checks.needs[] | select(test("zizmor"))' "$ci" | sort
+)"
+[[ "$aggregate_needs" == "$expected_aggregate" ]] ||
+  fail "required-check needs must retain only the reusable and failure-mode Zizmor jobs; got: ${aggregate_needs//$'\n'/,}"
+
+aggregate_results="$(
+  yq -r '
+    .jobs.ci-required-checks.steps[]
+    | select(.uses == "./aggregate-job-checks")
+    | .with["job-results"]
+  ' "$ci" |
+    grep -oE 'needs\.[a-z0-9-]*zizmor[a-z0-9-]*\.result' |
+    sed -E 's/^needs\.//; s/\.result$//' |
+    sort
+)"
+[[ "$aggregate_results" == "$expected_aggregate" ]] ||
+  fail "required-check results must match the retained Zizmor jobs; got: ${aggregate_results//$'\n'/,}"
+
+echo "PASS: Zizmor routing keeps one eligible full-repository scan plus the targeted failure-mode fixture"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1524,29 +1524,6 @@ jobs:
           fi
           echo "run-dotnet-tests inlined coverage step matches $WRAPPER (uses + input set) ✅"
 
-  # ── zizmor ──────────────────────────────────────────────────
-  zizmor:
-    runs-on: ubuntu-latest
-    # Run on pull_request (catch new findings) and on push to main (refresh the
-    # code-scanning baseline so resolved findings auto-close); skip merge_group,
-    # where the PR scan already ran and the queue ref makes a SARIF upload moot.
-    # Scanning on push to main is essential: without it the default-branch
-    # code-scanning baseline never refreshes, leaving stale alerts that the
-    # `code_scanning` branch rule treats as a merge blocker on every PR.
-    if: "${{ github.event_name != 'merge_group' && !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
-    permissions:
-      security-events: write
-      contents: read
-      actions: read
-    steps:
-      - name: 📑 Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: 🔒 Run zizmor
-        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
-
   # ── lint-readme-parity ──────────────────────────────────────
   lint-readme-parity:
     if: "${{ !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
@@ -1652,6 +1629,10 @@ jobs:
         shell: bash
         run: bash .github/tests/test-template-sync-token-routing.sh
 
+      - name: 🔀 Check Zizmor event routing
+        shell: bash
+        run: bash .github/tests/test-zizmor-routing.sh
+
       - name: 📋 Check ci.yaml test wiring is complete
         shell: bash
         run: |
@@ -1724,7 +1705,10 @@ jobs:
           exit "$status"
 
   test-zizmor:
-    if: "${{ !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
+    # Pull requests already run the organization-required standalone workflow.
+    # Keep this reusable-workflow self-test for main pushes so the default-branch
+    # SARIF baseline still refreshes without duplicating the PR advisory scan.
+    if: "${{ github.event_name == 'push' && !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
     name: "[Test] Zizmor - Default Settings"
     uses: ./.github/workflows/scan-for-workflow-vulnerabilities.yaml
     permissions:
@@ -2487,7 +2471,6 @@ jobs:
       - test-upsert-issue-missing-body
       - test-upsert-issue-missing-body-file
       - test-run-dotnet-tests-missing-working-directory
-      - zizmor
       - lint-readme-parity
       - lint-ci-coverage-parity
       - test-zizmor
@@ -2573,7 +2556,6 @@ jobs:
             ${{ needs.test-upsert-issue-missing-body.result }}
             ${{ needs.test-upsert-issue-missing-body-file.result }}
             ${{ needs.test-run-dotnet-tests-missing-working-directory.result }}
-            ${{ needs.zizmor.result }}
             ${{ needs.lint-readme-parity.result }}
             ${{ needs.lint-ci-coverage-parity.result }}
             ${{ needs.test-zizmor.result }}

--- a/.github/workflows/scan-for-workflow-vulnerabilities.yaml
+++ b/.github/workflows/scan-for-workflow-vulnerabilities.yaml
@@ -10,9 +10,36 @@ on:
   ##################################
 
 jobs:
-  zizmor:
+  # A required workflow whose only job is skipped can remain unsatisfied.
+  # Classify every event in an unconditional, zero-permission job so merge
+  # groups complete green as a deliberate no-op while the scan stays skipped.
+  eligibility:
+    permissions: {}
     runs-on: ubuntu-latest
-    if: github.event_name != 'merge_group'
+    outputs:
+      scan: ${{ steps.classify.outputs.scan }}
+    steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: 🔎 Classify advisory scan event
+        id: classify
+        if: github.event_name != 'merge_group'
+        run: echo "scan=true" >> "$GITHUB_OUTPUT"
+
+      - name: ✅ Complete merge-group required-workflow run
+        id: no-op
+        if: steps.classify.outputs.scan != 'true'
+        run: >-
+          echo "::notice::The pull-request advisory scan already ran;
+          completing this merge-group workflow as a safe no-op."
+
+  zizmor:
+    needs: eligibility
+    if: needs.eligibility.outputs.scan == 'true'
+    runs-on: ubuntu-latest
     permissions:
       security-events: write
       contents: read # only needed for private repos


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Summary

- route pull-request scanning through the standalone required workflow only
- retain one reusable full scan on non-release `main` pushes plus the targeted failure fixture
- complete merge-group required-workflow runs through an unconditional zero-permission no-op
- lock the event matrix and privilege boundary with a structural regression test

## Why

Actions currently performs three full-repository Zizmor scans per pull request and two per ordinary `main` push. Removing the redundant advisory lookups reduces self-inflicted GitHub API pressure without reducing the pull-request gate, default-branch SARIF refresh, or failure-mode coverage.

Fixes #639
Part of #514