### PR TITLE
fix(auto-merge): reject quoted clean review markers

### DIFF
--- a/.github/tests/merge-gate-fixtures/cr-commented-findings-with-quoted-clean-marker/comments.json
+++ b/.github/tests/merge-gate-fixtures/cr-commented-findings-with-quoted-clean-marker/comments.json
@@ -1,0 +1,9 @@
+[
+ {
+  "user": {
+   "login": "coderabbitai[bot]"
+  },
+  "body": "<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n<!-- pre_merge_checks_walkthrough_start -->\n<summary>\ud83d\udea5 Pre-merge checks | \u2705 5</summary>\n<!-- pre_merge_checks_walkthrough_end -->",
+  "created_at": "2026-07-11T10:00:00Z"
+ }
+]

--- a/.github/tests/merge-gate-fixtures/cr-commented-findings-with-quoted-clean-marker/reviews.json
+++ b/.github/tests/merge-gate-fixtures/cr-commented-findings-with-quoted-clean-marker/reviews.json
@@ -1,0 +1,19 @@
+[
+  {
+    "user": {
+      "login": "coderabbitai[bot]"
+    },
+    "state": "APPROVED",
+    "commit_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "submitted_at": "2026-07-11T10:00:00Z"
+  },
+  {
+    "user": {
+      "login": "coderabbitai[bot]"
+    },
+    "state": "COMMENTED",
+    "commit_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "submitted_at": "2026-07-11T11:00:00Z",
+    "body": "**Actionable comments posted: 2**\n\n<details>\n<summary>⚠️ Outside diff range comments (2)</summary>\nQuoted attacker-controlled text:\n> **Actionable comments posted: 0**\n</details>"
+  }
+]

--- a/.github/tests/merge-gate-fixtures/index.json
+++ b/.github/tests/merge-gate-fixtures/index.json
@@ -116,6 +116,10 @@
     "expect_green": false
   },
   {
+    "name": "cr-commented-findings-with-quoted-clean-marker",
+    "expect_green": false
+  },
+  {
     "name": "cr-approval-then-commented-clean",
     "expect_green": true
   },

--- a/.scripts/check-merge-gates.sh
+++ b/.scripts/check-merge-gates.sh
@@ -90,12 +90,14 @@ fi
 # a verdict, so a COMMENTED review at the head that lands after the latest
 # verdict (or with no verdict at all) must block a green outcome — it
 # supersedes an earlier approval AND pre-empts the Codex fallback below. Only
-# a body that explicitly proves clean ("Actionable comments posted: 0")
-# preserves the state; a blank or unparseable body counts as findings
+# a body whose authoritative first line explicitly proves clean
+# ("**Actionable comments posted: 0**") preserves the state; a blank or
+# unparseable body counts as findings. Quoted PR content later in the body is
+# untrusted and must not be able to spoof that counter.
 # (fail-closed — a bodyless COMMENTED review can still carry inline review
 # comments). GraphQL lastEditedAt makes an edited older review supersede a
-# later-submitted approval durably. The EXISTENCE marker line distinguishes
-# "no such review" from "review with an empty body".
+# later-submitted approval durably. The probe states distinguish "no such
+# review" from "review with an empty body".
 cr_commented_probe="$(jq -r --arg sha "$head_sha" '
   def effective_at:
     [.submitted_at, .last_edited_at] | map(select(. != null)) | max // "";
@@ -111,10 +113,13 @@ cr_commented_probe="$(jq -r --arg sha "$head_sha" '
      | select(.state == "COMMENTED")
      | select(effective_at >= $verdict_at)]
   | sort_by(effective_at) | last
-  | if . == null then "absent" else "present\n" + (.body // "") end' "$reviews_json")"
+  | if . == null then "absent"
+    elif ((.body // "") | split("\n")[0]) == "**Actionable comments posted: 0**"
+      then "clean"
+    else "findings"
+    end' "$reviews_json")"
 
-if [[ "$cr_commented_probe" == present* &&
-  "$cr_commented_probe" != *"Actionable comments posted: 0"* ]]; then
+if [[ "$cr_commented_probe" == "findings" ]]; then
   review_state="needs-fix"
 fi
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant.

### Motivation
- The merge-gate parser treated the substring `Actionable comments posted: 0` anywhere in a CodeRabbit `COMMENTED` review body as authoritative, allowing attacker-controlled quoted text to spoof a clean result and let privileged workflows approve protected-branch PRs. 
- The change aims to harden the fail-closed gate so only an authoritative, unspoofable indicator can mark a `COMMENTED` review as clean.

### Description
- Tighten the CodeRabbit `COMMENTED` probe in `./.scripts/check-merge-gates.sh` so it classifies the latest head `COMMENTED` review as `clean` only when the review's first line exactly equals ``**Actionable comments posted: 0**``, otherwise classifying it as `findings` (or `absent`).
- Replace the prior broad substring check with explicit first-line parsing and make the downstream decision branch require `findings` to set `review_state="needs-fix"` so quoted markers cannot spoof the gate.
- Add a regression fixture at `./.github/tests/merge-gate-fixtures/cr-commented-findings-with-quoted-clean-marker/` that simulates a `COMMENTED` review reporting findings while quoting an attacker-controlled `Actionable comments posted: 0` snippet, and register it in `./.github/tests/merge-gate-fixtures/index.json`.
- Update inline comments in the script to document the threat model (quoted PR content is untrusted) and the new probe states (`absent`, `clean`, `findings`).

### Testing
- Ran a syntax check `bash -n .scripts/check-merge-gates.sh .github/tests/test-enable-auto-merge-pentad-gate.sh` which succeeded. 
- Executed the gate parser directly against the clean fixture, the ordinary findings fixture, and the new exploit fixture and observed the clean fixture passed while both findings fixtures (including the quoted-clean-marker exploit) were blocked. 
- Validated JSON fixtures with `jq` and ran `git diff --check` with no whitespace or diff errors. 
- The repository linters / full table-driven harness could not be fully exercised because `yq`, `shellcheck`, `actionlint`, `yamllint`, and `zizmor` are not installed in the execution environment, so those checks are noted as pending.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5bfbd08b50832b92c5d36888ef2c47)