### PR TITLE
fix(validate-go-project): default test-default-branch to on

### DIFF
--- a/.github/tests/test-suite-default-branch-coverage-blocks.sh
+++ b/.github/tests/test-suite-default-branch-coverage-blocks.sh
@@ -194,7 +194,6 @@ run_guard_default() {
   local path="$tmpdir/$name.yaml"
   cp "$workflow" "$path"
   GATE="$GOOD" yq -i '.jobs.test.if = strenv(GATE)' "$path"
-  # shellcheck disable=SC2016
   case "$2" in
     MISSING) yq -i 'del(.on.workflow_call.inputs["test-default-branch"].default)' "$path" ;;
     *)       VAL="$2" yq -i '.on.workflow_call.inputs["test-default-branch"].default = (strenv(VAL) == "true")' "$path" ;;

--- a/.github/tests/test-suite-default-branch-coverage-blocks.sh
+++ b/.github/tests/test-suite-default-branch-coverage-blocks.sh
@@ -221,6 +221,12 @@ expect_block_default() {
 expect_block_default "default-false" "false" "defaults to 'false'"
 
 # No default at all — what an unopted caller gets becomes implicit rather than declared.
+#
+# This one fixture covers BOTH YAML spellings of "no default", which is why there is no
+# separate `default: null` case. Measured, not assumed: `del(...)` and an explicit
+# `default: null` both make `yq -r` return the string `null`, so the guard receives
+# byte-identical input either way and a second fixture could not fail unless this one did
+# too. A test that cannot fail independently of another is not coverage, it is noise.
 expect_block_default "default-missing" "MISSING" "has no declared default"
 
 # Control for the pair above: same scaffold, correct default, must PASS. Without this a

--- a/.github/tests/test-suite-default-branch-coverage-blocks.sh
+++ b/.github/tests/test-suite-default-branch-coverage-blocks.sh
@@ -179,6 +179,61 @@ expect_block "unflagged-arm-widens" "$REPO && ( $FILTER || ( $RAN && $DB ) || ( 
 expect_block "flagged-arm-lacks-ran-proof" "$REPO && ( $FILTER || ( $FLAG && $DB ) )" \
   "does not require needs.changes.outputs.go != ''"
 
+# ── 10. The input's DEFAULT, which no gate fixture can reach ─────────────────────────
+# Every fixture above rewrites `.jobs.test.if`, so none of them can exercise check 8 —
+# that check reads the input's declared default, not the gate. Without these two the flip
+# to `default: true` would be unguarded: someone could set it back to false, all nine
+# assertions above would still pass, and the guard would report full default-branch
+# coverage over a workflow whose next consumer silently inherits the ksail#6373 defect.
+#
+# The gate is held at the KNOWN-GOOD expression throughout, so the only thing that differs
+# from a passing run is the default itself — which is what makes the rejection attributable
+# to check 8 rather than to some incidental malformation.
+run_guard_default() {
+  local name="$1" out rc
+  local path="$tmpdir/$name.yaml"
+  cp "$workflow" "$path"
+  GATE="$GOOD" yq -i '.jobs.test.if = strenv(GATE)' "$path"
+  # shellcheck disable=SC2016
+  case "$2" in
+    MISSING) yq -i 'del(.on.workflow_call.inputs["test-default-branch"].default)' "$path" ;;
+    *)       VAL="$2" yq -i '.on.workflow_call.inputs["test-default-branch"].default = (strenv(VAL) == "true")' "$path" ;;
+  esac
+  out="$(bash "$guard" "$path" 2>&1)" && rc=0 || rc=$?
+  printf '%s\n' "$out" > "$tmpdir/$name.out"
+  return "$rc"
+}
+
+expect_block_default() {
+  local name="$1" val="$2" expected="$3"
+  if run_guard_default "$name" "$val"; then
+    echo "::error::the guard PASSED the deliberately-bad fixture '$name' (default=$val) — check 8 has stopped biting. Expected it to report: $expected"
+    status=1
+  elif ! grep -qF "$expected" "$tmpdir/$name.out"; then
+    echo "::error::fixture '$name' was rejected, but not for the expected reason. Expected a message containing: $expected"
+    while IFS= read -r line; do echo "    got: $line"; done < "$tmpdir/$name.out"
+    status=1
+  else
+    echo "blocks $name ✅"
+  fi
+}
+
+# The pre-flip state: opt-in, so a new consumer inherits the vacuous green.
+expect_block_default "default-false" "false" "defaults to 'false'"
+
+# No default at all — what an unopted caller gets becomes implicit rather than declared.
+expect_block_default "default-missing" "MISSING" "has no declared default"
+
+# Control for the pair above: same scaffold, correct default, must PASS. Without this a
+# `run_guard_default` that corrupted the file would make both rejections unattributable.
+if run_guard_default "default-true-control" "true"; then
+  echo "passes default-true-control ✅"
+else
+  echo "::error::control 'default-true-control' was REJECTED, so the default-fixture scaffold itself breaks the workflow — both 'blocks' results above are unattributable."
+  while IFS= read -r line; do echo "    got: $line"; done < "$tmpdir/default-true-control.out"
+  status=1
+fi
+
 if [[ "$status" -eq 0 ]]; then
   echo "test-suite-default-branch-coverage.sh bites on every modelled defect ✅"
 fi

