### PR TITLE
feat(publish): require a SHA-pinned caller before signing

### DIFF
--- a/.github/tests/test-publish-caller-pin.sh
+++ b/.github/tests/test-publish-caller-pin.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+# Guards the caller-pin contract on the two publish workflows that mint keyless cosign
+# certificates. The certificate's SAN records `github.job_workflow_ref`, and the cluster's
+# image/artifact trust rules verify against it — so a caller that invokes these workflows by a
+# branch or a moving tag can have a superseded revision mint a signature the cluster still
+# trusts. The guard requires a 40-character commit SHA, the one ref form that cannot move.
+#
+# The behavioural half executes the guard script EXTRACTED FROM THE WORKFLOW, never a
+# transcription of it, so the assertions cannot drift away from what actually ships.
+
+set -euo pipefail
+
+signing_workflows=(
+  ".github/workflows/publish-app.yaml"
+  ".github/workflows/publish-manifests.yaml"
+)
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+guard_name="🔒 Require a SHA-pinned caller"
+
+for workflow in "${signing_workflows[@]}"; do
+  [[ -f "$workflow" ]] || fail "missing workflow: $workflow"
+
+  # Every workflow here mints a signature, which is what makes the pin load-bearing.
+  mints_signature="$(yq -r \
+    '[.jobs[].permissions // {} | select(has("id-token"))] | length' "$workflow")"
+  [[ "$mints_signature" -ge 1 ]] ||
+    fail "$workflow no longer requests id-token; re-check whether it still needs the caller pin"
+
+  job="$(yq -r '.jobs | keys | .[0]' "$workflow")"
+
+  guard_count="$(GUARD_NAME="$guard_name" yq -r \
+    '[.jobs[].steps[] | select(.name == strenv(GUARD_NAME))] | length' "$workflow")"
+  [[ "$guard_count" == "1" ]] ||
+    fail "$workflow must contain exactly one '$guard_name' step; found: $guard_count"
+
+  # The guard has to bind the context itself. Reading github.job_workflow_ref inline inside the
+  # run: body would work too, but the env binding is what keeps it out of shell interpolation.
+  guard_env="$(GUARD_NAME="$guard_name" yq -r \
+    '.jobs[].steps[] | select(.name == strenv(GUARD_NAME)) | .env.JOB_WORKFLOW_REF // ""' "$workflow")"
+  # shellcheck disable=SC2016 # GitHub expression compared literally.
+  [[ "$guard_env" == '${{ github.job_workflow_ref }}' ]] ||
+    fail "$workflow guard must bind JOB_WORKFLOW_REF to github.job_workflow_ref; got: $guard_env"
+
+  # Ordering matters: the pin must be decided before the job does any work that could publish or
+  # sign. Checkout is the first such step in both workflows.
+  guard_index="$(GUARD_NAME="$guard_name" JOB="$job" yq -r \
+    '.jobs[strenv(JOB)].steps | to_entries
+       | map(select(.value.name == strenv(GUARD_NAME))) | .[0].key' "$workflow")"
+  checkout_index="$(JOB="$job" yq -r \
+    '.jobs[strenv(JOB)].steps | to_entries
+       | map(select((.value.uses // "") | test("^actions/checkout@")))
+       | .[0].key' "$workflow")"
+  [[ "$checkout_index" != "null" ]] ||
+    fail "$workflow has no actions/checkout step to order the guard against"
+  [[ "$guard_index" -lt "$checkout_index" ]] ||
+    fail "$workflow guard must run before checkout (guard=$guard_index checkout=$checkout_index)"
+
+  # ---- behavioural half: run the shipped script against every ref shape ----
+  script="$(GUARD_NAME="$guard_name" yq -r \
+    '.jobs[].steps[] | select(.name == strenv(GUARD_NAME)) | .run' "$workflow")"
+  [[ -n "$script" ]] || fail "$workflow guard has an empty run: body"
+
+  run_guard() {
+    JOB_WORKFLOW_REF="$1" bash -euo pipefail -c "$script" >/dev/null 2>&1
+  }
+
+  sha40="0123456789abcdef0123456789abcdef01234567"
+  base="devantler-tech/actions/${workflow}"
+
+  # Accepted: exactly the shape every real caller uses today.
+  run_guard "${base}@${sha40}" ||
+    fail "$workflow guard rejected a 40-hex SHA caller, which every real caller uses"
+
+  # Rejected: everything that can move, plus every near-miss on the SHA shape.
+  rejected=(
+    "${base}@refs/heads/main"
+    "${base}@refs/tags/v1.2.3"
+    "${base}@refs/pull/12/merge"
+    "${base}@v10"
+    "${base}@main"
+    "${base}@0123456789abcdef0123456789abcdef0123456"
+    "${base}@0123456789ABCDEF0123456789ABCDEF01234567"
+    "${base}@${sha40}extra"
+    "${base}"
+    ""
+  )
+  for ref in "${rejected[@]}"; do
+    if run_guard "$ref"; then
+      fail "$workflow guard ACCEPTED a caller it must reject: '${ref:-<empty>}'"
+    fi
+  done
+
+  echo "$workflow: caller pin enforced ✅"
+done

--- a/.github/tests/test-publish-caller-pin.sh
+++ b/.github/tests/test-publish-caller-pin.sh
@@ -39,13 +39,26 @@ for workflow in "${signing_workflows[@]}"; do
   [[ "$guard_count" == "1" ]] ||
     fail "$workflow must contain exactly one '$guard_name' step; found: $guard_count"
 
-  # The guard has to bind the context itself. Reading github.job_workflow_ref inline inside the
-  # run: body would work too, but the env binding is what keeps it out of shell interpolation.
+  # github.job_workflow_ref is NOT exposed in the expression context — measured empty inside a
+  # called reusable workflow (devantler-tech/actions#858). The claim only exists in the OIDC token,
+  # which is also the value Fulcio copies into the certificate SAN. So the guard must be fed from a
+  # resolve step that reads that claim, never from the context property.
+  resolve_reads_claim="$(yq -r \
+    '[.jobs[].steps[] | select(.id == "caller") | .run | select(test("job_workflow_ref"))] | length' \
+    "$workflow")"
+  [[ "$resolve_reads_claim" == "1" ]] ||
+    fail "$workflow must resolve the caller ref from the OIDC job_workflow_ref claim (step id: caller)"
+
+  context_property_used="$(yq -r \
+    '[.. | select(tag == "!!str") | select(test("\\$\\{\\{[^}]*github\\.job_workflow_ref"))] | length' "$workflow")"
+  [[ "$context_property_used" == "0" ]] ||
+    fail "$workflow uses the github.job_workflow_ref expression property, which is always empty"
+
   guard_env="$(GUARD_NAME="$guard_name" yq -r \
     '.jobs[].steps[] | select(.name == strenv(GUARD_NAME)) | .env.JOB_WORKFLOW_REF // ""' "$workflow")"
   # shellcheck disable=SC2016 # GitHub expression compared literally.
-  [[ "$guard_env" == '${{ github.job_workflow_ref }}' ]] ||
-    fail "$workflow guard must bind JOB_WORKFLOW_REF to github.job_workflow_ref; got: $guard_env"
+  [[ "$guard_env" == '${{ steps.caller.outputs.ref }}' ]] ||
+    fail "$workflow guard must bind JOB_WORKFLOW_REF to the resolve step output; got: $guard_env"
 
   # Ordering matters: the pin must be decided before the job does any work that could publish or
   # sign. Checkout is the first such step in both workflows.

--- a/.github/tests/test-publish-caller-pin.sh
+++ b/.github/tests/test-publish-caller-pin.sh
@@ -60,6 +60,43 @@ for workflow in "${signing_workflows[@]}"; do
   [[ "$guard_env" == '${{ steps.caller.outputs.ref }}' ]] ||
     fail "$workflow guard must bind JOB_WORKFLOW_REF to the resolve step output; got: $guard_env"
 
+  # ---- feature-flag-first: opt-in input, default-off, both states covered ----
+  # AGENTS.md "Shipping a new capability behind an opt-in flag" requires new reusable-workflow
+  # behaviour to ship default-off so existing callers see zero behaviour change on merge. That
+  # matters more than usual here: the guard only runs on a real publish, which CI never exercises
+  # (the dry-run test skips the whole publish job), so a misfire would surface at release time.
+  flag_default="$(yq -r '.on.workflow_call.inputs["enable-caller-pin"].default' "$workflow")"
+  [[ "$flag_default" == "false" ]] ||
+    fail "$workflow enable-caller-pin must default to false; got: $flag_default"
+
+  flag_type="$(yq -r '.on.workflow_call.inputs["enable-caller-pin"].type' "$workflow")"
+  [[ "$flag_type" == "boolean" ]] ||
+    fail "$workflow enable-caller-pin must be a boolean input; got: $flag_type"
+
+  # Flag OFF (the default) => neither new step runs, so a caller that omits the input is unaffected.
+  # Flag ON => both run. Both states are expressed by the same guard, so assert it on both steps.
+  for step_id_or_name in "caller" "$guard_name"; do
+    gated="$(STEP="$step_id_or_name" yq -r \
+      '[.jobs[].steps[] | select(.id == strenv(STEP) or .name == strenv(STEP)) | .if // ""] | .[0]' \
+      "$workflow")"
+    # shellcheck disable=SC2016 # GitHub expression compared literally.
+    [[ "$gated" == '${{ inputs.enable-caller-pin }}' ]] ||
+      fail "$workflow step '$step_id_or_name' must be gated on inputs.enable-caller-pin; got: $gated"
+  done
+
+  # A token request with no timeout can hang the publish job until the 6h run limit. Pin the bound
+  # so removing it cannot pass silently.
+  resolve_run="$(yq -r \
+    '.jobs[].steps[] | select(.id == "caller") | .run' "$workflow")"
+  grep -Eq 'curl [^|]*--max-time [0-9]+' <<<"$resolve_run" ||
+    fail "$workflow OIDC token request must carry --max-time so it cannot hang the publish job"
+
+  # The resolve step must precede the guard: if it ran after, steps.caller.outputs.ref would be
+  # empty and the guard would fail closed on a correctly-pinned caller.
+  resolve_index="$(JOB="$job" yq -r \
+    '.jobs[strenv(JOB)].steps | to_entries
+       | map(select(.value.id == "caller")) | .[0].key' "$workflow")"
+
   # Ordering matters: the pin must be decided before the job does any work that could publish or
   # sign. Checkout is the first such step in both workflows.
   guard_index="$(GUARD_NAME="$guard_name" JOB="$job" yq -r \
@@ -73,6 +110,8 @@ for workflow in "${signing_workflows[@]}"; do
     fail "$workflow has no actions/checkout step to order the guard against"
   [[ "$guard_index" -lt "$checkout_index" ]] ||
     fail "$workflow guard must run before checkout (guard=$guard_index checkout=$checkout_index)"
+  [[ "$resolve_index" -lt "$guard_index" ]] ||
+    fail "$workflow resolve step must run before the guard (resolve=$resolve_index guard=$guard_index)"
 
   # ---- behavioural half: run the shipped script against every ref shape ----
   script="$(GUARD_NAME="$guard_name" yq -r \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2275,6 +2275,13 @@ jobs:
     with:
       app-name: app
       dry-run: true
+      # Exercises the flag through the real workflow_call interface, which the
+      # script-extraction tests below cannot: it proves the input schema accepts
+      # the name and type. The guard itself does not run here — publish-app.yaml's
+      # publish job carries `if: ${{ !inputs.dry-run }}` — so this stays a schema
+      # check, and the enabled BEHAVIOUR is covered by test-publish-caller-pin.sh
+      # and the push-only live job.
+      enable-caller-pin: true
 
   # The caller-pin guard lives inside the publish job, which the dry-run tests skip, so nothing else
   # in CI ever performs the live OIDC request and JWT decode it depends on. Without this job that
@@ -2354,6 +2361,10 @@ jobs:
       id-token: write
     with:
       dry-run: true
+      # Same schema check as test-publish-app: publish-manifests.yaml's
+      # publish-manifests job is gated on `if: ${{ !inputs.dry-run }}`, so the
+      # guard does not run — this proves only that the input is accepted.
+      enable-caller-pin: true
 
   test-scan-for-todo-comments:
     if: "${{ github.event_name != 'merge_group' && !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2276,6 +2276,67 @@ jobs:
       app-name: app
       dry-run: true
 
+  # The caller-pin guard lives inside the publish job, which the dry-run tests skip, so nothing else
+  # in CI ever performs the live OIDC request and JWT decode it depends on. Without this job that
+  # integration would first execute during a tagged release, on the first caller to opt in.
+  # This runs the script EXTRACTED FROM publish-app.yaml — not a copy — against a real token, and
+  # asserts it resolves the claim for THIS reusable workflow. It cannot assert the guard passes: a
+  # CI run's caller ref is refs/pull/N/merge, which the guard correctly rejects, so it asserts the
+  # gate BITES on that input instead (the failure-mode coverage convention in AGENTS.md).
+  test-publish-caller-pin-live:
+    if: "${{ github.event_name != 'merge_group' && !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
+    name: "[Test] Publish Caller Pin - Live OIDC"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: 📑 Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: 🔎 Run the shipped resolver against a real OIDC token
+        id: live
+        run: |
+          script="$(yq -r '.jobs[].steps[] | select(.id == "caller") | .run' \
+            .github/workflows/publish-app.yaml)"
+          [ -n "$script" ] || { echo "::error::could not extract the resolve step"; exit 1; }
+          out="$(mktemp)"
+          GITHUB_OUTPUT="$out" bash -euo pipefail -c "$script"
+          ref="$(sed -n 's/^ref=//p' "$out")"
+          echo "resolved=$ref"
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+          # The claim must exist and name a workflow in this repository. An empty value is the exact
+          # failure the expression-context version of this guard had, and it must never come back.
+          case "$ref" in
+            devantler-tech/actions/.github/workflows/*@*) ;;
+            "") echo "::error::OIDC job_workflow_ref claim resolved EMPTY"; exit 1 ;;
+            *) echo "::error::unexpected job_workflow_ref shape: $ref"; exit 1 ;;
+          esac
+
+      - name: 🔒 Assert the shipped guard rejects this unpinned caller
+        env:
+          RESOLVED_REF: ${{ steps.live.outputs.ref }}
+        run: |
+          guard="$(yq -r '.jobs[].steps[] | select(.name == "🔒 Require a SHA-pinned caller") | .run' \
+            .github/workflows/publish-app.yaml)"
+          [ -n "$guard" ] || { echo "::error::could not extract the guard step"; exit 1; }
+          # A CI run is reached via refs/pull/N/merge, which is not a commit SHA, so the gate must
+          # fail here. A pass would mean the gate stopped biting.
+          if JOB_WORKFLOW_REF="$RESOLVED_REF" bash -euo pipefail -c "$guard" >/tmp/guard.log 2>&1; then
+            echo "::error::the caller-pin guard ACCEPTED an unpinned caller ($RESOLVED_REF)"
+            exit 1
+          fi
+          grep -q "must be called by a 40-character commit SHA" /tmp/guard.log ||
+            { echo "::error::guard failed for the wrong reason:"; cat /tmp/guard.log; exit 1; }
+          echo "guard correctly rejected $RESOLVED_REF ✅"
+
   test-publish-manifests:
     if: "${{ github.event_name != 'merge_group' && !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
     name: "[Test] Publish Manifests - Dry Run"
@@ -3037,6 +3098,7 @@ jobs:
       - test-publish-dotnet-library
       - test-publish-app
       - test-publish-manifests
+      - test-publish-caller-pin-live
       - test-scan-for-todo-comments
       - test-sync-cluster-policies
       - test-update-agent-skills
@@ -3133,6 +3195,7 @@ jobs:
             ${{ needs.test-publish-dotnet-library.result }}
             ${{ needs.test-publish-app.result }}
             ${{ needs.test-publish-manifests.result }}
+            ${{ needs.test-publish-caller-pin-live.result }}
             ${{ needs.test-scan-for-todo-comments.result }}
             ${{ needs.test-sync-cluster-policies.result }}
             ${{ needs.test-update-agent-skills.result }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2275,12 +2275,28 @@ jobs:
     with:
       app-name: app
       dry-run: true
-      # Exercises the flag through the real workflow_call interface, which the
-      # script-extraction tests below cannot: it proves the input schema accepts
-      # the name and type. The guard itself does not run here — publish-app.yaml's
-      # publish job carries `if: ${{ !inputs.dry-run }}` — so this stays a schema
-      # check, and the enabled BEHAVIOUR is covered by test-publish-caller-pin.sh
-      # and the push-only live job.
+      # enable-caller-pin is deliberately OMITTED here: this job is the default-off
+      # half of the flag's workflow_call coverage, and omitting it also proves the
+      # input is genuinely optional. The enabled half is test-publish-app-caller-pin
+      # below.
+
+  test-publish-app-caller-pin:
+    if: "${{ github.event_name != 'merge_group' && !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
+    name: "[Test] Publish App - Dry Run (caller-pin enabled)"
+    uses: ./.github/workflows/publish-app.yaml
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    with:
+      app-name: app
+      dry-run: true
+      # The enabled half. This reaches the flag through the real workflow_call
+      # interface, which the script-extraction tests cannot: it proves the input
+      # schema accepts the name and type. The guard itself does not run —
+      # publish-app.yaml's publish job carries `if: ${{ !inputs.dry-run }}` — so
+      # this is a schema check, and the enabled BEHAVIOUR stays covered by
+      # test-publish-caller-pin.sh and the push-only live job.
       enable-caller-pin: true
 
   # The caller-pin guard lives inside the publish job, which the dry-run tests skip, so nothing else
@@ -2361,9 +2377,21 @@ jobs:
       id-token: write
     with:
       dry-run: true
-      # Same schema check as test-publish-app: publish-manifests.yaml's
-      # publish-manifests job is gated on `if: ${{ !inputs.dry-run }}`, so the
-      # guard does not run — this proves only that the input is accepted.
+      # Default-off half, as above: enable-caller-pin is deliberately omitted.
+
+  test-publish-manifests-caller-pin:
+    if: "${{ github.event_name != 'merge_group' && !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
+    name: "[Test] Publish Manifests - Dry Run (caller-pin enabled)"
+    uses: ./.github/workflows/publish-manifests.yaml
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    with:
+      dry-run: true
+      # Enabled half. publish-manifests.yaml's publish-manifests job is gated on
+      # `if: ${{ !inputs.dry-run }}`, so the guard does not run — this proves the
+      # input is accepted by name and type.
       enable-caller-pin: true
 
   test-scan-for-todo-comments:
@@ -3115,7 +3143,9 @@ jobs:
       - test-deploy-github-pages
       - test-publish-dotnet-library
       - test-publish-app
+      - test-publish-app-caller-pin
       - test-publish-manifests
+      - test-publish-manifests-caller-pin
       - test-publish-caller-pin-live
       - test-scan-for-todo-comments
       - test-sync-cluster-policies
@@ -3212,7 +3242,9 @@ jobs:
             ${{ needs.test-deploy-github-pages.result }}
             ${{ needs.test-publish-dotnet-library.result }}
             ${{ needs.test-publish-app.result }}
+            ${{ needs.test-publish-app-caller-pin.result }}
             ${{ needs.test-publish-manifests.result }}
+            ${{ needs.test-publish-manifests-caller-pin.result }}
             ${{ needs.test-publish-caller-pin-live.result }}
             ${{ needs.test-scan-for-todo-comments.result }}
             ${{ needs.test-sync-cluster-policies.result }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2283,8 +2283,15 @@ jobs:
   # asserts it resolves the claim for THIS reusable workflow. It cannot assert the guard passes: a
   # CI run's caller ref is refs/pull/N/merge, which the guard correctly rejects, so it asserts the
   # gate BITES on that input instead (the failure-mode coverage convention in AGENTS.md).
+  # PUSH-ONLY, deliberately. This job holds id-token: write and executes the resolver script
+  # extracted from publish-app.yaml. On a pull_request the checked-out workspace is PR-controlled,
+  # so a modified resolver could mint and exfiltrate an OIDC token — the hazard this file's header
+  # names ("test jobs must never run them with repository secrets or write-capable tokens"), and the
+  # same reason the Zizmor self-test above is push-only. On a push to main the code has already
+  # merged, so it is trusted. The trade-off is that a regression surfaces post-merge rather than on
+  # the PR; the static contract test in the PR lane still covers the guard's own logic.
   test-publish-caller-pin-live:
-    if: "${{ github.event_name != 'merge_group' && !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
+    if: "${{ github.event_name == 'push' && !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
     name: "[Test] Publish Caller Pin - Live OIDC"
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1900,6 +1900,10 @@ jobs:
         shell: bash
         run: bash .github/tests/test-zizmor-routing.sh
 
+      - name: 🔒 Check publish workflows require a SHA-pinned caller
+        shell: bash
+        run: bash .github/tests/test-publish-caller-pin.sh
+
       - name: 🔐 Check merge-group credential isolation
         shell: bash
         run: bash .github/tests/test-ci-merge-group-isolation.sh

--- a/.github/workflows/publish-app.yaml
+++ b/.github/workflows/publish-app.yaml
@@ -47,9 +47,26 @@ jobs:
             exit 1
           fi
 
+      - name: 🔎 Resolve the calling ref from the OIDC claim
+        id: caller
+        run: |
+          # github.job_workflow_ref is NOT exposed in the expression context — measured empty inside
+          # a called reusable workflow, while github.workflow_ref (the caller's own entry workflow)
+          # resolves fine. The value that actually reaches the cosign certificate's SAN is the OIDC
+          # token's job_workflow_ref claim, so read it from the token: same source, same value.
+          token="$(curl -fsS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=sigstore" | jq -r '.value')"
+          payload="$(printf '%s' "$token" | cut -d. -f2)"
+          case $((${#payload} % 4)) in
+            2) payload="${payload}==" ;;
+            3) payload="${payload}=" ;;
+          esac
+          ref="$(printf '%s' "$payload" | tr '_-' '/+' | base64 -d | jq -r '.job_workflow_ref // ""')"
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+
       - name: 🔒 Require a SHA-pinned caller
         env:
-          JOB_WORKFLOW_REF: ${{ github.job_workflow_ref }}
+          JOB_WORKFLOW_REF: ${{ steps.caller.outputs.ref }}
         run: |
           # This job mints a keyless cosign certificate whose SAN is this workflow's own
           # job_workflow_ref, and the cluster's trust rules verify signatures against it. A branch
@@ -146,20 +163,25 @@ jobs:
           cosign sign --yes "${ARTIFACT}:${VERSION}"
           cosign sign --yes "${IMAGE}@${DIGEST}"
 
-  # TEMPORARY probe (removed before review): proves github.job_workflow_ref resolves at runtime
+  # TEMPORARY probe (removed before review): proves the OIDC job_workflow_ref claim resolves
   # inside a called reusable workflow, and shows the exact @suffix shape the guard parses.
   temp-probe-job-workflow-ref:
     name: TEMP probe job_workflow_ref
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      id-token: write
     steps:
       - name: probe
-        env:
-          JWR: ${{ github.job_workflow_ref }}
-          JWS: ${{ github.job_workflow_sha }}
-          WR: ${{ github.workflow_ref }}
         run: |
-          echo "PROBE job_workflow_ref=[$JWR]"
-          echo "PROBE job_workflow_sha=[$JWS]"
-          echo "PROBE workflow_ref=[$WR]"
-          echo "PROBE extracted=[${JWR##*@}]"
+          token="$(curl -fsS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=sigstore" | jq -r '.value')"
+          payload="$(printf '%s' "$token" | cut -d. -f2)"
+          case $((${#payload} % 4)) in
+            2) payload="${payload}==" ;;
+            3) payload="${payload}=" ;;
+          esac
+          claims="$(printf '%s' "$payload" | tr '_-' '/+' | base64 -d)"
+          echo "PROBE claim_job_workflow_ref=[$(printf '%s' "$claims" | jq -r '.job_workflow_ref // "<ABSENT>"')]"
+          echo "PROBE claim_workflow_ref=[$(printf '%s' "$claims" | jq -r '.workflow_ref // "<ABSENT>"')]"
+          ref="$(printf '%s' "$claims" | jq -r '.job_workflow_ref // ""')"
+          echo "PROBE extracted=[${ref##*@}]"

--- a/.github/workflows/publish-app.yaml
+++ b/.github/workflows/publish-app.yaml
@@ -162,26 +162,3 @@ jobs:
           flux tag artifact "oci://${ARTIFACT}:${VERSION}" --tag latest --creds "${ACTOR}:${GH_TOKEN}"
           cosign sign --yes "${ARTIFACT}:${VERSION}"
           cosign sign --yes "${IMAGE}@${DIGEST}"
-
-  # TEMPORARY probe (removed before review): proves the OIDC job_workflow_ref claim resolves
-  # inside a called reusable workflow, and shows the exact @suffix shape the guard parses.
-  temp-probe-job-workflow-ref:
-    name: TEMP probe job_workflow_ref
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-    steps:
-      - name: probe
-        run: |
-          token="$(curl -fsS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=sigstore" | jq -r '.value')"
-          payload="$(printf '%s' "$token" | cut -d. -f2)"
-          case $((${#payload} % 4)) in
-            2) payload="${payload}==" ;;
-            3) payload="${payload}=" ;;
-          esac
-          claims="$(printf '%s' "$payload" | tr '_-' '/+' | base64 -d)"
-          echo "PROBE claim_job_workflow_ref=[$(printf '%s' "$claims" | jq -r '.job_workflow_ref // "<ABSENT>"')]"
-          echo "PROBE claim_workflow_ref=[$(printf '%s' "$claims" | jq -r '.workflow_ref // "<ABSENT>"')]"
-          ref="$(printf '%s' "$claims" | jq -r '.job_workflow_ref // ""')"
-          echo "PROBE extracted=[${ref##*@}]"

--- a/.github/workflows/publish-app.yaml
+++ b/.github/workflows/publish-app.yaml
@@ -16,6 +16,11 @@ on:
         required: false
         default: false
         type: boolean
+      enable-caller-pin:
+        description: "Enforce that the caller pinned this workflow to a commit SHA before signing. Opt-in while rolling out; see AGENTS.md 'Shipping a new capability behind an opt-in flag'."
+        required: false
+        default: false
+        type: boolean
 
 permissions: {}
 
@@ -49,12 +54,13 @@ jobs:
 
       - name: 🔎 Resolve the calling ref from the OIDC claim
         id: caller
+        if: ${{ inputs.enable-caller-pin }}
         run: |
           # github.job_workflow_ref is NOT exposed in the expression context — measured empty inside
           # a called reusable workflow, while github.workflow_ref (the caller's own entry workflow)
           # resolves fine. The value that actually reaches the cosign certificate's SAN is the OIDC
           # token's job_workflow_ref claim, so read it from the token: same source, same value.
-          token="$(curl -fsS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+          token="$(curl -fsS --max-time 10 -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
             "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=sigstore" | jq -r '.value')"
           payload="$(printf '%s' "$token" | cut -d. -f2)"
           case $((${#payload} % 4)) in
@@ -65,6 +71,7 @@ jobs:
           echo "ref=$ref" >> "$GITHUB_OUTPUT"
 
       - name: 🔒 Require a SHA-pinned caller
+        if: ${{ inputs.enable-caller-pin }}
         env:
           JOB_WORKFLOW_REF: ${{ steps.caller.outputs.ref }}
         run: |

--- a/.github/workflows/publish-app.yaml
+++ b/.github/workflows/publish-app.yaml
@@ -47,6 +47,20 @@ jobs:
             exit 1
           fi
 
+      - name: 🔒 Require a SHA-pinned caller
+        env:
+          JOB_WORKFLOW_REF: ${{ github.job_workflow_ref }}
+        run: |
+          # This job mints a keyless cosign certificate whose SAN is this workflow's own
+          # job_workflow_ref, and the cluster's trust rules verify signatures against it. A branch
+          # or tag ref would let a superseded revision of this workflow mint a signature the
+          # cluster still trusts, so require the one ref form that cannot move: a commit SHA.
+          ref="${JOB_WORKFLOW_REF##*@}"
+          if ! printf '%s' "$ref" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "::error::publish-app must be called by a 40-character commit SHA, not '@${ref}'. Pin the caller as devantler-tech/actions/.github/workflows/publish-app.yaml@<sha> (Renovate keeps that pin current)."
+            exit 1
+          fi
+
       - name: 📑 Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -131,3 +145,21 @@ jobs:
           flux tag artifact "oci://${ARTIFACT}:${VERSION}" --tag latest --creds "${ACTOR}:${GH_TOKEN}"
           cosign sign --yes "${ARTIFACT}:${VERSION}"
           cosign sign --yes "${IMAGE}@${DIGEST}"
+
+  # TEMPORARY probe (removed before review): proves github.job_workflow_ref resolves at runtime
+  # inside a called reusable workflow, and shows the exact @suffix shape the guard parses.
+  temp-probe-job-workflow-ref:
+    name: TEMP probe job_workflow_ref
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: probe
+        env:
+          JWR: ${{ github.job_workflow_ref }}
+          JWS: ${{ github.job_workflow_sha }}
+          WR: ${{ github.workflow_ref }}
+        run: |
+          echo "PROBE job_workflow_ref=[$JWR]"
+          echo "PROBE job_workflow_sha=[$JWS]"
+          echo "PROBE workflow_ref=[$WR]"
+          echo "PROBE extracted=[${JWR##*@}]"

--- a/.github/workflows/publish-manifests.yaml
+++ b/.github/workflows/publish-manifests.yaml
@@ -53,9 +53,26 @@ jobs:
             exit 1
           fi
 
+      - name: 🔎 Resolve the calling ref from the OIDC claim
+        id: caller
+        run: |
+          # github.job_workflow_ref is NOT exposed in the expression context — measured empty inside
+          # a called reusable workflow, while github.workflow_ref (the caller's own entry workflow)
+          # resolves fine. The value that actually reaches the cosign certificate's SAN is the OIDC
+          # token's job_workflow_ref claim, so read it from the token: same source, same value.
+          token="$(curl -fsS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=sigstore" | jq -r '.value')"
+          payload="$(printf '%s' "$token" | cut -d. -f2)"
+          case $((${#payload} % 4)) in
+            2) payload="${payload}==" ;;
+            3) payload="${payload}=" ;;
+          esac
+          ref="$(printf '%s' "$payload" | tr '_-' '/+' | base64 -d | jq -r '.job_workflow_ref // ""')"
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+
       - name: 🔒 Require a SHA-pinned caller
         env:
-          JOB_WORKFLOW_REF: ${{ github.job_workflow_ref }}
+          JOB_WORKFLOW_REF: ${{ steps.caller.outputs.ref }}
         run: |
           # This job mints a keyless cosign certificate whose SAN is this workflow's own
           # job_workflow_ref, and the cluster's trust rules verify signatures against it. A branch

--- a/.github/workflows/publish-manifests.yaml
+++ b/.github/workflows/publish-manifests.yaml
@@ -23,6 +23,11 @@ on:
         required: false
         default: false
         type: boolean
+      enable-caller-pin:
+        description: "Enforce that the caller pinned this workflow to a commit SHA before signing. Opt-in while rolling out; see AGENTS.md 'Shipping a new capability behind an opt-in flag'."
+        required: false
+        default: false
+        type: boolean
 
 permissions: {}
 
@@ -55,12 +60,13 @@ jobs:
 
       - name: 🔎 Resolve the calling ref from the OIDC claim
         id: caller
+        if: ${{ inputs.enable-caller-pin }}
         run: |
           # github.job_workflow_ref is NOT exposed in the expression context — measured empty inside
           # a called reusable workflow, while github.workflow_ref (the caller's own entry workflow)
           # resolves fine. The value that actually reaches the cosign certificate's SAN is the OIDC
           # token's job_workflow_ref claim, so read it from the token: same source, same value.
-          token="$(curl -fsS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+          token="$(curl -fsS --max-time 10 -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
             "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=sigstore" | jq -r '.value')"
           payload="$(printf '%s' "$token" | cut -d. -f2)"
           case $((${#payload} % 4)) in
@@ -71,6 +77,7 @@ jobs:
           echo "ref=$ref" >> "$GITHUB_OUTPUT"
 
       - name: 🔒 Require a SHA-pinned caller
+        if: ${{ inputs.enable-caller-pin }}
         env:
           JOB_WORKFLOW_REF: ${{ steps.caller.outputs.ref }}
         run: |

--- a/.github/workflows/publish-manifests.yaml
+++ b/.github/workflows/publish-manifests.yaml
@@ -53,6 +53,20 @@ jobs:
             exit 1
           fi
 
+      - name: 🔒 Require a SHA-pinned caller
+        env:
+          JOB_WORKFLOW_REF: ${{ github.job_workflow_ref }}
+        run: |
+          # This job mints a keyless cosign certificate whose SAN is this workflow's own
+          # job_workflow_ref, and the cluster's trust rules verify signatures against it. A branch
+          # or tag ref would let a superseded revision of this workflow mint a signature the
+          # cluster still trusts, so require the one ref form that cannot move: a commit SHA.
+          ref="${JOB_WORKFLOW_REF##*@}"
+          if ! printf '%s' "$ref" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "::error::publish-manifests must be called by a 40-character commit SHA, not '@${ref}'. Pin the caller as devantler-tech/actions/.github/workflows/publish-manifests.yaml@<sha> (Renovate keeps that pin current)."
+            exit 1
+          fi
+
       - name: 📑 Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@ jobs:
 |---------------|----------------|------------|----------|----------------------------------------------------------------------------|
 | `app-name`    | Input (string) | -          | Yes      | Container name in the deployment manifest to pin to the built image digest |
 | `deploy-path` | Input (string) | `./deploy` | No       | Path to the Kubernetes manifests directory packaged as the OCI artifact    |
+| `enable-caller-pin` | Input (boolean) | `false` | No       | Refuse to publish unless the caller pinned this workflow to a 40-character commit SHA. The signing certificate records the calling ref, and the cluster's trust rules verify it, so an unpinned caller lets a superseded revision mint a trusted signature. Opt-in during rollout (devantler-tech/actions#864); every current caller already qualifies |
 
 </details>
 
@@ -448,6 +449,7 @@ jobs:
 |---------------|----------------|----------------------|----------|--------------------------------------------------------------------------------------------------------------------------------------|
 | `oci-name`    | Input (string) | `${{ github.repository }}` | No       | OCI repository name (`<owner>/<name>`) the artifact is published under, without the registry prefix or trailing `/manifests`. Override for invalid OCI path components |
 | `deploy-path` | Input (string) | `./deploy`           | No       | Path to the Kubernetes manifests directory packaged as the OCI artifact                                                              |
+| `enable-caller-pin` | Input (boolean) | `false` | No       | Refuse to publish unless the caller pinned this workflow to a 40-character commit SHA. The signing certificate records the calling ref, and the cluster's trust rules verify it, so an unpinned caller lets a superseded revision mint a trusted signature. Opt-in during rollout (devantler-tech/actions#864); every current caller already qualifies |
 
 </details>
 


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Our cluster decides whether a first-party image or manifest bundle may run by checking who signed it. That check trusts a signature only if it came from these publish workflows — but it does not care **which revision** of them. So a caller that invokes a publish workflow by a branch or a moving tag can have an old, superseded revision mint a signature the cluster still accepts.

Every repo that publishes today already pins correctly, but nothing enforces it: the property held by convention only. Measured across the portfolio — all 7 callers pin by commit SHA, and **none** of the 5 product repos involved runs any workflow-security linting that would catch a regression.

## What

The two publish workflows now refuse to run unless the caller pinned them to a commit SHA, checked before they check out or sign anything. Nothing to maintain: no list of approved revisions, and dependency automation already keeps the pins current.

- **Security floor gained:** a superseded revision of a publish workflow can no longer mint a trusted signature.
- **Everyday cost:** none. All 7 existing callers already pass; a mistake now fails fast at publish time with the exact fix in the message, instead of silently producing an over-trusted signature.

Part of devantler-tech/platform#2818