### PR TITLE
fix(upsert-issue): prevent jq injection through issue titles

### DIFF
--- a/upsert-issue/action.yaml
+++ b/upsert-issue/action.yaml
@@ -83,20 +83,18 @@ runs:
 
         # Search for existing issue by exact title (any state).
         # Prefer an open issue; fall back to the most recent closed one.
-        ISSUE_NUMBER=$(
-          retry gh issue list \
-            --repo "$REPO" \
-            --state all \
-            --search "in:title \"${TITLE}\"" \
-            --json number,title,state \
-            --jq "
-              [ .[] | select(.title == \"${TITLE}\") ] |
-              ([ .[] | select(.state == \"OPEN\") ] | first // empty) as \$open |
-              if \$open then \$open.number
-              else (last // empty | .number)
-              end
-            "
-        )
+        ISSUES_JSON=$(retry gh issue list \
+          --repo "$REPO" \
+          --state all \
+          --search "in:title \"${TITLE}\"" \
+          --json number,title,state)
+        ISSUE_NUMBER=$(jq -r --arg title "$TITLE" '
+          [ .[] | select(.title == $title) ] |
+          ([ .[] | select(.state == "OPEN") ] | first // empty) as $open |
+          if $open then $open.number
+          else (last // empty | .number)
+          end
+        ' <<< "$ISSUES_JSON")
 
         if [ "$OPEN" = "true" ]; then
           if [ -n "$ISSUE_NUMBER" ]; then


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Motivation
- The `upsert-issue` composite action interpolated the `title` input directly into the `gh --jq` program, allowing a crafted title to inject jq source and read environment values such as `GH_TOKEN` or fabricate an issue number. 
- The goal is to treat untrusted titles as data (not code) so they cannot alter the jq program while preserving exact-title matching and current open/closed selection semantics.

### Description
- Stop interpolating `TITLE` into `gh --jq` source; instead fetch the JSON with `gh issue list --json` and run a static `jq` program that receives the title via `--arg title "$TITLE"` to perform exact-title selection. 
- Preserve existing logic that prefers an open issue and falls back to the most recent closed issue when selecting an issue number. 
- Keep the rest of the flow unchanged (create/edit/reopen/close behavior and outputs), with only minimal bash/YAML edits in `upsert-issue/action.yaml` to implement the safer lookup.

### Testing
- Ran the targeted malicious-title regression check and confirmed the reported injection payload produced no issue number. 
- Ran an exact-quoted-title test and confirmed the selection still chooses the open issue as before. 
- Verified YAML structure with a Ruby `YAML.load_file` parse and performed `git diff --check` and local git checks; `actionlint`, `yamllint`, and `zizmor` were not available in the environment so those linters were not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c0a5b18e4832bbad4964d9e86d7fe)