### PR TITLE
feat(validate-go-project): run the Go suite on the default branch behind an opt-in

### DIFF
--- a/.github/tests/test-suite-default-branch-coverage-blocks.sh
+++ b/.github/tests/test-suite-default-branch-coverage-blocks.sh
@@ -139,6 +139,16 @@ expect_block "flag-top-level-and-in-group" "$REPO && $FLAG && ( $FILTER || ( $FL
 expect_block "filter-top-level" "$REPO && $FILTER && ( $FLAG && $RAN && $DB )" \
   "AND-s the path filter"
 
+# ── 4b. The base diff-trigger dropped entirely — opt-in-only execution ───────────────
+# The subtlest defect modelled here, and the one that motivated check 4b. The group still
+# contains a `||` — but only the one inside the flag's own `== true || == 'true'`
+# normalisation — so a `||`-presence test reports the base trigger as OR-ed when the
+# group's top level is in fact a pure conjunction. Every consumer that does not opt in
+# silently loses its diff-triggered test run, which is precisely the backward-compatibility
+# property this guard claims to protect. Verified to pass the guard before check 4b existed.
+expect_block "base-arm-dropped" "$REPO && ( $FLAG && $RAN && $DB )" \
+  "no top-level OR-arm of the group is exactly"
+
 # ── 5. A single event gating the whole job — no opt-in can reach the default branch ──
 expect_block "top-level-event" "$REPO && github.event_name == 'pull_request' && ( $FILTER || ( $FLAG && $RAN && $DB ) )" \
   "AND-s 'github.event_name ==' at the top level"

