### PR TITLE
fix: isolate MegaLinter from write credentials

### DIFF
--- a/.github/tests/test-lint-credential-boundary.sh
+++ b/.github/tests/test-lint-credential-boundary.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+lint_workflow="${1:-.github/workflows/lint.yaml}"
+ci_workflow="${2:-.github/workflows/ci.yaml}"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+caller_contents="$(
+  yq -r '.jobs.test-lint-workflow.permissions.contents // ""' "$ci_workflow"
+)"
+[[ "$caller_contents" == "read" ]] ||
+  fail "the clean-fixture caller must grant contents: read, found '${caller_contents:-unset}'"
+
+caller_write_scopes="$(
+  yq -r \
+    '[.jobs.test-lint-workflow.permissions
+      | to_entries[]
+      | select(.value == "write")] | length' \
+    "$ci_workflow"
+)"
+[[ "$caller_write_scopes" == "0" ]] ||
+  fail "the clean-fixture caller must not grant any write-scoped GITHUB_TOKEN permission"
+
+lint_contents="$(yq -r '.jobs.lint.permissions.contents // ""' "$lint_workflow")"
+[[ "$lint_contents" == "read" ]] ||
+  fail "the untrusted lint job must grant contents: read, found '${lint_contents:-unset}'"
+
+lint_write_scopes="$(
+  yq -r \
+    '[.jobs.lint.permissions
+      | to_entries[]
+      | select(.value == "write")] | length' \
+    "$lint_workflow"
+)"
+[[ "$lint_write_scopes" == "0" ]] ||
+  fail "the untrusted lint job must not grant any write-scoped GITHUB_TOKEN permission"
+
+lint_tokens="$(
+  yq -r \
+    '[.jobs.lint.steps[]
+      | ..
+      | select(tag == "!!str")
+      | select(test("secrets\\.(GITHUB_TOKEN|APP_PRIVATE_KEY)|github\\.token"))] | length' \
+    "$lint_workflow"
+)"
+[[ "$lint_tokens" == "0" ]] ||
+  fail "the untrusted lint job must not receive the GitHub token or App private key"
+
+persisted_checkouts="$(
+  yq -r \
+    '[.jobs.lint.steps[]
+      | select((.uses // "") | contains("actions/checkout@"))
+      | select(.with."persist-credentials" != false)] | length' \
+    "$lint_workflow"
+)"
+[[ "$persisted_checkouts" == "0" ]] ||
+  fail "every checkout in the untrusted lint job must set persist-credentials: false"
+
+echo "PASS: MegaLinter runs behind a live read-only caller without repository credentials"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2539,14 +2539,10 @@ jobs:
   test-lint-workflow:
     if: "${{ !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
     name: "[Test] Lint - Passes On Clean Fixture"
-    # contents: write even though apply-fixes is false and this job never pushes. A caller
-    # must grant at least what the called workflow's jobs declare, and lint.yaml's job
-    # declares contents: write for the auto-fix commit. Granting less is not a narrower
-    # permission — it is a startup failure, and the whole CI workflow never runs.
+    # This is the real read-only consumer proof: GitHub rejects a called workflow at
+    # startup if any job tries to elevate beyond these caller permissions.
     permissions:
-      contents: write
-      issues: write
-      pull-requests: write
+      contents: read
     uses: ./.github/workflows/lint.yaml
     with:
       working-directory: .github/tests/megalinter-clean-fixture
@@ -2620,6 +2616,10 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - name: 🔐 Assert the lint credential boundary
+        shell: bash
+        run: bash .github/tests/test-lint-credential-boundary.sh
 
       # `uses:` cannot be parametrized, so test-lint-blocks hard-codes the MegaLinter image
       # SHA. This guard asserts lint.yaml pins that SAME SHA — and that validate-go-project

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -101,7 +101,7 @@ jobs:
           DEFAULT_WORKSPACE: ${{ inputs.working-directory || '.' }}
           MEGALINTER_CONFIG: ${{ github.workspace }}/.mega-linter.yml
           VALIDATE_ALL_CODEBASE: true
-          APPLY_FIXES: ${{ inputs.apply-fixes && github.event.pull_request.head.repo.fork != true && 'all' || 'none' }}
+          APPLY_FIXES: ${{ inputs.apply-fixes && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork != true && 'all' || 'none' }}
           APPLY_FIXES_EVENT: all
           APPLY_FIXES_MODE: commit
           # actionlint (<=1.7.12, bundled in MegaLinter) doesn't yet know the `code-quality`
@@ -113,7 +113,7 @@ jobs:
       # PR-controlled MegaLinter configuration may execute commands. Export only its
       # resulting patch here; write credentials are minted later on a fresh runner.
       - name: 📦 Prepare applied fixes
