### PR TITLE
fix(enable-auto-merge): exclude Renovate from trusted authors

### DIFF
--- a/.github/tests/enable-auto-merge-authors.json
+++ b/.github/tests/enable-auto-merge-authors.json
@@ -18,7 +18,7 @@
     "event_name": "pull_request",
     "draft": false,
     "login": "renovate[bot]",
-    "eligible": true
+    "eligible": false
   },
   {
     "name": "GitHub Actions",

--- a/.github/workflows/enable-auto-merge.yaml
+++ b/.github/workflows/enable-auto-merge.yaml
@@ -68,7 +68,7 @@ jobs:
               github.event_name == 'pull_request' &&
               !github.event.pull_request.draft &&
               contains(
-                fromJSON('["dependabot[bot]","renovate[bot]","github-actions[bot]","ksail-bot[bot]","coderabbitai[bot]"]'),
+                fromJSON('["dependabot[bot]","github-actions[bot]","ksail-bot[bot]","coderabbitai[bot]"]'),
                 github.event.pull_request.user.login
               )
             ) ||
@@ -80,7 +80,7 @@ jobs:
               ) &&
               !github.event.pull_request.draft &&
               contains(
-                fromJSON('["dependabot[bot]","renovate[bot]","github-actions[bot]","ksail-bot[bot]","coderabbitai[bot]"]'),
+                fromJSON('["dependabot[bot]","github-actions[bot]","ksail-bot[bot]","coderabbitai[bot]"]'),
                 github.event.pull_request.user.login
               )
             ) ||
@@ -93,7 +93,7 @@ jobs:
                 github.event.comment.user.login
               ) &&
               contains(
-                fromJSON('["dependabot[bot]","renovate[bot]","github-actions[bot]","ksail-bot[bot]","coderabbitai[bot]"]'),
+                fromJSON('["dependabot[bot]","github-actions[bot]","ksail-bot[bot]","coderabbitai[bot]"]'),
                 github.event.issue.user.login
               )
             )


### PR DESCRIPTION
### Motivation

- A security scan flagged that `renovate[bot]` was added to the privileged auto-merge allowlist and could be auto-approved and auto-armed without additional dependency-review or head-binding checks, expanding an attack surface for dependency update PRs.

### Description

- Remove `renovate[bot]` from the privileged author classification arrays in ` .github/workflows/enable-auto-merge.yaml` so Renovate PRs are no longer eligible for the legacy bot approve-and-arm path.
- Update the regression fixture ` .github/tests/enable-auto-merge-authors.json` to mark `renovate[bot]` as ineligible so tests reflect the tightened allowlist.
- Preserve all other allowlisted bot identities and the enforced review-gate machinery; this change is narrowly scoped to authorship classification only.

### Testing

- Ran `git diff --check` which produced no whitespace/patch problems and a clean diff for the two modified files (success).
- Validated the updated fixture with `python -m json.tool .github/tests/enable-auto-merge-authors.json` which succeeded (success).
- Parsed the workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0), aliases: true)' .github/workflows/enable-auto-merge.yaml` which succeeded (success).
- Repository-specific author-gate script `bash .github/tests/test-enable-auto-merge-author-gate.sh` could not be executed because `yq` is not installed in the environment (not run).
- Linting tools `yamllint`, `actionlint`, and `zizmor` were not available in the environment so those checks could not be executed (not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c10055f74832bb807bf160b549169)