### PR TITLE
fix: stop persisting Go module tokens in setup-go-toolchain

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -661,12 +661,12 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: 🧪 Run setup-go-toolchain with token
+      - name: 🧪 Run setup-go-toolchain with private module discovery
         uses: ./setup-go-toolchain
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: ✅ Verify GOPRIVATE is set
+      - name: ✅ Verify private module configuration is safe
         shell: bash
         run: |
           goprivate=$(go env GOPRIVATE)
@@ -675,6 +675,11 @@ jobs:
             exit 1
           fi
           echo "GOPRIVATE: $goprivate"
+
+          if git config --global --get-regexp '^url\..*\.insteadof$' 2>/dev/null | grep -q 'x-access-token'; then
+            echo "::error::A GitHub token was persisted in global Git configuration"
+            exit 1
+          fi
 
   # ── setup-ksail-cli ────────────────────────────────────────
   test-setup-ksail-cli:

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ flowchart TD
 | [login-to-ghcr](login-to-ghcr/README.md) | Login to GitHub Container Registry |
 | [run-dotnet-tests](run-dotnet-tests/README.md) | Test .NET solution or project with coverage |
 | [setup-agent-skills](setup-agent-skills/README.md) | Install agent skills via `gh skill` from a newline list of `<owner/repo> <skill>[@pin]` entries, for one or more agents (e.g. Copilot, Claude Code) |
-| [setup-go-toolchain](setup-go-toolchain/README.md) | Setup Go with optional private module support |
+| [setup-go-toolchain](setup-go-toolchain/README.md) | Setup Go with private module discovery |
 | [setup-ksail-cli](setup-ksail-cli/README.md) | Install KSail CLI via Homebrew |
 | [update-agent-skills](update-agent-skills/README.md) | Run `gh skill update --all` against installed skills and report changes |
 | [upload-coverage](upload-coverage/README.md) | Upload a Cobertura coverage report to GitHub Code Quality |

--- a/setup-go-toolchain/README.md
+++ b/setup-go-toolchain/README.md
@@ -1,13 +1,13 @@
 # Setup Go Toolchain
 
-Setup Go with optional private module support for devantler-tech repositories.
+Setup Go with private module discovery for devantler-tech repositories.
 
 ## Inputs
 
 | Name | Description | Required | Default |
 |------|-------------|----------|---------|
 | `go-version` | Go version to install | ❌ | `stable` |
-| `github-token` | GitHub token for private module access | ❌ | - |
+| `github-token` | Deprecated and ignored; retained for compatibility | ❌ | - |
 
 ## Outputs
 
@@ -37,10 +37,14 @@ steps:
 
 ### With private module support
 
+The action configures `GOPRIVATE` so the Go toolchain recognizes
+`github.com/devantler-tech/*` as private. Configure authentication separately in
+a trusted step that limits the credential to the operation that needs it. The
+action intentionally does not accept or persist a token because later steps can
+read credentials stored in the runner's Git configuration.
+
 ```yaml
 steps:
   - name: Setup Go
     uses: devantler-tech/actions/setup-go-toolchain@main
-    with:
-      github-token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/setup-go-toolchain/action.yaml
+++ b/setup-go-toolchain/action.yaml
@@ -1,5 +1,5 @@
 name: Setup Go Toolchain
-description: Setup Go with optional private module support for devantler-tech
+description: Setup Go with private module discovery for devantler-tech
 author: devantler-tech
 inputs:
   go-version:
@@ -7,7 +7,7 @@ inputs:
     required: false
     default: stable
   github-token:
-    description: GitHub token for private module access
+    description: Deprecated; tokens are not persisted by this action
     required: false
 outputs:
   go-version:
@@ -22,11 +22,6 @@ runs:
       with:
         go-version: ${{ inputs.go-version }}
 
-    - name: 🔑 Configure private modules
-      if: inputs.github-token != ''
+    - name: 🔒 Configure private module discovery
       shell: bash
-      env:
-        TOKEN: ${{ inputs.github-token }}
-      run: |
-        go env -w GOPRIVATE=github.com/devantler-tech/*
-        git config --global url."https://x-access-token:${TOKEN}@github.com/devantler-tech/".insteadOf "https://github.com/devantler-tech/"
+      run: go env -w GOPRIVATE=github.com/devantler-tech/*


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

`setup-go-toolchain` persisted a supplied GitHub token in the runner global Git configuration, making the credential readable by every later step in the job.

## What

Keep private-module discovery while removing credential persistence. The legacy input remains accepted but ignored for compatibility; callers that need private-module authentication must scope it to their trusted operation instead of leaving it in runner-global state.