-        if: ${{ inputs.apply-fixes && github.event.pull_request.head.repo.fork != true }}
+        if: ${{ inputs.apply-fixes && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork != true }}
         id: fixes
         shell: bash
         run: |
@@ -161,7 +161,7 @@ jobs:
           permission-contents: write
 
       - name: 📄 Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: true
           token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -61,19 +61,16 @@ jobs:
   lint:
     name: 🧹 Lint - mega-linter
     runs-on: ubuntu-latest
+    outputs:
+      fixes-created: ${{ steps.fixes.outputs.changed }}
     permissions:
-      contents: write
-      issues: write
-      pull-requests: write
+      contents: read
     steps:
       - name: 🛡️ Harden runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
-      # continue-on-error: a consumer without the App configured (or a fork PR, where
-      # secrets are unavailable) still gets a lint gate — it just cannot commit fixes.
-      # The final step turns that into a clear failure rather than a silent pass.
       # Fork pull requests never get secrets, so the App token cannot be minted and fixes
       # can never be committed back. Auto-fixing there would leave changes that the job then
       # fails on — a red check an outside contributor cannot resolve except by installing
@@ -83,23 +80,10 @@ jobs:
       # This is not a softer gate. With APPLY_FIXES=none a fixable formatting issue is
       # reported as a warning and MegaLinter exits 0, but real lint ERRORS — invalid JSON,
       # shellcheck failures — still fail the job exactly as they do on a branch.
