### PR TITLE
fix(agent-skills): verify gh release attestations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -801,7 +801,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: 🧪 Exercise ensure-gh-skill.sh (guards, fast-return, platform/arch errors)
+      - name: 🧪 Exercise ensure-gh-skill.sh (guards, fast-return, platform/arch/integrity errors)
         shell: bash
         run: |
           set -uo pipefail
@@ -942,7 +942,33 @@ jobs:
           fi
           echo "✅ stale-but-skill-capable: bypassed fast-return into install path"
 
-          # 8. macOS (ext=zip) with unzip absent → the zip-needs-unzip guard fires
+          # 8. A downloaded archive whose GitHub artifact attestation does not
+          #    verify must never reach extraction or installation. The fake curl
+          #    models a substituted release asset; the trusted, preinstalled gh
+          #    verifier deliberately rejects it.
+          untrusted=$(mktemp -d)
+          cat > "$untrusted/gh" <<'EOF'
+          #!/usr/bin/env bash
+          if [ "$1" = "attestation" ] && [ "$2" = "--help" ]; then exit 0; fi
+          if [ "$1" = "attestation" ] && [ "$2" = "verify" ]; then exit 1; fi
+          if [ "$1" = "skill" ]; then exit 1; fi
+          exit 0
+          EOF
+          cat > "$untrusted/curl" <<'EOF'
+          #!/usr/bin/env bash
+          while [ "$1" != "-o" ]; do shift; done
+          printf 'substituted archive' > "$2"
+          EOF
+          chmod +x "$untrusted/gh" "$untrusted/curl"
+          set +e
+          out=$(PATH="$untrusted:$PATH" REQUIRED=999.0.0 INSTALL_NAMESPACE=t bash "$script" 2>&1); status=$?
+          set -e
+          if [ "$status" -eq 0 ] || ! printf '%s' "$out" | grep -q "attestation verification failed"; then
+            echo "::error::expected substituted archive to be rejected; status=$status out=$out"; exit 1
+          fi
+          echo "✅ substituted-archive: rejected before extraction"
+
+          # 9. macOS (ext=zip) with unzip absent → the zip-needs-unzip guard fires
           #    BEFORE any network download. A skill-LESS gh forces the install path;
           #    uname is faked to Darwin/arm64 (valid arch → passes the arch check);
           #    and PATH is a CURATED stub dir holding only the stubs plus the real

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1015,6 +1015,61 @@ jobs:
           fi
           echo "✅ digest-mismatch: rejected despite a passing attestation"
 
