### PR TITLE
fix: keep approve-pr CI test unprivileged

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,8 +25,7 @@ jobs:
   test-approve-pr:
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
-      contents: write
+      contents: read
     if: >-
       !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') &&
       startsWith(github.event_name, 'pull_request') &&
@@ -45,9 +44,9 @@ jobs:
       - name: 🧪 Run approve-pr
         uses: ./approve-pr
         with:
-          client-id: ${{ vars.APP_CLIENT_ID }}
-          app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          app-private-key: dry-run-placeholder
           pr-number: ${{ github.event.pull_request.number }}
+          dry-run: true
 
   # ── cleanup-ghcr-packages ───────────────────────────────────
   test-cleanup-ghcr-packages:


### PR DESCRIPTION
### Motivation

> 🤖 Generated by the Daily AI Assistant.

- Mitigate a CI/CD supply-chain secret exposure where a pull-request could run a PR-controlled local composite action (`./approve-pr`) with a GitHub App private key and write permissions.
- Preserve the CI validation of the `approve-pr` action while ensuring PRs cannot receive real secrets or a write-capable token.

### Description

- Reduced the `test-approve-pr` job permissions to `contents: read` so it no longer grants write capabilities to PR-run jobs in `.github/workflows/ci.yaml`.
- Removed passing `vars.APP_CLIENT_ID` and `secrets.APP_PRIVATE_KEY` into the PR-controlled local action and replaced the private key with a non-secret placeholder `app-private-key: dry-run-placeholder`.
- Enabled the action's dry-run path by adding `dry-run: true` to the `approve-pr` invocation so the test exercises the action without minting an App token or approving the PR.

### Testing

- Repository sanity checks (`git diff --check`) passed.
- YAML parse via Ruby/Psych succeeded for the modified workflow file.
- Targeted grep/sed check confirmed the `test-approve-pr` job contains neither secret expressions nor write permissions and reported success.
- Lint tools (`yamllint`, `zizmor`, `actionlint`) could not be executed due to outbound package/download restrictions in the execution environment, so they were not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c09728d80832b80de048a1baf559e)