-      - name: 🔑 Generate GitHub App Token
-        if: ${{ inputs.apply-fixes && github.event.pull_request.head.repo.fork != true }}
-        continue-on-error: true
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        id: generate-token
-        with:
-          client-id: ${{ vars.APP_CLIENT_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          # Least-privilege: this token only pushes auto-fixes back to the PR branch.
-          # MegaLinter's PR/issue reporting uses the default GITHUB_TOKEN.
-          permission-contents: write
-
       - name: 📄 Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          persist-credentials: ${{ steps.generate-token.outcome == 'success' }}
-          token: ${{ steps.generate-token.outputs.token || github.token }}
+          persist-credentials: false
 
       - name: ⚙️ Setup Go
         if: ${{ inputs.go-version-file != '' }}
@@ -117,7 +101,6 @@ jobs:
           DEFAULT_WORKSPACE: ${{ inputs.working-directory || '.' }}
           MEGALINTER_CONFIG: ${{ github.workspace }}/.mega-linter.yml
           VALIDATE_ALL_CODEBASE: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           APPLY_FIXES: ${{ inputs.apply-fixes && github.event.pull_request.head.repo.fork != true && 'all' || 'none' }}
           APPLY_FIXES_EVENT: all
           APPLY_FIXES_MODE: commit
@@ -127,33 +110,75 @@ jobs:
           # catches up.
           ACTION_ACTIONLINT_ARGUMENTS: -ignore code-quality
 
+      # PR-controlled MegaLinter configuration may execute commands. Export only its
+      # resulting patch here; write credentials are minted later on a fresh runner.
+      - name: 📦 Prepare applied fixes
+        if: ${{ inputs.apply-fixes && github.event.pull_request.head.repo.fork != true }}
+        id: fixes
+        shell: bash
+        run: |
+          git add --intent-to-add .
+          if git diff --quiet HEAD; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            git diff --binary --full-index HEAD > "${RUNNER_TEMP}/megalinter-fixes.patch"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: 📤 Upload applied fixes
+        if: ${{ steps.fixes.outputs.changed == 'true' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: megalinter-fixes
+          path: ${{ runner.temp }}/megalinter-fixes.patch
+          if-no-files-found: error
+
+  apply-fixes:
+    name: 🧹 Lint - apply fixes
+    needs: lint
+    if: |
+      inputs.apply-fixes
+      && needs.lint.outputs.fixes-created == 'true'
+      && github.event.pull_request.head.repo.fork != true
+      && github.event_name == 'pull_request'
+      && !contains(fromJSON('["dependabot[bot]","dependabot","renovate[bot]","renovatebot","renovate"]'), github.event.pull_request.user.login)
+      && !contains(fromJSON('["dependabot[bot]","dependabot","renovate[bot]","renovatebot","renovate"]'), inputs.pr-owner)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: 🔑 Generate GitHub App Token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: generate-token
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+
+      - name: 📄 Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: true
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - name: 📥 Download applied fixes
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: megalinter-fixes
+          path: ${{ runner.temp }}
+
+      - name: Apply fixes
+        shell: bash
+        run: git apply --index "${RUNNER_TEMP}/megalinter-fixes.patch"
+
       - name: Commit and push applied linter fixes
-        if: |
-          inputs.apply-fixes
-          && steps.generate-token.outcome == 'success'
-          && github.event_name == 'pull_request'
-          && !contains(fromJSON('["dependabot[bot]","dependabot","renovate[bot]","renovatebot","renovate"]'), github.event.pull_request.user.login)
-          && !contains(fromJSON('["dependabot[bot]","dependabot","renovate[bot]","renovatebot","renovate"]'), inputs.pr-owner)
         uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
         with:
           commit_message: "chore: Apply megalinter fixes"
           commit_user_name: megalinter-bot
           commit_user_email: 129584137+megalinter-bot@users.noreply.github.com
-
-      # Auto-fix was requested but the fixes could not be committed (no App token — a fork
-      # PR, or an unconfigured consumer). Leaving them uncommitted would pass a PR whose
-      # tree is still unformatted, so fail loudly with the diff instead.
-      - name: ❌ Fail if uncommitted changes remain
-        if: ${{ inputs.apply-fixes && github.event.pull_request.head.repo.fork != true && steps.generate-token.outcome != 'success' }}
-        shell: bash
-        run: |
-          if [ -n "$(git status --porcelain)" ]; then
-            echo "::error::Auto-fix produced changes that cannot be committed (no App token — e.g. a fork PR). Please run the fix locally and push."
-            echo ""
-            echo "Changed files:"
-            git diff --stat
-            echo ""
-            echo "Full diff:"
-            git diff
-            exit 1
-          fi

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ The Go flavor covers Go, JSON, Markdown, YAML, shell, GitHub Actions, Dockerfile
 
 Configure the linters themselves in a `.mega-linter.yml` at your repository root, as usual.
 
-**Grant `contents: write`, even if you set `apply-fixes: false`.** A caller must grant at least what the called workflow's jobs declare. Granting less is not a narrower permission — GitHub rejects the call when it loads the file, and *the entire calling workflow* returns `startup_failure` with no jobs at all, which looks exactly like the workflow never triggering. `actionlint` does not catch it.
+MegaLinter always runs read-only, without a GitHub token or persisted checkout credentials. When auto-fixing is enabled, the lint job exports a patch and a separate job on a fresh runner mints the write-scoped App token, applies that patch, and commits it. This isolation prevents pull-request-controlled MegaLinter configuration from accessing repository write credentials.
 
 **Fork pull requests lint read-only, automatically.** GitHub withholds secrets from forks, so fixes could never be committed back; auto-fixing there would only produce a failure an outside contributor cannot resolve. Real lint errors still fail on forks — only the auto-fix half is skipped.
 
@@ -310,9 +310,7 @@ jobs:
   lint:
     uses: devantler-tech/actions/.github/workflows/lint.yaml@{ref} # ref
     permissions:
-      contents: write
-      issues: write
-      pull-requests: write
+      contents: read
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 ```

--- a/README.md
+++ b/README.md
@@ -311,9 +311,13 @@ jobs:
     uses: devantler-tech/actions/.github/workflows/lint.yaml@{ref} # ref
     permissions:
       contents: read
-    secrets:
-      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+    with:
+      apply-fixes: false
 ```
+
+To enable pull-request auto-fixes, set `apply-fixes: true` and pass
+`APP_PRIVATE_KEY`. MegaLinter still runs without that secret; only the separate
+patch-application job can access it.
 
 #### Secrets and Inputs
 


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The reusable lint workflow ran MegaLinter against pull-request-controlled configuration while its job held a write-scoped `GITHUB_TOKEN`, persisted checkout credentials, and could receive the repository App private key. A caller could not simply grant read-only permissions: GitHub rejected the called workflow at startup because the callee still declared write scopes.

## What

- Run the untrusted MegaLinter job with `contents: read`, no GitHub token in its environment, and no persisted checkout credentials.
- Export auto-fixes as a binary patch artifact and apply them on a fresh runner that mints the write-scoped App token only after untrusted execution has ended.
- Keep patch production and application pull-request-only, so non-PR callers never produce an orphaned fix artifact.
- Exercise the real reusable-workflow call from a `contents: read` clean-fixture job; GitHub's workflow loader now proves the callee cannot elevate beyond that boundary.
- Add a structural regression for the caller permissions, lint-job scopes, token references, and checkout credential persistence.
- Document the read-only boundary and least-privilege caller contract.

## RED / GREEN

RED against current `main` before rebuilding the fix:

```text
FAIL: the clean-fixture caller must grant contents: read, found 'write'
```

GREEN on this head:

```text
PASS: MegaLinter runs behind a live read-only caller without repository credentials
```

## Validation

- `bash .github/tests/test-lint-credential-boundary.sh`
- `shellcheck .github/tests/test-lint-credential-boundary.sh`
- `actionlint` on both changed workflows, with only the repository's documented `code-quality` compatibility ignore
- Ruby/Psych parse of both changed workflows
- `git diff --check`
- both commits are GPG-signed
- `zizmor` is not installed locally; exact-head repository CI remains authoritative

Unblocks the credential-free World at Ruin consumer in devantler-tech/world-at-ruin#382.