### PR TITLE
feat: add a repo-wide MegaLinter reusable workflow for non-Go-module repos

### DIFF
--- a/.github/tests/megalinter-bad-fixture/bad.json
+++ b/.github/tests/megalinter-bad-fixture/bad.json
@@ -1,0 +1,4 @@
+{
+  "deliberatelyInvalid": ,
+  "why": "syntax error with no value after the colon"
+}

--- a/.github/tests/megalinter-clean-fixture/good.json
+++ b/.github/tests/megalinter-clean-fixture/good.json
@@ -1,0 +1,4 @@
+{
+  "purpose": "clean fixture for the lint.yaml pass-on-good-input self-test",
+  "valid": true
+}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2429,6 +2429,117 @@ jobs:
           fi
           echo "validate-go-project.yaml concurrency group is invocation-aware ✅"
 
+  # ── lint.yaml self-tests ─────────────────────────────────────────────────────
+  # lint.yaml is a GATING reusable workflow (it fails a PR on a lint finding), so per the
+  # AGENTS.md convention it carries BOTH a passes-on-good-input and a blocks-on-bad-input
+  # self-test — a happy-path test alone cannot catch a gate that silently stopped biting.
+  # apply-fixes is false here: the self-test must never commit to the branch under test.
+  test-lint-workflow:
+    if: "${{ !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
+    name: "[Test] Lint - Passes On Clean Fixture"
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    uses: ./.github/workflows/lint.yaml
+    with:
+      working-directory: .github/tests/megalinter-clean-fixture
+      apply-fixes: false
+
+  test-lint-blocks:
+    if: "${{ !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
+    name: "[Test] Lint - Blocks On Invalid Fixture"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: 📄 Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # Same MegaLinter image SHA as lint.yaml's gate (guarded by test-lint-gate-lockstep),
+      # pointed at a fixture whose JSON has a syntax error no formatter can auto-fix — so
+      # APPLY_FIXES cannot mask it and the run must exit non-zero. continue-on-error lets
+      # the next step assert the failure. Reports go to a dedicated folder the assertion
+      # reads, which distinguishes a real lint block from an operational failure (e.g. an
+      # image pull error), which would leave no report at all.
+      - name: 🧹 Lint invalid fixture (expected to fail)
+        id: ml
+        continue-on-error: true
+        uses: oxsecurity/megalinter/flavors/go@ef3e84b8b836d76db562d0f3ed7da61e8fd538bc # v9.6.0
+        env:
+          DEFAULT_WORKSPACE: .github/tests/megalinter-bad-fixture
+          REPORT_OUTPUT_FOLDER: ${{ github.workspace }}/megalinter-bad-fixture-reports
+          VALIDATE_ALL_CODEBASE: true
+          APPLY_FIXES: none
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: ✅ Assert the lint gate blocked on the invalid fixture
+        shell: bash
+        env:
+          OUTCOME: ${{ steps.ml.outcome }}
+        run: |
+          set -euo pipefail
+          REPORTS="${GITHUB_WORKSPACE}/megalinter-bad-fixture-reports"
+          if [ "$OUTCOME" != "failure" ]; then
+            echo "::error::MegaLinter should FAIL on the deliberately-invalid JSON in .github/tests/megalinter-bad-fixture, but its outcome was '$OUTCOME'. lint.yaml's gate is no longer blocking on lint findings."
+            exit 1
+          fi
+          if ! grep -rqF "bad.json" "$REPORTS" 2>/dev/null; then
+            echo "::error::MegaLinter failed, but no report named the bad.json fixture — the failure was operational (e.g. an image pull error), not a real lint block. Reports:"
+            ls -R "$REPORTS" 2>/dev/null || echo "(no reports captured)"
+            exit 1
+          fi
+          echo "Lint gate correctly blocked on the invalid JSON fixture ✅"
+
+  test-lint-gate-lockstep:
+    if: "${{ !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
+    name: "[Test] Lint - Gate Pins Self-Tested Image"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: 📄 Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # `uses:` cannot be parametrized, so test-lint-blocks hard-codes the MegaLinter image
+      # SHA. This guard asserts lint.yaml pins that SAME SHA — and that validate-go-project
+      # .yaml, the org's other MegaLinter consumer, has not drifted onto a different image.
+      # If any of the three is bumped alone, this goes red and forces them to move together.
+      - name: 🔒 Assert both gates pin the self-tested MegaLinter image
+        shell: bash
+        env:
+          # Match the full `uses:` line, not the bare SHA — the SHA also appears in
+          # comments, so a bare grep could false-pass if the real `uses:` changed while a
+          # comment still named the old one.
+          EXPECTED: "uses: oxsecurity/megalinter/flavors/go@ef3e84b8b836d76db562d0f3ed7da61e8fd538bc"
+        run: |
+          set -euo pipefail
+          status=0
+          for gate in .github/workflows/lint.yaml .github/workflows/validate-go-project.yaml; do
+            if ! grep -qF "$EXPECTED" "$gate"; then
+              echo "::error::$gate no longer pins '$EXPECTED'. If the MegaLinter image was bumped intentionally, update test-lint-blocks, both gates and this EXPECTED value together so the failure-mode self-test keeps exercising the real gate."
+              status=1
+            fi
+          done
+          if [ "$status" -ne 0 ]; then
+            exit 1
+          fi
+          echo "Both MegaLinter gates pin the self-tested image ✅"
+
   # ── gate ────────────────────────────────────────────────────
   ci-required-checks:
     name: CI - Required Checks
