### PR TITLE
fix(dotnet): withhold package token from pull requests

### DIFF
--- a/.github/workflows/run-dotnet-tests.yaml
+++ b/.github/workflows/run-dotnet-tests.yaml
@@ -57,5 +57,8 @@ jobs:
       - name: 🧪 Test .NET solution or project
         uses: ./.devantler-tech-actions/run-dotnet-tests
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Never expose a package-capable credential to pull-request-controlled
+          # MSBuild targets or test code. Private GitHub Packages remain available
+          # to trusted workflow_call and merge-queue runs.
+          github-token: ${{ github.event_name != 'pull_request' && secrets.GITHUB_TOKEN || '' }}
           working-directory: ${{ inputs.working-directory || '.' }}

--- a/README.md
+++ b/README.md
@@ -413,7 +413,11 @@ jobs:
 
 #### Secrets and Inputs
 
-This workflow needs no caller-provided secrets or inputs — it authenticates to the GHCR NuGet feed with the automatic `GITHUB_TOKEN` (requires the `packages: read` permission shown above).
+This workflow needs no caller-provided secrets or inputs. Trusted `workflow_call` and
+merge-queue runs authenticate to the GHCR NuGet feed with the automatic `GITHUB_TOKEN`
+(requiring the `packages: read` permission shown above). Pull-request runs deliberately
+omit that credential so repository-controlled MSBuild targets and test code cannot read
+or exfiltrate it; consequently, private GitHub Packages are unavailable in that context.
 
 </details>
 

--- a/run-dotnet-tests/README.md
+++ b/run-dotnet-tests/README.md
@@ -8,7 +8,7 @@ Test .NET solutions or projects across multiple platforms with code coverage rep
 
 | Name | Description | Required | Default |
 |------|-------------|----------|---------|
-| `github-token` | GitHub token to access the repository | ✅ | - |
+| `github-token` | GitHub token used to access private GitHub Packages. Do not pass it when testing untrusted code. | ❌ | - |
 | `working-directory` | Directory to run the tests in | ❌ | `.` |
 
 ## Usage

--- a/run-dotnet-tests/action.yaml
+++ b/run-dotnet-tests/action.yaml
@@ -3,8 +3,8 @@ description: Test .NET solution or project
 author: devantler-tech
 inputs:
   github-token:
-    description: GitHub token to access the repository
-    required: true
+    description: GitHub token used to access private GitHub Packages; omit for untrusted code
+    required: false
   working-directory:
     description: Directory to run the tests in
     required: false
@@ -21,6 +21,7 @@ runs:
           9
           10
     - name: 🚚 Add GHCR as NuGet feed
+      if: inputs.github-token != ''
       run: |
         dotnet nuget add source \
           --username ${GITHUB_ACTOR} \


### PR DESCRIPTION
### Motivation

> 🤖 Generated by the Daily AI Assistant.

- Patch a high-severity credential-exposure issue where the workflow wrote `secrets.GITHUB_TOKEN` into NuGet configuration with `--store-password-in-clear-text` before running `dotnet test`, allowing PR-controlled build/test code to read and exfiltrate the token.
- Ensure private GitHub Packages access remains for trusted callers while preventing untrusted pull-request runs from receiving package-capable credentials.

### Description

- Stop passing a package-capable token into PR runs by changing the reusable workflow call to supply `github-token: ${{ github.event_name != 'pull_request' && secrets.GITHUB_TOKEN || '' }}` so pull-request executions receive an empty token.
- Make the composite action's `github-token` input optional by changing `required: true` → `required: false` and guard the `dotnet nuget add source` step with `if: inputs.github-token != ''` so no cleartext credential is written when the token is absent.
- Update `run-dotnet-tests/README.md` and the repo `README.md` to document that private GitHub Packages are intentionally unavailable to pull-request runs and that callers should only pass package credentials for trusted invocations.

### Testing

- Verified YAML parsing of the changed files with Ruby/Psych successfully parsed `.github/workflows/run-dotnet-tests.yaml` and `run-dotnet-tests/action.yaml`.
- Ran targeted Python assertions that confirm the pull-request token suppression expression is present and the composite action step is guarded by `if: inputs.github-token != ''` which precedes the cleartext NuGet command, and `git diff --check` reported no whitespace issues.
- Committed the changes and verified the repository working tree is clean after the commit; `yamllint`, `actionlint`, and `zizmor` were not available in the execution environment so those automated checks were not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c172782f0832b9b6e614e29d84beb)