+          # 8c. An archive can pass attestation AND match the published digest and still be a
+          #     DIFFERENT release: an actor rewriting the release's assets pairs a genuinely-attested
+          #     OLDER archive with a checksums entry under this version's asset name, so both gates
+          #     above are satisfied. The post-install version assertion is what rejects it, using the
+          #     installed binary's own truthful self-report. GITHUB_PATH/RUNNER_TEMP are redirected
+          #     because this case runs all the way THROUGH install, unlike 8 and 8b.
+          oldrelease=$(mktemp -d)
+          cat > "$oldrelease/gh" <<'EOF'
+          #!/usr/bin/env bash
+          if [ "$1" = "attestation" ] && [ "$2" = "--help" ]; then exit 0; fi
+          if [ "$1" = "attestation" ] && [ "$2" = "verify" ]; then exit 0; fi
+          if [ "$1" = "skill" ]; then exit 1; fi
+          echo "gh version 2.81.0 (2026-01-01)"
+          EOF
+          cat > "$oldrelease/curl" <<'EOF'
+          #!/usr/bin/env bash
+          while [ "$1" != "-o" ]; do shift; done
+          dest="$2"
+          case "$dest" in
+            *checksums.txt)
+              a=$(ls "$(dirname "$dest")" | grep -v 'checksums.txt$' | head -1)
+              printf '%s  %s\n' "$(sha256sum "$(dirname "$dest")/$a" | awk '{print $1}')" "$a" > "$dest" ;;
+            *)
+              d=$(mktemp -d); mkdir -p "$d/gh_999.0.0_linux_amd64/bin"
+              printf '#!/usr/bin/env bash\nif [ "$1" = "skill" ]; then exit 0; fi\necho "gh version 2.40.0 (2024-01-01)"\n' \
+                > "$d/gh_999.0.0_linux_amd64/bin/gh"
+              chmod +x "$d/gh_999.0.0_linux_amd64/bin/gh"
+              tar -czf "$dest" -C "$d" gh_999.0.0_linux_amd64 ;;
+          esac
+          EOF
+          chmod +x "$oldrelease/gh" "$oldrelease/curl"
+          set +e
+          out=$(PATH="$oldrelease:$PATH" GITHUB_PATH="$oldrelease/ghpath" RUNNER_TEMP="$oldrelease/rt" \
+                REQUIRED=999.0.0 INSTALL_NAMESPACE=t bash "$script" 2>&1); status=$?
+          set -e
+          if [ "$status" -eq 0 ] || ! printf '%s' "$out" | grep -q "is older than the requested"; then
+            echo "::error::expected a downgraded release archive to be rejected after install; status=$status out=$out"; exit 1
+          fi
+          echo "✅ downgraded-release: rejected despite passing attestation and matching digest"
+
+          # 8d. Positive control for 8c: an honest archive reporting the requested version must still
+          #     install cleanly, so the assertion above cannot be satisfied by rejecting everything.
+          okrelease=$(mktemp -d)
+          cp "$oldrelease/gh" "$okrelease/gh"
+          sed 's/2\.40\.0 (2024-01-01)/999.0.0 (2026-01-01)/' "$oldrelease/curl" > "$okrelease/curl"
+          chmod +x "$okrelease/gh" "$okrelease/curl"
+          set +e
+          out=$(PATH="$okrelease:$PATH" GITHUB_PATH="$okrelease/ghpath" RUNNER_TEMP="$okrelease/rt" \
+                REQUIRED=999.0.0 INSTALL_NAMESPACE=t bash "$script" 2>&1); status=$?
+          set -e
+          if [ "$status" -ne 0 ]; then
+            echo "::error::expected an honest v999.0.0 archive to install cleanly; status=$status out=$out"; exit 1
+          fi
+          echo "✅ honest-release: installs cleanly (version assertion is not a blanket reject)"
+
           # 9. macOS (ext=zip) with unzip absent → the zip-needs-unzip guard fires
           #    BEFORE any network download. A skill-LESS gh forces the install path;
           #    uname is faked to Darwin/arm64 (valid arch → passes the arch check);

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -951,11 +951,22 @@ jobs:
           #    verify must never reach extraction or installation. The fake curl
           #    models a substituted release asset; the trusted, preinstalled gh
           #    verifier deliberately rejects it.
+          # Every fake gh asserts the SCOPE of the attestation call, not just that one happened.
+          # Without this, dropping --repo or --signer-workflow from the installer would still let
+          # each case return its expected result, so these mocks would keep passing while the
+          # verification had silently widened to "any attestation from anyone".
+          # A violation is recorded out-of-band (a marker file) rather than via the exit status,
+          # because cases 8/8b/8c all EXPECT a non-zero script exit — an in-band failure would be
+          # indistinguishable from the rejection each case is asserting.
           untrusted=$(mktemp -d)
           cat > "$untrusted/gh" <<'EOF'
           #!/usr/bin/env bash
+          assert_scope() {
+            case " $* " in *" --repo cli/cli "*) ;; *) echo "missing --repo cli/cli" >> "${GH_MOCK_SCOPE_MARKER:-/dev/null}" ;; esac
+            case " $* " in *" --signer-workflow cli/cli/.github/workflows/deployment.yml "*) ;; *) echo "missing --signer-workflow" >> "${GH_MOCK_SCOPE_MARKER:-/dev/null}" ;; esac
+          }
           if [ "$1" = "attestation" ] && [ "$2" = "--help" ]; then exit 0; fi
-          if [ "$1" = "attestation" ] && [ "$2" = "verify" ]; then exit 1; fi
+          if [ "$1" = "attestation" ] && [ "$2" = "verify" ]; then assert_scope "$@"; exit 1; fi
           if [ "$1" = "skill" ]; then exit 1; fi
           exit 0
           EOF
@@ -976,12 +987,16 @@ jobs:
           EOF
           chmod +x "$untrusted/gh" "$untrusted/curl"
           set +e
-          out=$(PATH="$untrusted:$PATH" REQUIRED=999.0.0 INSTALL_NAMESPACE=t bash "$script" 2>&1); status=$?
+          out=$(PATH="$untrusted:$PATH" GH_MOCK_SCOPE_MARKER="$untrusted/scope" \
+                REQUIRED=999.0.0 INSTALL_NAMESPACE=t bash "$script" 2>&1); status=$?
           set -e
           if [ "$status" -eq 0 ] || ! printf '%s' "$out" | grep -q "attestation verification failed"; then
             echo "::error::expected substituted archive to be rejected; status=$status out=$out"; exit 1
           fi