--- a/.github/tests/test-suite-default-branch-coverage.sh
+++ b/.github/tests/test-suite-default-branch-coverage.sh
@@ -272,8 +272,30 @@ else
   fi
 fi
 
+# ── 8. The corrected coverage must be what a caller gets by DEFAULT ──────────────────
+# Checks 1-7 verify the gate can reach the default-branch run when a caller opts in. They
+# say nothing about what a caller who passes NOTHING gets, and that is the property that
+# actually decides whether the next consumer inherits the ksail#6373 defect: an input
+# defaulting to false makes the vacuous green the paved road and the correct behaviour the
+# detour, so every repo onboarded after this workflow starts out reporting a green default
+# branch over a suite it never ran.
+#
+# The rollout this completes is the one the input's own description prescribes — adopt
+# caller-by-caller, then flip the default. `ksail` is the only consumer and passes it
+# explicitly, so the flip changes no existing caller's behaviour; it changes what a NEW
+# caller gets, which is the whole point.
+#
+# Read through `.on` rather than a grep for `default: true`: the file declares several
+# inputs and a textual match cannot attribute a default to the input it belongs to.
+default_val="$(yq -r '.on.workflow_call.inputs["'"$flag_input"'"].default' "$workflow" 2>/dev/null || echo "MISSING")"
+if [[ "$default_val" == "MISSING" || "$default_val" == "null" ]]; then
+  fail "input '$flag_input' has no declared default, so what an unopted caller gets is implicit — see ksail#6373."
+elif [[ "$default_val" != "true" ]]; then
+  fail "input '$flag_input' defaults to '$default_val', so a caller that passes nothing still decides whether to run the Go suite on its default branch from the diff alone — the exact state ksail#6373 was filed against, now inherited by every new consumer instead of fixed. Flip the default to true (devantler-tech/actions#788 tracks the same flip for scan-default-branch)."
+fi
+
 if [[ "$status" -eq 0 ]]; then
-  echo "validate-go-project.yaml's test job covers the default branch behind '$flag_input' ✅"
+  echo "validate-go-project.yaml's test job covers the default branch, and '$flag_input' defaults to on ✅"
 fi
 
 exit "$status"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2078,9 +2078,18 @@ jobs:
       issues: write
       code-quality: write # callers must grant this for the coverage upload (GitHub Code Quality)
 
-  # ── Flag-ON counterpart for `test-default-branch` (the both-states rule) ──
-  # test-validate-go-project omits this input entirely, so it exercises the OFF state every
-  # existing consumer gets; this job passes it as true. Together they cover both states.
+  # ── Flag-OFF counterpart for `test-default-branch` (the both-states rule) ──
+  # `test-default-branch` defaults to TRUE, so test-validate-go-project above — which omits
+  # the input — is the ON state, and it is also what every consumer now gets. This job
+  # passes it as false, which is the only remaining way to instantiate the OFF path.
+  # Together they cover both states, per AGENTS.md "Shipping a new capability behind an
+  # opt-in flag": a flag whose off-path is untested can regress silently, and so can an
+  # on-path that was never instantiated.
+  #
+  # The direction is deliberate. While the input defaulted to false these two jobs were
+  # ON-explicit plus OFF-by-default; flipping the default without flipping this job would
+  # have left BOTH of them exercising ON and the off-path uninstantiated — a both-states
+  # pair that silently became a one-state pair.
   #
   # As with scan-default-branch, what this proves is that the input is declared and
   # accepted and that the workflow still behaves correctly in both states of it — NOT that
@@ -2090,11 +2099,11 @@ jobs:
   # in test-suite-default-branch-coverage.sh asserts instead.
   test-validate-go-project-test-default-branch:
     if: "${{ github.event_name != 'merge_group' && !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
-    name: "[Test] Validate Go Project - Default-Branch Test Opted In"
+    name: "[Test] Validate Go Project - Default-Branch Test Opted Out"
     uses: ./.github/workflows/validate-go-project.yaml
     with:
       working-directory: .github/tests/go-valid-fixture