@@ -2504,6 +2615,9 @@ jobs:
       - test-validate-go-test-blocks
       - test-validate-go-gate-lockstep
       - test-validate-go-project-concurrency-key
+      - test-lint-workflow
+      - test-lint-blocks
+      - test-lint-gate-lockstep
       - test-run-dotnet-tests-blocks
       - test-run-dotnet-tests-gate-lockstep
       - test-run-dotnet-tests-coverage-inline-lockstep
@@ -2589,6 +2703,9 @@ jobs:
             ${{ needs.test-validate-go-test-blocks.result }}
             ${{ needs.test-validate-go-gate-lockstep.result }}
             ${{ needs.test-validate-go-project-concurrency-key.result }}
+            ${{ needs.test-lint-workflow.result }}
+            ${{ needs.test-lint-blocks.result }}
+            ${{ needs.test-lint-gate-lockstep.result }}
             ${{ needs.test-run-dotnet-tests-blocks.result }}
             ${{ needs.test-run-dotnet-tests-gate-lockstep.result }}
             ${{ needs.test-run-dotnet-tests-coverage-inline-lockstep.result }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2437,8 +2437,12 @@ jobs:
   test-lint-workflow:
     if: "${{ !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
     name: "[Test] Lint - Passes On Clean Fixture"
+    # contents: write even though apply-fixes is false and this job never pushes. A caller
+    # must grant at least what the called workflow's jobs declare, and lint.yaml's job
+    # declares contents: write for the auto-fix commit. Granting less is not a narrower
+    # permission — it is a startup failure, and the whole CI workflow never runs.
     permissions:
-      contents: read
+      contents: write
       issues: write
       pull-requests: write
     uses: ./.github/workflows/lint.yaml

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,150 @@
+name: 🧹 Lint
+
+# Repo-wide linting with MegaLinter, for consumers that are NOT plain Go modules.
+#
+# validate-go-project.yaml already embeds a MegaLinter job, but it is one stage of a
+# full Go pipeline (tidy, golangci-lint, deadcode, govulncheck, build, test, coverage)
+# and scopes MegaLinter to the Go module directory. A repo whose Go code is one subtree
+# of a larger tree — a Godot client plus a Go server, say — needs the opposite: lint the
+# WHOLE repo, and leave the Go build/test to the consumer's own job. That is this
+# workflow.
+#
+# Flavor: `go`. MegaLinter's flavors differ only in which linters are baked into the
+# image, and the `go` flavor's 55 cover every surface this org actually lints — Go, JSON,
+# Markdown, YAML, shell, GitHub Actions, Dockerfile, Kubernetes, spelling, secrets and
+# copy-paste. `cupcake` adds Python/Terraform/JS at roughly double the image; `all` adds
+# far more still. Staying on `go` also means consumers share one warm image layer with
+# validate-go-project.yaml. Keep the SHA below in lockstep with that workflow's.
+#
+# NOTE: `workflow_call` only — deliberately NO `pull_request`/`merge_group` triggers. A
+# repo already covered by the org-required validate-go-project.yaml would otherwise run
+# MegaLinter twice on every PR.
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        required: false
+        type: string
+        default: ""
+        description: "Directory to lint. Empty = the whole repository (the normal case); the CI self-test sets it to a fixture."
+      go-version-file:
+        required: false
+        type: string
+        default: ""
+        description: "Path to a go.mod. When set, Go is installed before linting so MegaLinter's Go linters run against the module's own toolchain instead of the container's (which lags patched releases). Leave empty when the consumer disables the Go linters or has no Go code."
+      apply-fixes:
+        required: false
+        type: boolean
+        default: true
+        description: "Auto-fix what the linters can fix and commit the result back to the PR branch. Set false for a read-only gate (and in the self-test, which must never commit to the branch under test)."
+      pr-owner:
+        required: false
+        type: string
+        default: ""
+        description: "Pull request author login. Auto-fix commits are suppressed for dependency-bot PRs, whose branches are owned by their automation."
+    secrets:
+      APP_PRIVATE_KEY:
+        description: "GitHub App private key. Required only for auto-fix commits; without it the job still lints, but a fixable finding fails the build instead of being committed."
+        required: false
+
+# A reusable workflow inherits the CALLER's github.workflow, so keying on it keeps
+# separate invocations in separate groups while runs of the same invocation supersede
+# (devantler-tech/actions#587).
+concurrency:
+  group: "lint-${{ github.repository }}-${{ github.ref }}-${{ github.workflow }}"
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  lint:
+    name: 🧹 Lint - mega-linter
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      # continue-on-error: a consumer without the App configured (or a fork PR, where
+      # secrets are unavailable) still gets a lint gate — it just cannot commit fixes.
+      # The final step turns that into a clear failure rather than a silent pass.
+      - name: 🔑 Generate GitHub App Token
+        if: ${{ inputs.apply-fixes }}
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: generate-token
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # Least-privilege: this token only pushes auto-fixes back to the PR branch.
+          # MegaLinter's PR/issue reporting uses the default GITHUB_TOKEN.
+          permission-contents: write
+
+      - name: 📄 Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: ${{ steps.generate-token.outcome == 'success' }}
+          token: ${{ steps.generate-token.outputs.token || github.token }}
+
+      - name: ⚙️ Setup Go
+        if: ${{ inputs.go-version-file != '' }}
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: ${{ inputs.go-version-file }}
+
+      # Keep this `uses:` in lockstep with validate-go-project.yaml's MegaLinter step
+      # (enforced by test-lint-gate-lockstep) so both consumers run the same image and
+      # the failure-mode self-test always exercises the real gate.
+      - name: 🧹 Lint
+        id: ml
+        uses: oxsecurity/megalinter/flavors/go@ef3e84b8b836d76db562d0f3ed7da61e8fd538bc # v9.6.0
+        env:
+          DEFAULT_WORKSPACE: ${{ inputs.working-directory || '.' }}
+          MEGALINTER_CONFIG: ${{ github.workspace }}/.mega-linter.yml
+          VALIDATE_ALL_CODEBASE: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APPLY_FIXES: ${{ inputs.apply-fixes && 'all' || 'none' }}
+          APPLY_FIXES_EVENT: all
+          APPLY_FIXES_MODE: commit
+          # actionlint (<=1.7.12, bundled in MegaLinter) doesn't yet know the `code-quality`
+          # permission scope that GitHub Code Quality coverage requires callers to grant, so
+          # it reports a false "unknown permission scope" error. Ignore it until actionlint
+          # catches up.
+          ACTION_ACTIONLINT_ARGUMENTS: -ignore code-quality
+
+      - name: Commit and push applied linter fixes
+        if: |
+          inputs.apply-fixes
+          && steps.generate-token.outcome == 'success'
+          && github.event_name == 'pull_request'
+          && !contains(fromJSON('["dependabot[bot]","dependabot","renovate[bot]","renovatebot","renovate"]'), github.event.pull_request.user.login)
+          && !contains(fromJSON('["dependabot[bot]","dependabot","renovate[bot]","renovatebot","renovate"]'), inputs.pr-owner)
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
+        with:
+          commit_message: "chore: Apply megalinter fixes"
+          commit_user_name: megalinter-bot
+          commit_user_email: 129584137+megalinter-bot@users.noreply.github.com
+
+      # Auto-fix was requested but the fixes could not be committed (no App token — a fork
+      # PR, or an unconfigured consumer). Leaving them uncommitted would pass a PR whose
+      # tree is still unformatted, so fail loudly with the diff instead.
+      - name: ❌ Fail if uncommitted changes remain
+        if: ${{ inputs.apply-fixes && steps.generate-token.outcome != 'success' }}
+        shell: bash
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::Auto-fix produced changes that cannot be committed (no App token — e.g. a fork PR). Please run the fix locally and push."
+            echo ""
+            echo "Changed files:"
+            git diff --stat
+            echo ""
+            echo "Full diff:"
+            git diff
+            exit 1
+          fi

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -74,8 +74,17 @@ jobs:
       # continue-on-error: a consumer without the App configured (or a fork PR, where
       # secrets are unavailable) still gets a lint gate — it just cannot commit fixes.
       # The final step turns that into a clear failure rather than a silent pass.
+      # Fork pull requests never get secrets, so the App token cannot be minted and fixes
+      # can never be committed back. Auto-fixing there would leave changes that the job then
+      # fails on — a red check an outside contributor cannot resolve except by installing
+      # this image locally. So forks lint READ-ONLY: nothing is fixed, nothing is left
+      # uncommitted, nothing fails for a reason they cannot act on.
+      #
+      # This is not a softer gate. With APPLY_FIXES=none a fixable formatting issue is
+      # reported as a warning and MegaLinter exits 0, but real lint ERRORS — invalid JSON,
+      # shellcheck failures — still fail the job exactly as they do on a branch.
       - name: 🔑 Generate GitHub App Token
-        if: ${{ inputs.apply-fixes }}
+        if: ${{ inputs.apply-fixes && github.event.pull_request.head.repo.fork != true }}
         continue-on-error: true
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
@@ -109,7 +118,7 @@ jobs:
           MEGALINTER_CONFIG: ${{ github.workspace }}/.mega-linter.yml
           VALIDATE_ALL_CODEBASE: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          APPLY_FIXES: ${{ inputs.apply-fixes && 'all' || 'none' }}
+          APPLY_FIXES: ${{ inputs.apply-fixes && github.event.pull_request.head.repo.fork != true && 'all' || 'none' }}
           APPLY_FIXES_EVENT: all
           APPLY_FIXES_MODE: commit
           # actionlint (<=1.7.12, bundled in MegaLinter) doesn't yet know the `code-quality`
@@ -135,7 +144,7 @@ jobs:
       # PR, or an unconfigured consumer). Leaving them uncommitted would pass a PR whose
       # tree is still unformatted, so fail loudly with the diff instead.
       - name: ❌ Fail if uncommitted changes remain
-        if: ${{ inputs.apply-fixes && steps.generate-token.outcome != 'success' }}
+        if: ${{ inputs.apply-fixes && github.event.pull_request.head.repo.fork != true && steps.generate-token.outcome != 'success' }}
         shell: bash
         run: |
           if [ -n "$(git status --porcelain)" ]; then

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -5,3 +5,12 @@ DISABLE_LINTERS:
   - GO_GOLANGCI_LINT
   - REPOSITORY_GRYPE
   - SPELL_CSPELL
+
+# .github/tests/megalinter-bad-fixture/ holds a deliberately-invalid file that the
+# lint.yaml failure-mode self-test (test-lint-blocks) points MegaLinter at, to prove the
+# gate still BITES. Every other gate's fixture escapes its scanner by living outside that
+# scanner's discovery path; MegaLinter scans the whole tree, so this exclusion is how the
+# same separation is achieved here. Without it the repo's own MegaLinter run would fail on
+# the fixture. Keep the exclusion this narrow — never widen it to the whole tests folder,
+# which would silently stop linting real fixtures.
+FILTER_REGEX_EXCLUDE: (\.github/tests/megalinter-bad-fixture/.*)

--- a/README.md
+++ b/README.md
@@ -286,6 +286,45 @@ jobs:
 
 </details>
 
+### 🧹 Lint
+
+<details>
+<summary>Click to expand</summary>
+
+[.github/workflows/lint.yaml](.github/workflows/lint.yaml) lints a whole repository with [MegaLinter](https://megalinter.io) (Go flavor), auto-fixing what it can and committing the result back to the pull request.
+
+**Which one do I want?** If your repository *is* a Go module, use [✅ Validate Go Project](#-validate-go-project) — it already runs MegaLinter as one stage of a full Go pipeline. Reach for this workflow when Go is only part of a larger tree (a game client plus a Go server, for example): it lints everything and leaves the Go build and tests to your own job.
+
+The Go flavor covers Go, JSON, Markdown, YAML, shell, GitHub Actions, Dockerfile, Kubernetes, spelling, secrets and copy-paste. It has no GDScript, Python or Terraform linters — see [MegaLinter's flavor list](https://megalinter.io/latest/flavors/) if you need those.
+
+Configure the linters themselves in a `.mega-linter.yml` at your repository root, as usual.
+
+#### Usage
+
+```yaml
+jobs:
+  lint:
+    uses: devantler-tech/actions/.github/workflows/lint.yaml@{ref} # ref
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    secrets:
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+```
+
+#### Secrets and Inputs
+
+| Key                 | Type            | Default | Required | Description                                                                                                          |
+|---------------------|-----------------|---------|----------|----------------------------------------------------------------------------------------------------------------------|
+| `APP_PRIVATE_KEY`   | Secret          | -       | No       | GitHub App private key. Needed only to commit auto-fixes; without it a fixable finding fails the build instead        |
+| `working-directory` | Input           | `""`    | No       | Directory to lint. Empty lints the whole repository                                                                   |
+| `go-version-file`   | Input           | `""`    | No       | Path to a `go.mod`. When set, Go is installed first so the Go linters use the module's toolchain, not the container's |
+| `apply-fixes`       | Input (boolean) | `true`  | No       | Auto-fix and commit back to the pull request. Set `false` for a read-only gate                                        |
+| `pr-owner`          | Input           | `""`    | No       | Pull request author login. Auto-fix commits are suppressed for dependency-bot pull requests                           |
+
+</details>
+
 ### 📦 Publish App
 
 <details>

--- a/README.md
+++ b/README.md
@@ -299,6 +299,10 @@ The Go flavor covers Go, JSON, Markdown, YAML, shell, GitHub Actions, Dockerfile
 
 Configure the linters themselves in a `.mega-linter.yml` at your repository root, as usual.
 
+**Grant `contents: write`, even if you set `apply-fixes: false`.** A caller must grant at least what the called workflow's jobs declare. Granting less is not a narrower permission — GitHub rejects the call when it loads the file, and *the entire calling workflow* returns `startup_failure` with no jobs at all, which looks exactly like the workflow never triggering. `actionlint` does not catch it.
+
+**Fork pull requests lint read-only, automatically.** GitHub withholds secrets from forks, so fixes could never be committed back; auto-fixing there would only produce a failure an outside contributor cannot resolve. Real lint errors still fail on forks — only the auto-fix half is skipped.
+
 #### Usage
 
 ```yaml


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

World at Ruin has no repo-wide linting — its JSON, Markdown, YAML, shell and GitHub Actions files are checked by nothing today. The obvious fix is to reuse what every other repo uses, but the existing `validate-go-project` workflow does not fit: it runs MegaLinter as one stage of a full Go pipeline and scopes it to the Go module directory. World at Ruin is a Godot client with a Go server in a subtree, so that would lint the server and ignore the rest of the repo.

## What

A new `lint.yaml` reusable workflow that lints a whole repository with MegaLinter and leaves the Go build and tests to the caller. It is `workflow_call` only, so a repo already covered by the org-required `validate-go-project` never runs MegaLinter twice.

It ships with the failure-mode coverage this repo requires of a gating workflow — a passes-on-clean test and a blocks-on-invalid test — plus a guard that keeps `lint.yaml`, `validate-go-project.yaml` and the self-test pinned to one MegaLinter image, so none can drift alone.

**No behaviour change for existing consumers.** Nothing calls this yet; `validate-go-project.yaml` is untouched.

**Merge order:** this lands first. The World at Ruin caller (devantler-tech/world-at-ruin#283) pins a released SHA from here and cannot merge until this does.

Part of devantler-tech/world-at-ruin#269