-          echo "✅ substituted-archive: rejected before extraction"
+          if [ -s "$untrusted/scope" ]; then
+            echo "::error::attestation verify was called without its full scope: $(cat "$untrusted/scope")"; exit 1
+          fi
+          echo "✅ substituted-archive: rejected before extraction, attestation scoped"
 
           # 8b. An archive that passes attestation but does NOT match the digest the release published
           #     for v${REQUIRED} must also be refused. This is the gate that binds the download to a
@@ -990,8 +1005,12 @@ jobs:
           wrongsum=$(mktemp -d)
           cat > "$wrongsum/gh" <<'EOF'
           #!/usr/bin/env bash
+          assert_scope() {
+            case " $* " in *" --repo cli/cli "*) ;; *) echo "missing --repo cli/cli" >> "${GH_MOCK_SCOPE_MARKER:-/dev/null}" ;; esac
+            case " $* " in *" --signer-workflow cli/cli/.github/workflows/deployment.yml "*) ;; *) echo "missing --signer-workflow" >> "${GH_MOCK_SCOPE_MARKER:-/dev/null}" ;; esac
+          }
           if [ "$1" = "attestation" ] && [ "$2" = "--help" ]; then exit 0; fi
-          if [ "$1" = "attestation" ] && [ "$2" = "verify" ]; then exit 0; fi
+          if [ "$1" = "attestation" ] && [ "$2" = "verify" ]; then assert_scope "$@"; exit 0; fi
           if [ "$1" = "skill" ]; then exit 1; fi
           exit 0
           EOF
@@ -1008,24 +1027,33 @@ jobs:
           EOF
           chmod +x "$wrongsum/gh" "$wrongsum/curl"
           set +e
-          out=$(PATH="$wrongsum:$PATH" REQUIRED=999.0.0 INSTALL_NAMESPACE=t bash "$script" 2>&1); status=$?
+          out=$(PATH="$wrongsum:$PATH" GH_MOCK_SCOPE_MARKER="$wrongsum/scope" \
+                REQUIRED=999.0.0 INSTALL_NAMESPACE=t bash "$script" 2>&1); status=$?
           set -e
           if [ "$status" -eq 0 ] || ! printf '%s' "$out" | grep -q "does not match the digest published"; then
             echo "::error::expected digest mismatch to be rejected even with a passing attestation; status=$status out=$out"; exit 1
           fi
-          echo "✅ digest-mismatch: rejected despite a passing attestation"
+          if [ -s "$wrongsum/scope" ]; then
+            echo "::error::attestation verify was called without its full scope: $(cat "$wrongsum/scope")"; exit 1
+          fi
+          echo "✅ digest-mismatch: rejected despite a passing attestation, attestation scoped"
 
           # 8c. An archive can pass attestation AND match the published digest and still be a
           #     DIFFERENT release: an actor rewriting the release's assets pairs a genuinely-attested
           #     OLDER archive with a checksums entry under this version's asset name, so both gates
           #     above are satisfied. The post-install version assertion is what rejects it, using the
-          #     installed binary's own truthful self-report. GITHUB_PATH/RUNNER_TEMP are redirected
-          #     because this case runs all the way THROUGH install, unlike 8 and 8b.
+          #     candidate binary's own truthful self-report. GITHUB_PATH/RUNNER_TEMP are redirected
+          #     because this case runs all the way to the version assertion, unlike 8 and 8b — and
+          #     the redirect is also what lets it assert the rejected candidate is never PUBLISHED.
           oldrelease=$(mktemp -d)
           cat > "$oldrelease/gh" <<'EOF'
           #!/usr/bin/env bash
+          assert_scope() {
+            case " $* " in *" --repo cli/cli "*) ;; *) echo "missing --repo cli/cli" >> "${GH_MOCK_SCOPE_MARKER:-/dev/null}" ;; esac
+            case " $* " in *" --signer-workflow cli/cli/.github/workflows/deployment.yml "*) ;; *) echo "missing --signer-workflow" >> "${GH_MOCK_SCOPE_MARKER:-/dev/null}" ;; esac
+          }
           if [ "$1" = "attestation" ] && [ "$2" = "--help" ]; then exit 0; fi
-          if [ "$1" = "attestation" ] && [ "$2" = "verify" ]; then exit 0; fi
+          if [ "$1" = "attestation" ] && [ "$2" = "verify" ]; then assert_scope "$@"; exit 0; fi
           if [ "$1" = "skill" ]; then exit 1; fi
           echo "gh version 2.81.0 (2026-01-01)"
           EOF