--- a/.github/tests/test-suite-default-branch-coverage-blocks.sh
+++ b/.github/tests/test-suite-default-branch-coverage-blocks.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Failing-input counterpart to test-suite-default-branch-coverage.sh, per the repo
+# convention that a gating self-test carries BOTH a passes-on-good-input and a
+# blocks-on-bad-input test (AGENTS.md, "Failure-mode coverage for gating workflows").
+#
+# The guard it exercises is a *gate*: its job is to fail when the `test` job's trigger
+# conditions would leave a default branch untested, or would push the new default-branch
+# run onto consumers that never opted in. A happy-path test alone cannot catch a guard that
+# has silently stopped biting — and this guard is unusually easy to make vacuous, because
+# every check is structural string analysis over an expression. A regression in
+# `defun`/`strip_groups`/`split_arms`/`outer_group_with` (say, one that makes `$outside`
+# always empty, or yields zero arms) would leave every assertion trivially satisfied while
+# the positive test stayed green.
+#
+# Fixtures are GENERATED here from the real workflow rather than committed, so they cannot
+# drift from it: each is the real file with `.jobs.test.if` replaced by one deliberately
+# wrong gate, composed from the same named clauses as the good one. A fixture therefore
+# differs from the good gate ONLY in the defect it is named for. Asserting the *expected
+# message* rather than merely a non-zero exit is what stops an operational error (a missing
+# yq, a typo'd path) from false-passing as "the gate bit".
+#
+# Two controls guard the opposite failure — a guard that rejected everything would satisfy
+# every assertion above:
+#   * the REAL workflow must PASS;
+#   * a REFLOWED good gate (same clauses, different wrapping and spacing) must PASS, which
+#     proves each rejection is caused by its defect and not by the generation scaffold.
+
+set -euo pipefail
+
+guard="${1:-.github/tests/test-suite-default-branch-coverage.sh}"
+workflow="${2:-.github/workflows/validate-go-project.yaml}"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+status=0
+
+# The named clauses the good gate is built from. Every fixture below re-composes THESE, so
+# no fixture can differ from the good gate by an accidental typo in a shared part.
+REPO="github.repository != 'devantler-tech/reusable-workflows'"
+FLAG="(inputs.test-default-branch == true || inputs.test-default-branch == 'true')"
+FILTER="needs.changes.outputs.go == 'true'"
+RAN="needs.changes.outputs.go != ''"
+DB="github.ref == format('refs/heads/{0}', github.event.repository.default_branch)"
+
+GOOD="$REPO && ( $FILTER || ( $FLAG && $RAN && $DB ) )"
+
+# Build a copy of the real workflow whose `test` job carries $2, then run the guard on it.
+# `expect_pass` and `expect_block` differ only in the direction asserted, so a control and
+# a fixture cannot diverge in how they are evaluated.
+run_guard() {
+  local name="$1" gate="$2" out rc
+  local path="$tmpdir/$name.yaml"
+  cp "$workflow" "$path"
+  GATE="$gate" yq -i '.jobs.test.if = strenv(GATE)' "$path"
+  out="$(bash "$guard" "$path" 2>&1)" && rc=0 || rc=$?
+  printf '%s\n' "$out" > "$tmpdir/$name.out"
+  return "$rc"
+}
+
+expect_block() {
+  local name="$1" gate="$2" expected="$3"
+  if run_guard "$name" "$gate"; then
+    echo "::error::the guard PASSED the deliberately-bad fixture '$name' — it has stopped biting. Expected it to report: $expected"
+    status=1
+  elif ! grep -qF "$expected" "$tmpdir/$name.out"; then
+    echo "::error::fixture '$name' was rejected, but not for the expected reason. Expected a message containing: $expected"
+    while IFS= read -r line; do echo "    got: $line"; done < "$tmpdir/$name.out"
+    status=1
+  else
+    echo "blocks $name ✅"
+  fi
+}
+
+expect_pass() {
+  local name="$1" gate="$2"
+  if run_guard "$name" "$gate"; then
+    echo "passes $name ✅"
+  else
+    echo "::error::control '$name' was REJECTED, so the guard rejects more than the defect it names — every 'blocks' result above is therefore unattributable."
+    while IFS= read -r line; do echo "    got: $line"; done < "$tmpdir/$name.out"
+    status=1
+  fi
+}
+
+# ── Controls: the guard must accept correct input ────────────────────────────────────
+if out="$(bash "$guard" "$workflow" 2>&1)"; then
+  echo "passes real-workflow ✅"
+else
+  echo "::error file=$workflow::the guard rejects the REAL workflow, so it is not asserting the shipped gate. Output:"
+  while IFS= read -r line; do echo "    got: $line"; done <<<"$out"
+  status=1
+fi
+
+# Same clauses, different wrapping/spacing. If this were rejected, the fixtures below would
+# be failing on how they are written rather than on what they say.
+expect_pass "good-reflowed" "$REPO
+&& (
+  $FILTER
+  || (
+    $FLAG
+    && $RAN
+    && $DB
+  )
+)"
+
+# ── 1. The pre-change gate — the state ksail#6373 was filed against ──────────────────
+expect_block "original-diff-only" "$REPO && $FILTER" \
+  "has no default-branch clause"
+
+# ── 2. Default-branch run not behind the opt-in — a behaviour change for everyone ────
+expect_block "no-flag" "$REPO && ( $FILTER || ( $RAN && $DB ) )" \
+  "does not reference 'inputs.test-default-branch'"
+
+# ── 3. Flag AND-ed at the top level — a non-opted caller loses the job entirely ──────
+expect_block "flag-top-level-bare" "$REPO && inputs.test-default-branch == true && ( $FILTER || ( $RAN && $DB ) )" \
+  "OUTSIDE the OR-group"
+
+# The same defect wearing parentheses, AND still correctly placed inside the arm-group.
+# This is the arm that earns the guard's containment test, and it is a narrower shape than
+# it first appears — verified by ablation rather than assumed:
+#
+#   * `flag-top-level-bare` above is caught by a `strip_groups`-based check too, because a
+#     bare conjunct survives group deletion;
+#   * a parenthesised top-level flag that was REMOVED from the arm-group is also still
+#     caught — by checks 5 and 6, which notice the group has lost its flagged arm;
+#   * only this shape — parenthesised at the top level while the arm-group remains
+#     well-formed — defeats every other check. `strip_groups` erases the conjunct along
+#     with every legitimate group, checks 5-7 all pass because the arm-group really is
+#     correct, and the guard reports a gate that has silently removed the test job from
+#     every consumer that never opted in.
+#
+# Hence the guard asks "is the flag inside the arm-group?" (containment) instead of
+# deleting parenthesised text and inspecting what is left.
+expect_block "flag-top-level-and-in-group" "$REPO && $FLAG && ( $FILTER || ( $FLAG && $RAN && $DB ) )" \
+  "OUTSIDE the OR-group"
+
+# ── 4. Path filter AND-ed at the top level — the default-branch arm is decorative ────
+expect_block "filter-top-level" "$REPO && $FILTER && ( $FLAG && $RAN && $DB )" \
+  "AND-s the path filter"
+
+# ── 5. A single event gating the whole job — no opt-in can reach the default branch ──
+expect_block "top-level-event" "$REPO && github.event_name == 'pull_request' && ( $FILTER || ( $FLAG && $RAN && $DB ) )" \
+  "AND-s 'github.event_name ==' at the top level"
+
+# ── 6. A top-level ref predicate excluding the very branch the new arm targets ───────
+expect_block "top-level-ref" "$REPO && github.ref != 'refs/heads/main' && ( $FILTER || ( $FLAG && $RAN && $DB ) )" \
+  "AND-s a top-level ref predicate"
+
+# ── 7. The flag gates something OTHER than the default-branch clause ─────────────────
+# Referenced (so check 3 is satisfied) and a default-branch clause exists (check 2), but
+# they live in different arms — so opting in does not buy the default-branch run.
+expect_block "flag-arm-lacks-default-branch" "$REPO && ( $FILTER || ( $FLAG && $RAN ) || ( $RAN && $DB ) )" \
+  "no OR-arm both references"
+
+# ── 8. An unflagged arm that widens — new behaviour without opting in ────────────────
+expect_block "unflagged-arm-widens" "$REPO && ( $FILTER || ( $RAN && $DB ) || ( $FLAG && $RAN && $DB ) )" \
+  "without being gated by"
+
+# ── 9. The flagged arm fires without proof the filter ever ran ───────────────────────
+# `changes` is itself gated; when it is skipped its outputs are the empty string. Dropping
+# the `!= ''` term turns "the suite ran because we checked the diff" into "the suite ran
+# because we could not tell", which is a different guarantee wearing the same green tick.
+expect_block "flagged-arm-lacks-ran-proof" "$REPO && ( $FILTER || ( $FLAG && $DB ) )" \
+  "does not require needs.changes.outputs.go != ''"
+
+if [[ "$status" -eq 0 ]]; then
+  echo "test-suite-default-branch-coverage.sh bites on every modelled defect ✅"
+fi
+
+exit "$status"