-      test-default-branch: true
+      test-default-branch: false
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/validate-go-project.yaml
+++ b/.github/workflows/validate-go-project.yaml
@@ -20,8 +20,8 @@ on:
       test-default-branch:
         required: false
         type: boolean
-        default: false
-        description: "Opt in to running the Go test suite on every default-branch invocation, rather than only when the diff touched a Go file. `go` answers 'did a Go source file change', which is narrower than 'could the suite's verdict have changed': a Go test may read a non-Go file as its subject, so a commit touching only those files skips the suite while breaking it, and the default branch keeps reporting green. Off by default because it is a behaviour change for every consumer — a default branch that was reporting green starts reporting whatever the suite actually says, which may be red. Callers that omit this input keep the previous behaviour exactly. Roll out caller-by-caller, then flip this default to true and remove the input (devantler-tech/ksail#6373)."
+        default: true
+        description: "Run the Go test suite on every default-branch invocation, rather than only when the diff touched a Go file. `go` answers 'did a Go source file change', which is narrower than 'could the suite's verdict have changed': a Go test may read a non-Go file as its subject, so a commit touching only those files skips the suite while breaking it, and the default branch keeps reporting green. On by default, so a consumer inherits the corrected coverage without knowing this input exists; the default branch then reports whatever the suite actually says, which may be red. Set it to false only to accept a default branch whose green does not mean the suite ran (devantler-tech/ksail#6373)."
     secrets:
       APP_PRIVATE_KEY:
         description: "GitHub App Private Key"

--- a/README.md
+++ b/README.md
@@ -751,7 +751,7 @@ jobs:
 | `pr-owner`            | Input (string)  | -       | No       | Pull request author login (used to disable auto-commit for bot PRs)                                                                                                                                                             |
 | `working-directory`   | Input (string)  | `""`    | No       | Go module directory to validate. Empty means the repository root                                                                                                                                                                |
 | `scan-default-branch` | Input (boolean) | `false` | No       | Also run the vulnerability scan on every default-branch run, not just on pull requests. Off by default: a default branch that was green can legitimately go red once an advisory is published against code that already merged    |
-| `test-default-branch` | Input (boolean) | `false` | No       | Also run the Go test suite on every default-branch run, not just when the diff touched a Go file. Off by default: a test can take a non-Go file as its subject, so a default branch that was green can legitimately go red once the suite stops being skipped |
+| `test-default-branch` | Input (boolean) | `true`  | No       | Run the Go test suite on every default-branch run, not just when the diff touched a Go file. On by default: a test can take a non-Go file as its subject, so a diff-only gate leaves the default branch reporting green over a suite it never ran. Set to `false` to accept that                                    |
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -751,7 +751,7 @@ jobs:
 | `pr-owner`            | Input (string)  | -       | No       | Pull request author login (used to disable auto-commit for bot PRs)                                                                                                                                                             |
 | `working-directory`   | Input (string)  | `""`    | No       | Go module directory to validate. Empty means the repository root                                                                                                                                                                |
 | `scan-default-branch` | Input (boolean) | `false` | No       | Also run the vulnerability scan on every default-branch run, not just on pull requests. Off by default: a default branch that was green can legitimately go red once an advisory is published against code that already merged    |
-| `test-default-branch` | Input (boolean) | `true`  | No       | Run the Go test suite on every default-branch run, not just when the diff touched a Go file. On by default: a test can take a non-Go file as its subject, so a diff-only gate leaves the default branch reporting green over a suite it never ran. Set to `false` to accept that                                    |
+| `test-default-branch` | Input (boolean) | `true`  | No       | Run the Go test suite on every default-branch run, not just when the diff touched a Go file. On by default: a test can take a non-Go file as its subject, so a diff-only gate leaves the default branch reporting green over a suite it never ran. Set to `false` to accept a default branch that can report green without the suite having run          |
 
 </details>
 


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

A repository could break its Go test suite and still show a green default branch. The suite only ran when a change touched a Go file — but a Go test can take a *non-Go* file as its subject, so a change to a workflow or a script could break it and never trigger it. The branch then kept reporting green, and the breakage surfaced later on an unrelated pull request, costing that author a diagnosis for something they did not cause.

That was fixed for KSail by opting it in. The fix shipped as an opt-in, which left the unsafe behaviour as what any *new* repository gets by default — so the next project onboarded would inherit the same blind spot rather than the fix.

## What

Makes the corrected coverage the default, so a repository gets it without knowing the setting exists. KSail is the only consumer and already opts in explicitly, so no existing repository changes behaviour — what changes is what the next one inherits.

The setting stays available for a repository that deliberately wants the old behaviour, and the CI self-tests now cover both states of it.

Part of devantler-tech/ksail#6373