@@ -1048,12 +1076,26 @@ jobs:
           chmod +x "$oldrelease/gh" "$oldrelease/curl"
           set +e
           out=$(PATH="$oldrelease:$PATH" GITHUB_PATH="$oldrelease/ghpath" RUNNER_TEMP="$oldrelease/rt" \
+                GH_MOCK_SCOPE_MARKER="$oldrelease/scope" \
                 REQUIRED=999.0.0 INSTALL_NAMESPACE=t bash "$script" 2>&1); status=$?
           set -e
           if [ "$status" -eq 0 ] || ! printf '%s' "$out" | grep -q "is older than the requested"; then
-            echo "::error::expected a downgraded release archive to be rejected after install; status=$status out=$out"; exit 1
+            echo "::error::expected a downgraded release archive to be rejected; status=$status out=$out"; exit 1
           fi
-          echo "✅ downgraded-release: rejected despite passing attestation and matching digest"
+          if [ -s "$oldrelease/scope" ]; then
+            echo "::error::attestation verify was called without its full scope: $(cat "$oldrelease/scope")"; exit 1
+          fi
+          # A non-zero exit is NOT enough on its own. GITHUB_PATH is processed by the runner after
+          # the step ends regardless of exit status, so a rejected binary published before the check
+          # would still reach every later step of a `continue-on-error` caller. Assert the rejected
+          # candidate was never published.
+          if [ -s "$oldrelease/ghpath" ]; then
+            echo "::error::rejected downgrade was published to GITHUB_PATH: $(cat "$oldrelease/ghpath")"; exit 1
+          fi
+          if [ -e "$oldrelease/rt/t/bin/gh" ]; then
+            echo "::error::rejected downgrade was installed to the shared bin dir"; exit 1
+          fi
+          echo "✅ downgraded-release: rejected, and never published to GITHUB_PATH"
 
           # 8d. Positive control for 8c: an honest archive reporting the requested version must still
           #     install cleanly, so the assertion above cannot be satisfied by rejecting everything.
@@ -1068,7 +1110,16 @@ jobs:
           if [ "$status" -ne 0 ]; then
             echo "::error::expected an honest v999.0.0 archive to install cleanly; status=$status out=$out"; exit 1
           fi
-          echo "✅ honest-release: installs cleanly (version assertion is not a blanket reject)"
+          # The mirror of 8c's publication check: deferring publication until after validation must
+          # still PUBLISH on the happy path. Without this, a script that simply never wrote
+          # GITHUB_PATH would satisfy 8c while breaking every consumer.
+          if [ ! -s "$okrelease/ghpath" ]; then
+            echo "::error::honest archive installed but was never published to GITHUB_PATH"; exit 1
+          fi
+          if [ ! -x "$okrelease/rt/t/bin/gh" ]; then
+            echo "::error::honest archive was never installed to the shared bin dir"; exit 1
+          fi
+          echo "✅ honest-release: installs cleanly AND is published (version assertion is not a blanket reject)"
 
           # 9. macOS (ext=zip) with unzip absent → the zip-needs-unzip guard fires
           #    BEFORE any network download. A skill-LESS gh forces the install path;

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -954,10 +954,20 @@ jobs:
           if [ "$1" = "skill" ]; then exit 1; fi
           exit 0
           EOF
+          # The archive is served with a MATCHING checksums entry, so the digest gate passes and the
+          # attestation gate is the one under test. Without this the substituted archive is rejected
+          # one step earlier and this case would silently stop covering attestation at all.
           cat > "$untrusted/curl" <<'EOF'
           #!/usr/bin/env bash
           while [ "$1" != "-o" ]; do shift; done
-          printf 'substituted archive' > "$2"
+          case "$2" in
+            *checksums.txt)
+              # Name the archive the script actually asked for, not a hard-coded os/arch: the
+              # checksums file lists the asset, and the script downloads it before this call.
+              a=$(ls "$(dirname "$2")" | grep -v 'checksums.txt$' | head -1)
+              printf '%s  %s\n' "$(sha256sum "$(dirname "$2")/$a" | awk '{print $1}')" "$a" > "$2" ;;
+            *) printf 'substituted archive' > "$2" ;;
+          esac
           EOF
           chmod +x "$untrusted/gh" "$untrusted/curl"
           set +e
@@ -967,6 +977,38 @@ jobs:
             echo "::error::expected substituted archive to be rejected; status=$status out=$out"; exit 1
           fi
           echo "✅ substituted-archive: rejected before extraction"