--- a/.github/tests/test-suite-default-branch-coverage-blocks.sh
+++ b/.github/tests/test-suite-default-branch-coverage-blocks.sh
@@ -92,8 +92,13 @@ else
   status=1
 fi
 
-# Same clauses, different wrapping/spacing. If this were rejected, the fixtures below would
-# be failing on how they are written rather than on what they say.
+# The canonical single-line composition of the shared clauses. Every fixture below is built
+# from these same five variables, so if this were rejected each "blocks" result would be
+# unattributable — the rejection could be the composition rather than the named defect.
+expect_pass "good-canonical" "$GOOD"
+
+# Same clauses, different wrapping/spacing. Together with the canonical form above this
+# separates "written differently" from "says something different".
 expect_pass "good-reflowed" "$REPO
 && (
   $FILTER

--- a/.github/tests/test-suite-default-branch-coverage.sh
+++ b/.github/tests/test-suite-default-branch-coverage.sh
@@ -197,6 +197,38 @@ else
     elif ! grep -qF '||' <<<"$group"; then
       fail "the path-filter term and the default-branch clause share a group but are not OR-ed, so the default-branch clause cannot rescue a run the path filter rejected — see ksail#6373."
     else
+      # ── 4b. The base diff-trigger must SURVIVE as a real OR-alternative ───────────
+      # Check 4's `||` presence test is not sufficient on its own, and cannot be made
+      # sufficient: the flag-normalisation idiom this file requires elsewhere
+      # (`inputs.X == true || inputs.X == 'true'`) contributes a literal `||` nested one
+      # level inside the group, so the group contains a `||` even when its top level is a
+      # pure conjunction.
+      #
+      # The gate that exploits that — reproduced against this guard before the check was
+      # added, and it PASSED:
+      #
+      #   A && ( (inputs.test-default-branch == true || …== 'true') && go != '' && <db> )
+      #
+      # There the base trigger is gone entirely, so the job runs ONLY for callers that opt
+      # in and every other consumer silently loses its diff-triggered test run — the exact
+      # backward-compatibility property checks 3 and 6 exist to protect. It slips through
+      # because `outside` holds no path-filter term to catch (check 4), the group really
+      # does contain `default_branch` and a `||`, and `split_arms` returns a single arm
+      # that legitimately carries the flag, the ran-proof and the default-branch clause,
+      # satisfying checks 5, 6 and 7.
+      #
+      # Asserting the arm EXACTLY, rather than merely that one contains the term, is
+      # deliberate: an arm of `go == 'true' && github.event_name == 'pull_request'` would
+      # also be a regression for push consumers, and a containment test would accept it.
+      base_arm_found=0
+      while IFS= read -r arm; do
+        trimmed="$(sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' <<<"$arm")"
+        [[ "$trimmed" == "needs.changes.outputs.go == 'true'" ]] && base_arm_found=1
+      done < <(split_arms "$group")
+      if [[ "$base_arm_found" -eq 0 ]]; then
+        fail "no top-level OR-arm of the group is exactly \"needs.changes.outputs.go == 'true'\", so the base diff-trigger is not OR-ed with the flagged arm — the group's '||' may be nothing but the flag's own true/'true' normalisation. A caller that does not opt in would lose the diff-triggered test run it has today. See ksail#6373."
+      fi
+
       # ── 5. The default-branch clause must sit in the arm the input gates ──────────
       # Otherwise the input is referenced (check 3) but guards something else, and the new
       # behaviour is reachable without opting in.

--- a/.github/tests/test-suite-default-branch-coverage.sh
+++ b/.github/tests/test-suite-default-branch-coverage.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# Guards the `test` job's TRIGGER conditions in validate-go-project.yaml
+# (devantler-tech/ksail#6373).
+#
+# `needs.changes.outputs.go` answers "did a Go SOURCE file change". The Go test suite's
+# verdict does not depend only on that: a Go test may read a NON-Go file as its subject,
+# so a commit that touches only such files leaves `go == 'false'` — correctly, the filter
+# is not misconfigured — and skips the suite while breaking it.
+#
+# Measured on ksail: `internal/ciharness` asserts against `.github/workflows/*.yaml` and
+# `.github/scripts/*.sh`. Commit `a5ed9f85` (#6363) moved an EKS teardown guard out of a
+# workflow's inline `run:` into a script and broke
+# `TestEKSSmokePreparesCloudGitOpsAndBoundsCleanup`. That push to `main` changed four
+# files, NONE of them Go, so 🧪 Test was skipped and `main` reported green — and every
+# later `main` run repeated that verdict, until an unrelated pull request that happened to
+# touch Go files inherited the failure and paid for the diagnosis.
+#
+# On the default branch the diff is not a sound basis for this decision at all: that
+# branch's green IS the branch-protection signal, so it has to mean the suite ran. Fixing
+# it changes behaviour in every consumer at once, so the default-branch run ships behind
+# the opt-in input `test-default-branch` (AGENTS.md, *Shipping a new capability behind an
+# opt-in flag*), making the gate a two-armed expression whose BOTH arms this guard asserts:
+#
+#   * the flagged arm must actually be REACHABLE — the default-branch clause OR-ed with the
+#     diff gate, not AND-ed alongside it, and no top-level predicate able to veto it;
+#   * the unflagged arm must not have GROWN — nothing may become reachable without opting
+#     in, which is what keeps the change backward compatible for a caller passing nothing.
+#
+# Everything is asserted POSITIVELY — the intended property must hold — rather than by
+# rejecting one known-bad string. A test that merely rejects a specific bad predicate still
+# passes when the job is restricted some other way, and would then claim default-branch
+# coverage over a workflow that never runs the suite there.
+#
+# This deliberately mirrors test-govulncheck-main-coverage.sh, which guards the same
+# property for the vulnerability scan. The three expression-parsing helpers are duplicated
+# rather than shared: extracting them is a pure refactor and belongs in its own change, not
+# folded into a behaviour change (devantler-tech/actions#869).
+
+set -euo pipefail
+
+workflow="${1:-.github/workflows/validate-go-project.yaml}"
+
+flag_input="test-default-branch"
+flag_ref="inputs.${flag_input}"
+
+status=0
+
+fail() {
+  echo "::error file=$workflow::$1"
+  status=1
+}
+
+# Collapse the gate to one whitespace-normalised line so the structural checks below do not
+# depend on how the YAML block scalar happens to be wrapped.
+gate="$(yq -r '.jobs.test.if // ""' "$workflow")"
+flat="$(tr '\n' ' ' <<<"$gate" | tr -s ' ')"
+
+# Rewrite function-call parentheses — `format('refs/heads/{0}', x)` — into angle brackets,
+# preserving their contents. Without this the call's parens are indistinguishable from
+# grouping parens, which both hides the real group and makes `default_branch` (an argument
+# to such a call) impossible to attribute to the group it actually guards.
+defun() {
+  local s="$1" prev=""
+  while [[ "$s" != "$prev" ]]; do
+    prev="$s"
+    s="$(sed -E 's/([A-Za-z_][A-Za-z0-9_.-]*)\(([^()]*)\)/\1<\2>/g' <<<"$s")"
+  done
+  printf '%s' "$s"
+}
+
+# Repeatedly delete innermost parenthesised groups, leaving only the top-level conjuncts. A
+# term that survives this is AND-ed at the top level and can therefore veto the job on its
+# own, whatever else the gate says.
+strip_groups() {
+  local s="$1" prev=""
+  while [[ "$s" != "$prev" ]]; do
+    prev="$s"
+    s="$(sed -E 's/\([^()]*\)/ /g' <<<"$s")"
+  done
+  printf '%s' "$s"
+}
+
+# Split a parenthesised group into its top-level `||` arms, one per line. Balance-scanned
+# rather than split on `||`, because an arm may itself contain a parenthesised `||`.
+split_arms() {
+  awk '
+    {
+      s = $0
+      # Strip one enclosing layer of parens, but only when the leading "(" is the partner
+      # of the trailing ")" — in "(a) || (b)" it is not, and stripping would corrupt.
+      if (substr(s, 1, 1) == "(") {
+        d = 0
+        for (i = 1; i <= length(s); i++) {
+          c = substr(s, i, 1)
+          if (c == "(") d++
+          else if (c == ")") { d--; if (d == 0) break }
+        }
+        if (i == length(s)) s = substr(s, 2, length(s) - 2)
+      }
+      depth = 0; arm = ""
+      for (i = 1; i <= length(s); i++) {
+        c = substr(s, i, 1)
+        if (c == "(") depth++
+        else if (c == ")") depth--
+        if (depth == 0 && c == "|" && substr(s, i + 1, 1) == "|") {
+          print arm; arm = ""; i++; continue
+        }
+        arm = arm c
+      }
+      print arm
+    }' <<<"$1"
+}
+
+# Extract the OUTERMOST parenthesised group containing the path-filter term, by
+# balance-scanning rather than by regex. A regex bounded with `[^()]*` can only match a
+# group with no nesting, so it silently returns the INNERMOST group — and the flagged arm
+# of this gate legitimately nests.
+outer_group_with() {
+  awk -v needle="$2" '
+    { s = $0; depth = 0; start = 0
+      for (i = 1; i <= length(s); i++) {
+        c = substr(s, i, 1)
+        if (c == "(") { if (depth == 0) start = i; depth++ }
+        else if (c == ")") {
+          depth--
+          if (depth == 0 && start > 0) {
+            g = substr(s, start, i - start + 1)
+            if (index(g, needle) > 0) { print g; exit }
+          }
+        }
+      }
+    }' <<<"$1"
+}
+
+# Everything in the expression EXCEPT the arm-group, with the group excised exactly once.
+# This is what makes "term X may not veto the whole job" checkable without relying on
+# `strip_groups`, which deletes parenthesised text wholesale and would therefore report a
+# PARENTHESISED top-level conjunct — `&& (inputs.f == true || inputs.f == 'true') &&` — as
+# absent. That shape ANDs the flag at the top level while satisfying a strip_groups-based
+# check, so a caller that never opted in would silently lose the job entirely.
+outside_group() {
+  local whole="$1" grp="$2"
+  local prefix="${whole%%"$grp"*}"
+  local suffix="${whole#*"$grp"}"
+  printf '%s %s' "$prefix" "$suffix"
+}
+
+if [[ -z "$gate" || "$gate" == "null" ]]; then
+  fail "the test job has no 'if:' gate to verify"
+else
+  normalized="$(defun "$flat")"
+  top_level="$(strip_groups "$normalized")"
+  arm_group="$(outer_group_with "$normalized" "needs.changes.outputs.go" || true)"
+  if [[ -n "$arm_group" ]]; then
+    outside="$(outside_group "$normalized" "$arm_group")"
+  else
+    outside="$normalized"
+  fi
+
+  # ── 1. No single event may gate the whole job ─────────────────────────────────────
+  # Scoped to the TOP LEVEL. An event equality inside an OR-arm is legitimate; a top-level
+  # one vetoes every arm, so no opt-in could ever reach the default-branch run.
+  if grep -qE "github\.event_name[[:space:]]*==" <<<"$top_level"; then
+    fail "the test job AND-s 'github.event_name ==' at the top level, so whole classes of run — including the default branch — can never run the suite, whatever the opt-in input says. An event equality belongs inside an OR-arm, not alongside it; see ksail#6373."
+  fi
+
+  # ── 2. A default-branch run must be able to test regardless of the diff ───────────
+  if ! grep -qF 'default_branch' <<<"$flat"; then
+    fail "the test job's gate has no default-branch clause, so the path filter is the only gate on the default branch and a commit that breaks the suite without touching a Go file leaves it unrun while reporting green. Add: || github.ref == format('refs/heads/{0}', github.event.repository.default_branch) — see ksail#6373."
+  fi
+
+  # ── 3. The opt-in input must gate the new capability, not the whole job ───────────
+  if ! grep -qF "$flag_ref" <<<"$flat"; then
+    fail "the test job's gate does not reference '$flag_ref', so the default-branch run is not behind the opt-in input it is required to ship behind — a behaviour change landing on every consumer at once. See AGENTS.md, 'Shipping a new capability behind an opt-in flag'."
+  elif grep -qF "$flag_ref" <<<"$outside"; then
+    fail "the test job references '$flag_ref' OUTSIDE the OR-group that holds the path filter, so it is AND-ed at the top level and a caller that does not opt in loses the diff-triggered suite it has today. The input must gate the default-branch arm only — see AGENTS.md, 'Shipping a new capability behind an opt-in flag'."
+  fi
+
+  # ── 4. The path filter must not be able to veto a default-branch run ──────────────
+  # The diff gate has to sit inside an OR-group with the default-branch clause. If it is a
+  # top-level conjunct instead, the default-branch clause is decorative: `go == 'true'`
+  # still has to hold, which is exactly the state check 2 exists to prevent.
+  if grep -qF "needs.changes.outputs.go == 'true'" <<<"$outside"; then
+    fail "the test job AND-s the path filter (needs.changes.outputs.go == 'true') at the top level, so a default-branch run with no Go paths changed is still skipped. The path filter must be OR-ed with the default-branch clause, not AND-ed alongside it — see ksail#6373."
+  elif grep -qE 'github\.(ref|ref_name|head_ref|base_ref)' <<<"$top_level"; then
+    # The legitimate default-branch clause lives inside the OR-group and has already been
+    # stripped by now, so any ref predicate still standing here is an ADDITIONAL top-level
+    # conjunct. `&& github.ref != 'refs/heads/main'` would satisfy the checks above while
+    # making default-branch runs unreachable — the state this file exists to prevent.
+    fail "the test job AND-s a top-level ref predicate, which can exclude the default branch no matter what the OR-ed default-branch clause says. A ref condition belongs inside that OR-group, not alongside it — see ksail#6373."
+  else
+    group="$arm_group"
+    if [[ -z "$group" ]]; then
+      fail "could not find the parenthesised group holding the path-filter term; the gate's structure is not what this guard can verify — see ksail#6373."
+    elif ! grep -qF 'default_branch' <<<"$group"; then
+      fail "the path-filter term is grouped, but not with the default-branch clause, so a default-branch run with no Go paths changed is still skipped — see ksail#6373."
+    elif ! grep -qF '||' <<<"$group"; then
+      fail "the path-filter term and the default-branch clause share a group but are not OR-ed, so the default-branch clause cannot rescue a run the path filter rejected — see ksail#6373."
+    else
+      # ── 5. The default-branch clause must sit in the arm the input gates ──────────
+      # Otherwise the input is referenced (check 3) but guards something else, and the new
+      # behaviour is reachable without opting in.
+      flagged_arm_has_default_branch=0
+      while IFS= read -r arm; do
+        if grep -qF "$flag_ref" <<<"$arm" && grep -qF 'default_branch' <<<"$arm"; then
+          flagged_arm_has_default_branch=1
+        fi
+      done < <(split_arms "$group")
+      if [[ "$flagged_arm_has_default_branch" -eq 0 ]]; then
+        fail "no OR-arm both references '$flag_ref' and carries the default-branch clause, so the default-branch run is not the thing the opt-in input actually gates. See AGENTS.md, 'Shipping a new capability behind an opt-in flag'."
+      fi
+
+      # ── 6. Nothing new may become reachable without opting in ─────────────────────
+      # The backward-compatibility property, asserted directly. This job legitimately runs
+      # on pushes today (whenever the diff touched Go), so — unlike the vuln scan's guard —
+      # the unflagged arms cannot be required to be pull-request-only. What they must not
+      # do is widen: an arm the input does not gate may not introduce a ref or
+      # default-branch predicate of its own. Without this an arm could be added that fires
+      # on every consumer's default branch, and checks 1-5 would all still pass.
+      while IFS= read -r arm; do
+        [[ -n "${arm// /}" ]] || continue
+        grep -qF "$flag_ref" <<<"$arm" && continue
+        if grep -qF 'default_branch' <<<"$arm" || grep -qE 'github\.(ref|ref_name|base_ref)' <<<"$arm"; then
+          fail "an OR-arm of the test job's gate carries a ref/default-branch predicate without being gated by '$flag_ref', so the new default-branch behaviour reaches consumers that never opted in. Offending arm: ${arm}. See AGENTS.md, 'Shipping a new capability behind an opt-in flag'."
+        fi
+      done < <(split_arms "$group")
+
+      # ── 7. The flagged arm must prove the path filter actually RAN ────────────────
+      # `changes` is itself gated, so a skipped `changes` job leaves its outputs as the
+      # empty string. Without this term the flagged arm would fire on a default-branch run
+      # where no filtering happened at all, turning "the suite ran because we checked" into
+      # "the suite ran because we could not tell".
+      while IFS= read -r arm; do
+        grep -qF "$flag_ref" <<<"$arm" || continue
+        if ! grep -qF "needs.changes.outputs.go != ''" <<<"$arm"; then
+          fail "the '$flag_ref' arm does not require needs.changes.outputs.go != '', so it fires even when the changes job was skipped entirely and no path filtering ever ran — see ksail#6373."
+        fi
+      done < <(split_arms "$group")
+    fi
+  fi
+fi
+
+if [[ "$status" -eq 0 ]]; then
+  echo "validate-go-project.yaml's test job covers the default branch behind '$flag_input' ✅"
+fi
+
+exit "$status"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2074,6 +2074,29 @@ jobs:
       issues: write
       code-quality: write # callers must grant this for the coverage upload (GitHub Code Quality)
 
+  # ── Flag-ON counterpart for `test-default-branch` (the both-states rule) ──
+  # test-validate-go-project omits this input entirely, so it exercises the OFF state every
+  # existing consumer gets; this job passes it as true. Together they cover both states.
+  #
+  # As with scan-default-branch, what this proves is that the input is declared and
+  # accepted and that the workflow still behaves correctly in both states of it — NOT that
+  # a default-branch push runs the suite, which no pull-request-triggered job can
+  # demonstrate (`github.ref` here is a PR merge ref, so the default-branch arm is
+  # unreachable by construction). The reachability of that arm is what the structural guard
+  # in test-suite-default-branch-coverage.sh asserts instead.
+  test-validate-go-project-test-default-branch:
+    if: "${{ github.event_name != 'merge_group' && !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
+    name: "[Test] Validate Go Project - Default-Branch Test Opted In"
+    uses: ./.github/workflows/validate-go-project.yaml
+    with:
+      working-directory: .github/tests/go-valid-fixture
+      test-default-branch: true
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      code-quality: write # callers must grant this for the coverage upload (GitHub Code Quality)
+
   test-run-dotnet-tests-workflow:
     if: "${{ github.event_name != 'merge_group' && !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
     name: "[Test] Run .NET Tests"
@@ -2525,6 +2548,57 @@ jobs:
 
       - name: 🧪 Assert the trigger guard blocks every bad-input fixture
         run: bash .github/tests/test-govulncheck-main-coverage-blocks.sh
+
+  # ── The same property, asserted for the Go TEST suite (ksail#6373) ──────────────
+  # `needs.changes.outputs.go` answers "did a Go source file change", which is narrower
+  # than "could the suite's verdict have changed": a Go test may read a non-Go file as its
+  # subject, so a commit touching only those files skips the suite while breaking it, and
+  # the default branch keeps reporting green. Measured on ksail — a5ed9f85 changed four
+  # files, none of them Go, broke internal/ciharness, and main stayed green.
+  test-suite-default-branch-coverage:
+    if: "${{ github.event_name != 'merge_group' && !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
+    name: "[Test] Go Suite - Default-Branch Trigger Coverage"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: 📄 Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: 🧪 Assert the Go test suite runs on the default branch behind its opt-in
+        run: bash .github/tests/test-suite-default-branch-coverage.sh
+
+  # ── Failing-input counterpart to the job above (the both-tests convention) ──
+  # Generates its fixtures from the real workflow, so they cannot drift from it, and
+  # asserts the guard fails WITH THE EXPECTED MESSAGE on each — plus that it still passes
+  # the real workflow and a reflowed-but-equivalent gate, so neither an accept-everything
+  # nor a reject-everything guard passes.
+  test-suite-default-branch-coverage-blocks:
+    if: "${{ github.event_name != 'merge_group' && !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
+    name: "[Test] Go Suite Trigger Guard - Blocks On Bad Input"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: 📄 Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: 🧪 Assert the trigger guard blocks every bad-input fixture
+        run: bash .github/tests/test-suite-default-branch-coverage-blocks.sh
 
   # ── Zizmor gate failure-mode self-test (generalizes the govulncheck guard; #313) ──
   # scan-for-workflow-vulnerabilities.yaml is a SECURITY GATE: its job is to FAIL a PR
@@ -3020,6 +3094,7 @@ jobs:
       - test-delete-workflow-runs-minimal
       - test-validate-go-project
       - test-validate-go-project-scan-default-branch
+      - test-validate-go-project-test-default-branch
       - test-run-dotnet-tests-workflow
       - test-run-dotnet-tests-workflow-authenticated
       - test-enable-auto-merge
@@ -3043,6 +3118,8 @@ jobs:
       - test-govulncheck-timeout
       - test-govulncheck-main-coverage
       - test-govulncheck-main-coverage-blocks
+      - test-suite-default-branch-coverage
+      - test-suite-default-branch-coverage-blocks
       - test-zizmor-blocks
       - test-zizmor-action-lockstep
       - test-validate-go-lint-blocks
@@ -3116,6 +3193,7 @@ jobs:
             ${{ needs.test-delete-workflow-runs-minimal.result }}
             ${{ needs.test-validate-go-project.result }}
             ${{ needs.test-validate-go-project-scan-default-branch.result }}
+            ${{ needs.test-validate-go-project-test-default-branch.result }}
             ${{ needs.test-run-dotnet-tests-workflow.result }}
             ${{ needs.test-run-dotnet-tests-workflow-authenticated.result }}
             ${{ needs.test-enable-auto-merge.result }}
@@ -3139,6 +3217,8 @@ jobs:
             ${{ needs.test-govulncheck-timeout.result }}
             ${{ needs.test-govulncheck-main-coverage.result }}
             ${{ needs.test-govulncheck-main-coverage-blocks.result }}
+            ${{ needs.test-suite-default-branch-coverage.result }}
+            ${{ needs.test-suite-default-branch-coverage-blocks.result }}
             ${{ needs.test-zizmor-blocks.result }}
             ${{ needs.test-zizmor-action-lockstep.result }}
             ${{ needs.test-validate-go-lint-blocks.result }}

--- a/.github/workflows/validate-go-project.yaml
+++ b/.github/workflows/validate-go-project.yaml
@@ -49,7 +49,7 @@ on:
 # Adding a discriminator only ever splits groups further; it cannot merge two that were
 # separate, so this direction of change cannot reintroduce #587.
 concurrency:
-  group: "validate-go-project-${{ github.repository }}-${{ github.ref }}-${{ github.workflow }}-${{ inputs.pr-owner }}-${{ inputs.working-directory }}-${{ inputs.scan-default-branch }}"
+  group: "validate-go-project-${{ github.repository }}-${{ github.ref }}-${{ github.workflow }}-${{ inputs.pr-owner }}-${{ inputs.working-directory }}-${{ inputs.scan-default-branch }}-${{ inputs.test-default-branch }}"
   cancel-in-progress: true
 
 permissions: {}

--- a/.github/workflows/validate-go-project.yaml
+++ b/.github/workflows/validate-go-project.yaml
@@ -17,6 +17,11 @@ on:
         type: boolean
         default: false
         description: "Opt in to the vulnerability scan's corrected coverage: it then runs on every default-branch invocation rather than only on pull requests, and a pull request that edits only a .govulncheck-allow.txt runs it too, so a risk acceptance is validated by the scanner it applies to. Off by default because both are behaviour changes for every consumer: a default branch that was reporting green can legitimately go red the moment an advisory is published against code that was already merged, and an allowlist-only pull request that used to skip the scan starts paying for it. Callers that omit this input keep the previous behaviour exactly. Roll out caller-by-caller, then flip this default to true and remove the input (devantler-tech/actions#788)."
+      test-default-branch:
+        required: false
+        type: boolean
+        default: false
+        description: "Opt in to running the Go test suite on every default-branch invocation, rather than only when the diff touched a Go file. `go` answers 'did a Go source file change', which is narrower than 'could the suite's verdict have changed': a Go test may read a non-Go file as its subject, so a commit touching only those files skips the suite while breaking it, and the default branch keeps reporting green. Off by default because it is a behaviour change for every consumer — a default branch that was reporting green starts reporting whatever the suite actually says, which may be red. Callers that omit this input keep the previous behaviour exactly. Roll out caller-by-caller, then flip this default to true and remove the input (devantler-tech/ksail#6373)."
     secrets:
       APP_PRIVATE_KEY:
         description: "GitHub App Private Key"
@@ -693,10 +698,41 @@ jobs:
     defaults:
       run:
         working-directory: ${{ inputs.working-directory || '.' }}
-    # Skip if no Go files changed or on reusable-workflows repo
+    # Skip if no Go files changed or on reusable-workflows repo.
+    #
+    # `needs.changes.outputs.go` answers "did a Go SOURCE file change", which is a strictly
+    # narrower question than "could this suite's verdict have changed". A Go test may read a
+    # non-Go file as its subject: ksail's `internal/ciharness` package asserts against
+    # `.github/workflows/*.yaml` and `.github/scripts/*.sh`. A commit touching only those
+    # files therefore yields `go == 'false'` CORRECTLY — the filter is not misconfigured —
+    # and this job skips CORRECTLY by its own rule, while the suite is in fact broken.
+    # Measured on ksail: `a5ed9f85` (#6363) moved an EKS teardown guard out of a workflow's
+    # inline `run:` into a script, breaking `TestEKSSmokePreparesCloudGitOpsAndBoundsCleanup`.
+    # That push to `main` changed four files, none of them Go, so `go` was false, 🧪 Test was
+    # skipped, and `main` reported green. Every later `main` run repeated that verdict until
+    # an unrelated pull request that happened to touch Go files inherited the failure.
+    #
+    # On the default branch there is no diff worth trusting for this decision: that branch's
+    # green IS the branch-protection signal, so it has to mean the suite ran. Fixing it
+    # changes behaviour in every consumer at once, so it ships behind the opt-in
+    # `test-default-branch` — the same shape `scan-default-branch` uses for the vuln scan.
+    #
+    # `needs.changes.outputs.go != ''` proves the filter actually RAN: an empty string means
+    # the `changes` job itself was skipped (it is gated too), so a concrete 'true'/'false' is
+    # the only evidence that this arm is deciding on a real answer.
+    #
+    # The input is compared against both the boolean and the string because a workflow
+    # reachable from more than one trigger receives it either way (AGENTS.md, *Gotchas*).
     if: |
       github.repository != 'devantler-tech/reusable-workflows'
-      && needs.changes.outputs.go == 'true'
+      && (
+        needs.changes.outputs.go == 'true'
+        || (
+          (inputs.test-default-branch == true || inputs.test-default-branch == 'true')
+          && needs.changes.outputs.go != ''
+          && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        )
+      )
     permissions:
       contents: write
     steps:

--- a/README.md
+++ b/README.md
@@ -749,6 +749,7 @@ jobs:
 | `pr-owner`            | Input (string)  | -       | No       | Pull request author login (used to disable auto-commit for bot PRs)                                                                                                                                                             |
 | `working-directory`   | Input (string)  | `""`    | No       | Go module directory to validate. Empty means the repository root                                                                                                                                                                |
 | `scan-default-branch` | Input (boolean) | `false` | No       | Also run the vulnerability scan on every default-branch run, not just on pull requests. Off by default: a default branch that was green can legitimately go red once an advisory is published against code that already merged    |
+| `test-default-branch` | Input (boolean) | `false` | No       | Also run the Go test suite on every default-branch run, not just when the diff touched a Go file. Off by default: a test can take a non-Go file as its subject, so a default branch that was green can legitimately go red once the suite stops being skipped |
 
 </details>
 


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

A repository's default branch can report green while its Go test suite is broken, and stay that way indefinitely.

The suite is gated on "did a Go source file change". That is narrower than "could the suite's verdict have changed", because a Go test may read a **non-Go** file as its subject. A commit that touches only such files skips the suite — correctly, by the gate's own rule — while breaking it.

Measured on KSail: one merge changed four files, none of them Go, and broke a test that asserts against a workflow file. `main` reported green, and kept reporting green, until an unrelated pull request that happened to touch Go files inherited the failure and paid for the diagnosis.

## What

On the default branch the diff is no longer treated as a reason to skip the Go suite — that branch's green is the branch-protection signal, so it has to mean the suite ran.

This is a behaviour change for every consumer (a default branch that was reporting green starts reporting whatever the suite actually says), so it ships **default-off** behind a new opt-in input, exactly as the vulnerability scan's `scan-default-branch` did. Callers that pass nothing keep today's behaviour. Roll-out is caller-by-caller.

Part of devantler-tech/ksail#6373