### PR TITLE
fix(security): disable GitHub App remote control

### DIFF
--- a/.github/github-app.yml
+++ b/.github/github-app.yml
@@ -1,3 +1,3 @@
 automation:
   auto_issue_session: true
-  remote_control: true
+  remote_control: false


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant.

### Motivation

- The repository enabled `remote_control: true` in the GitHub App config while CI treats `botantler[bot]` PRs as trusted, creating a path where issue/comment-driven remote control could result in bot-authored PRs that receive automated approval and auto-merge.

### Description

- Update ` .github/github-app.yml` to set `remote_control: false` while retaining `auto_issue_session: true`, closing the remote-control attack surface without changing issue-session behaviour.

### Testing

- Ran `git diff --check`, parsed `.github/github-app.yml` with `YAML.safe_load_file` and asserted the `remote_control` value is `false`, and verified no `remote_control: true` remains; these checks passed, while `yamllint`, `actionlint`, and `zizmor` were unavailable in the environment and therefore not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c0634c5ec832bac78ca527550412b)