+
+          # 8b. An archive that passes attestation but does NOT match the digest the release published
+          #     for v${REQUIRED} must also be refused. This is the gate that binds the download to a
+          #     specific release: attestation alone cannot, because cli/cli attests every release from
+          #     refs/heads/trunk, so its certificate is identical across versions.
+          wrongsum=$(mktemp -d)
+          cat > "$wrongsum/gh" <<'EOF'
+          #!/usr/bin/env bash
+          if [ "$1" = "attestation" ] && [ "$2" = "--help" ]; then exit 0; fi
+          if [ "$1" = "attestation" ] && [ "$2" = "verify" ]; then exit 0; fi
+          if [ "$1" = "skill" ]; then exit 1; fi
+          exit 0
+          EOF
+          cat > "$wrongsum/curl" <<'EOF'
+          #!/usr/bin/env bash
+          while [ "$1" != "-o" ]; do shift; done
+          case "$2" in
+            *checksums.txt)
+              a=$(ls "$(dirname "$2")" | grep -v 'checksums.txt$' | head -1)
+              printf '%s  %s\n' \
+                "0000000000000000000000000000000000000000000000000000000000000000" "$a" > "$2" ;;
+            *) printf 'an archive from another release' > "$2" ;;
+          esac
+          EOF
+          chmod +x "$wrongsum/gh" "$wrongsum/curl"
+          set +e
+          out=$(PATH="$wrongsum:$PATH" REQUIRED=999.0.0 INSTALL_NAMESPACE=t bash "$script" 2>&1); status=$?
+          set -e
+          if [ "$status" -eq 0 ] || ! printf '%s' "$out" | grep -q "does not match the digest published"; then
+            echo "::error::expected digest mismatch to be rejected even with a passing attestation; status=$status out=$out"; exit 1
+          fi
+          echo "✅ digest-mismatch: rejected despite a passing attestation"
 
           # 9. macOS (ext=zip) with unzip absent → the zip-needs-unzip guard fires
           #    BEFORE any network download. A skill-LESS gh forces the install path;

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -796,6 +796,11 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: 🔒 Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
       - name: 📑 Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.scripts/ensure-gh-skill.sh
+++ b/.scripts/ensure-gh-skill.sh
@@ -48,6 +48,16 @@ case "$(uname -m)" in
   *) echo "::error::Unsupported arch: $(uname -m)"; exit 1 ;;
 esac
 
+# The release archive is executable input.  Verify its GitHub artifact
+# attestation with the runner-provided gh before trusting it; downloading a
+# checksum beside the archive would leave both files under the same mutable
+# release-asset trust boundary.  Do not bootstrap the verifier from the asset
+# it is about to verify.
+if ! command -v gh >/dev/null 2>&1 || ! gh attestation --help >/dev/null 2>&1; then
+  echo "::error::A trusted runner-provided gh with 'gh attestation' support is required to verify the gh release archive before installation."
+  exit 1
+fi
+
 tmp=$(mktemp -d)
 asset="gh_${REQUIRED}_${os}_${arch}.${ext}"
 url="https://github.com/cli/cli/releases/download/v${REQUIRED}/${asset}"
@@ -60,6 +70,10 @@ fi
 # Linux path downloads to a file rather than streaming `curl | tar` so the network
 # pull is a single retryable command.
 retry curl -fsSL -o "$tmp/$asset" "$url"
+if ! gh attestation verify "$tmp/$asset" --repo cli/cli; then
+  echo "::error::GitHub artifact attestation verification failed for $asset; refusing to install it."
+  exit 1
+fi
 if [ "$ext" = "zip" ]; then
   unzip -q "$tmp/$asset" -d "$tmp"
 else

--- a/.scripts/ensure-gh-skill.sh
+++ b/.scripts/ensure-gh-skill.sh
@@ -70,7 +70,42 @@ fi
 # Linux path downloads to a file rather than streaming `curl | tar` so the network
 # pull is a single retryable command.
 retry curl -fsSL -o "$tmp/$asset" "$url"
-if ! gh attestation verify "$tmp/$asset" --repo cli/cli; then
+
+# Attestation proves cli/cli's release workflow built this archive. It does NOT prove the archive is
+# the one published for v${REQUIRED}: every cli/cli release is attested from refs/heads/trunk, so the
+# certificate's source ref is identical across versions and cannot distinguish them. (Verified against
+# v2.81.0: sourceRepositoryRef is refs/heads/trunk, so pinning --source-ref refs/tags/v<version> would
+# reject every legitimate artifact.) The release's own checksums file is what binds a digest to a
+# version, so both checks are required and neither is sufficient alone.
+sums="gh_${REQUIRED}_checksums.txt"
+retry curl -fsSL -o "$tmp/$sums" "https://github.com/cli/cli/releases/download/v${REQUIRED}/${sums}"
+
+expected_digest=$(awk -v want="$asset" '$2 == want { print $1; exit }' "$tmp/$sums")
+if [ -z "$expected_digest" ]; then
+  echo "::error::$sums for v${REQUIRED} lists no entry for $asset; refusing to install it."
+  exit 1
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+  actual_digest=$(sha256sum "$tmp/$asset" | awk '{print $1}')
+elif command -v shasum >/dev/null 2>&1; then
+  actual_digest=$(shasum -a 256 "$tmp/$asset" | awk '{print $1}')
+else
+  echo "::error::Neither sha256sum nor shasum is available to verify $asset against $sums."
+  exit 1
+fi
+
+if [ "$actual_digest" != "$expected_digest" ]; then
+  echo "::error::$asset does not match the digest published for v${REQUIRED} (expected $expected_digest, got $actual_digest); refusing to install it."
+  exit 1
+fi
+
+# --signer-workflow narrows this from "any workflow in cli/cli" to the release workflow specifically.
+# If cli/cli ever renames that workflow this fails closed: read the new path from
+# `gh attestation verify <asset> --repo cli/cli --format json` (.buildSignerURI) and update it here.
+if ! gh attestation verify "$tmp/$asset" \
+  --repo cli/cli \
+  --signer-workflow 'cli/cli/.github/workflows/deployment.yml'; then
   echo "::error::GitHub artifact attestation verification failed for $asset; refusing to install it."
   exit 1
 fi

--- a/.scripts/ensure-gh-skill.sh
+++ b/.scripts/ensure-gh-skill.sh
@@ -123,32 +123,45 @@ if [ "$ext" = "zip" ]; then
 else
   tar -xzC "$tmp" -f "$tmp/$asset"
 fi
-install_dir="${RUNNER_TEMP:-/tmp}/${INSTALL_NAMESPACE}/bin"
-mkdir -p "$install_dir"
-install "$tmp/gh_${REQUIRED}_${os}_${arch}/bin/gh" "$install_dir/gh"
-echo "$install_dir" >> "$GITHUB_PATH"
-export PATH="$install_dir:$PATH"
-hash -r
-gh --version
+# Validate the candidate WHERE IT WAS EXTRACTED, and publish it only once every check has
+# passed. Installing first and appending to GITHUB_PATH before validating would expose a
+# rejected binary to every later step in the job: GITHUB_PATH is processed by the runner after
+# the step ends regardless of its exit status, so a `continue-on-error` caller — or any caller
+# that does not halt the job on this step — would inherit the very downgrade the checks below
+# exist to reject. Nothing reaches install_dir or PATH until the candidate is proven.
+candidate="$tmp/gh_${REQUIRED}_${os}_${arch}/bin/gh"
+if [ ! -x "$candidate" ]; then
+  echo "::error::Extracted archive does not contain an executable gh at the expected path."
+  exit 1
+fi
 
-# Bind what was INSTALLED to what was REQUESTED. Attestation proves cli/cli built this
+# Bind what was DOWNLOADED to what was REQUESTED. Attestation proves cli/cli built this
 # archive but cannot say which version it is (every release attests from refs/heads/trunk),
 # and the checksums file is served from the same mutable release as the archive — so a
 # genuinely-attested OLDER archive paired with a matching checksums entry passes both gates
 # above. A cli/cli build reports its own version truthfully, so asserting it here rejects
 # that substitution using only signals already verified. Same `sort -V -C` comparison as the
 # fast-return guard: success means REQUIRED <= installed.
-installed=$(gh --version | awk '/^gh version /{print $3; exit}')
+installed=$("$candidate" --version | awk '/^gh version /{print $3; exit}')
 if [ -z "$installed" ]; then
-  echo "::error::Could not determine the installed gh version from 'gh --version' output."
+  echo "::error::Could not determine the downloaded gh version from 'gh --version' output."
   exit 1
 fi
 if ! printf '%s\n%s\n' "$REQUIRED" "$installed" | sort -V -C; then
-  echo "::error::Installed gh ($installed) is older than the requested v${REQUIRED}; the downloaded archive is not the release it was published under. Refusing to use it."
+  echo "::error::Downloaded gh ($installed) is older than the requested v${REQUIRED}; the downloaded archive is not the release it was published under. Refusing to use it."
   exit 1
 fi
 
-if ! gh skill --help >/dev/null 2>&1; then
-  echo "::error::Installed gh still does not expose the 'skill' command."
+if ! "$candidate" skill --help >/dev/null 2>&1; then
+  echo "::error::Downloaded gh does not expose the 'skill' command."
   exit 1
 fi
+
+# Every check passed — now publish it.
+install_dir="${RUNNER_TEMP:-/tmp}/${INSTALL_NAMESPACE}/bin"
+mkdir -p "$install_dir"
+install "$candidate" "$install_dir/gh"
+echo "$install_dir" >> "$GITHUB_PATH"
+export PATH="$install_dir:$PATH"
+hash -r
+gh --version

--- a/.scripts/ensure-gh-skill.sh
+++ b/.scripts/ensure-gh-skill.sh
@@ -78,13 +78,14 @@ retry curl -fsSL -o "$tmp/$asset" "$url"
 # reject every legitimate artifact.) The release's own checksums file is what binds a digest to a
 # version, so both checks are required and neither is sufficient alone.
 #
-# Residual risk, stated honestly: the checksums file is served from the same release as the archive,
-# so it is not an independent authority. An actor able to rewrite that release's assets could pair a
-# genuinely-attested archive from a DIFFERENT version with a checksums entry naming it under this
-# version's asset name, and both gates above would pass — attestation cannot tell versions apart, and
-# the digest would match the substituted file. Closing that needs a version-to-digest pin held in
-# THIS repository (reviewed, not fetched); no independently-signed upstream manifest exists to use
-# instead. Tracked separately rather than widened into this change.
+# The checksums file is served from the same release as the archive, so it is not an independent
+# authority: an actor able to rewrite that release's assets could pair a genuinely-attested archive
+# from a DIFFERENT version with a checksums entry naming it under this version's asset name, and both
+# gates here would pass — attestation cannot tell versions apart, and the digest would match the
+# substituted file. The post-install version assertion below is what rejects that substitution: a
+# cli/cli build reports its own version truthfully, so an older archive is caught after extraction
+# even though it clears both gates here. That leaves a same-version rewrite, which attestation
+# already covers, since a rewritten archive cannot be re-attested by cli/cli's release workflow.
 sums="gh_${REQUIRED}_checksums.txt"
 retry curl -fsSL -o "$tmp/$sums" "https://github.com/cli/cli/releases/download/v${REQUIRED}/${sums}"
 
@@ -129,6 +130,24 @@ echo "$install_dir" >> "$GITHUB_PATH"
 export PATH="$install_dir:$PATH"
 hash -r
 gh --version
+
+# Bind what was INSTALLED to what was REQUESTED. Attestation proves cli/cli built this
+# archive but cannot say which version it is (every release attests from refs/heads/trunk),
+# and the checksums file is served from the same mutable release as the archive — so a
+# genuinely-attested OLDER archive paired with a matching checksums entry passes both gates
+# above. A cli/cli build reports its own version truthfully, so asserting it here rejects
+# that substitution using only signals already verified. Same `sort -V -C` comparison as the
+# fast-return guard: success means REQUIRED <= installed.
+installed=$(gh --version | awk '/^gh version /{print $3; exit}')
+if [ -z "$installed" ]; then
+  echo "::error::Could not determine the installed gh version from 'gh --version' output."
+  exit 1
+fi
+if ! printf '%s\n%s\n' "$REQUIRED" "$installed" | sort -V -C; then
+  echo "::error::Installed gh ($installed) is older than the requested v${REQUIRED}; the downloaded archive is not the release it was published under. Refusing to use it."
+  exit 1
+fi
+
 if ! gh skill --help >/dev/null 2>&1; then
   echo "::error::Installed gh still does not expose the 'skill' command."
   exit 1

--- a/.scripts/ensure-gh-skill.sh
+++ b/.scripts/ensure-gh-skill.sh
@@ -77,6 +77,14 @@ retry curl -fsSL -o "$tmp/$asset" "$url"
 # v2.81.0: sourceRepositoryRef is refs/heads/trunk, so pinning --source-ref refs/tags/v<version> would
 # reject every legitimate artifact.) The release's own checksums file is what binds a digest to a
 # version, so both checks are required and neither is sufficient alone.
+#
+# Residual risk, stated honestly: the checksums file is served from the same release as the archive,
+# so it is not an independent authority. An actor able to rewrite that release's assets could pair a
+# genuinely-attested archive from a DIFFERENT version with a checksums entry naming it under this
+# version's asset name, and both gates above would pass — attestation cannot tell versions apart, and
+# the digest would match the substituted file. Closing that needs a version-to-digest pin held in
+# THIS repository (reviewed, not fetched); no independently-signed upstream manifest exists to use
+# instead. Tracked separately rather than widened into this change.
 sums="gh_${REQUIRED}_checksums.txt"
 retry curl -fsSL -o "$tmp/$sums" "https://github.com/cli/cli/releases/download/v${REQUIRED}/${sums}"
 

--- a/setup-agent-skills/README.md
+++ b/setup-agent-skills/README.md
@@ -59,4 +59,4 @@ Omit `agents` to install for GitHub Copilot only (the default), or set it to any
 
 ## Requirements
 
-- `gh` **≥ 2.90.0** on the runner (with `gh skill` support). If the runner image ships an older `gh`, this action downloads the required release tarball on demand (Linux and macOS, amd64/arm64). Windows runners must pre-install `gh >= 2.90.0`.
+- A trusted runner-provided `gh` with `gh attestation` support. If it is older than **2.90.0** (and therefore lacks `gh skill`), this action downloads the required GitHub CLI release archive on Linux or macOS (amd64/arm64) and verifies its GitHub artifact attestation before installation. Windows runners must pre-install `gh >= 2.90.0`.

--- a/setup-agent-skills/action.yaml
+++ b/setup-agent-skills/action.yaml
@@ -50,6 +50,7 @@ runs:
       env:
         REQUIRED: ${{ inputs.gh-version }}
         INSTALL_NAMESPACE: setup-agent-skills
+        GH_TOKEN: ${{ inputs.github-token }}
       # Shared with update-agent-skills via .scripts/ensure-gh-skill.sh. Composite
       # actions cannot share steps, but they can share a bundled script resolved
       # relative to ${GITHUB_ACTION_PATH} (works for both local `uses: ./<action>`

--- a/update-agent-skills/README.md
+++ b/update-agent-skills/README.md
@@ -95,4 +95,4 @@ For repositories that organise skills into subdirectories (e.g. a plugin marketp
 
 ## Requirements
 
-- `gh` **≥ 2.90.0** on the runner. Same bootstrap behaviour as `setup-agent-skills`: if the runner image ships an older `gh`, the action downloads the required release tarball on demand (Linux and macOS, amd64/arm64). Windows runners must pre-install `gh >= 2.90.0`.
+- A trusted runner-provided `gh` with `gh attestation` support. Same bootstrap behaviour as `setup-agent-skills`: if it is older than **2.90.0**, the action downloads the required GitHub CLI release archive on Linux or macOS (amd64/arm64) and verifies its GitHub artifact attestation before installation. Windows runners must pre-install `gh >= 2.90.0`.

--- a/update-agent-skills/action.yaml
+++ b/update-agent-skills/action.yaml
@@ -37,6 +37,7 @@ runs:
       env:
         REQUIRED: ${{ inputs.gh-version }}
         INSTALL_NAMESPACE: update-agent-skills
+        GH_TOKEN: ${{ inputs.github-token }}
       # Shared with setup-agent-skills via .scripts/ensure-gh-skill.sh. Composite
       # actions cannot share steps, but they can share a bundled script resolved
       # relative to ${GITHUB_ACTION_PATH} (works for both local `uses: ./<action>`


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant.

### Motivation

- Remediate a supply-chain vulnerability where the action downloaded a `gh` release archive, installed it into the runner PATH, and later executed it with `GH_TOKEN` without any archive integrity or provenance verification. 
- Ensure a substituted or tampered release asset cannot be installed and used to exfiltrate or misuse workflow credentials. 

### Description

- Added a pre-install verification step to `.scripts/ensure-gh-skill.sh` that requires a trusted runner-provided `gh` with `gh attestation` support and aborts if not present. 
- Download the release archive to a file and run `gh attestation verify "$tmp/$asset" --repo cli/cli` before extraction or installation, failing the step if verification does not pass. 
- Propagate `GH_TOKEN` into the `Ensure gh >= required version` step in both `setup-agent-skills/action.yaml` and `update-agent-skills/action.yaml` so the verifier runs with the existing runner token. 
- Document the new runner prerequisite in `setup-agent-skills/README.md` and `update-agent-skills/README.md`. 
- Extend the CI self-test in `.github/workflows/ci.yaml` with a regression scenario that simulates a substituted release asset and asserts it is rejected before extraction/installation. 

### Testing

- Ran `bash -n .scripts/ensure-gh-skill.sh` to verify script parses cleanly (passed). 
- Parsed changed YAML files with Ruby YAML loading to ensure valid YAML for `action.yaml` and workflow files (passed). 
- Executed a direct substituted-archive regression scenario (mocked `gh` and `curl`) that simulates a compromised release and asserted the script rejects it before extraction (passed). 
- Ran `git diff --check` to validate no whitespace issues (passed). 
- `shellcheck`, `yamllint`, and `actionlint` checks were attempted but could not be fully run in this environment due to missing tools or external network/proxy restrictions (installation/network failures reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c079160e8832b967348f5a05f27fb)