### PR TITLE
fix(go): prevent clean vulnerability scans timing out

### DIFF
--- a/.github/tests/test-govulncheck-timeout.sh
+++ b/.github/tests/test-govulncheck-timeout.sh
@@ -2,14 +2,16 @@
 # Guards the govulncheck job's runtime safety controls in
 # validate-go-project.yaml (actions#593). A cold-cache scan of a large module
 # runs ~14 min and a clean run crossed the old 15-min bound, so Actions
-# cancelled a passing scan and failed the required check. The floor below keeps
-# headroom over that observed runtime while preserving a *finite* ceiling and
-# the GOMEMLIMIT heap cap — so neither control can silently regress.
+# cancelled a passing scan and failed the required check. A later KSail main
+# run finished the scan after 17m44s, then setup-go's cache-save post-step hit
+# the 20-minute job limit. The floor below keeps headroom over both phases while
+# preserving a *finite* ceiling and the GOMEMLIMIT heap cap — so neither
+# control can silently regress.
 
 set -euo pipefail
 
 workflow="${1:-.github/workflows/validate-go-project.yaml}"
-min_timeout="${2:-20}"
+min_timeout="${2:-25}"
 
 status=0
 
@@ -18,7 +20,7 @@ if [[ -z "$timeout" || "$timeout" == "null" ]]; then
   echo "::error file=$workflow::govulncheck job must set a finite timeout-minutes (found none)"
   status=1
 elif ((timeout < min_timeout)); then
-  echo "::error file=$workflow::govulncheck timeout-minutes must be >= $min_timeout to survive a cold-cache scan (actions#593); got $timeout"
+  echo "::error file=$workflow::govulncheck timeout-minutes must be >= $min_timeout to survive a cold-cache scan and cache-save cleanup; got $timeout"
   status=1
 fi
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2622,6 +2622,30 @@ jobs:
       - name: 🧪 Assert govulncheck keeps a cold-cache-safe finite timeout + GOMEMLIMIT
         run: bash .github/tests/test-govulncheck-timeout.sh
 
+      - name: 🛡️ Assert the timeout floor blocks bad input
+        shell: bash
+        run: |
+          set -euo pipefail
+          fixture="$(mktemp)"
+          trap 'rm -f "$fixture"' EXIT
+          cp .github/workflows/validate-go-project.yaml "$fixture"
+          yq -i '.jobs.govulncheck."timeout-minutes" = 24' "$fixture"
+
+          set +e
+          output="$(bash .github/tests/test-govulncheck-timeout.sh "$fixture" 25 2>&1)"
+          outcome=$?
+          set -e
+
+          if (( outcome == 0 )); then
+            echo "::error::The timeout guard accepted the deliberately-bad 24-minute fixture"
+            exit 1
+          fi
+          if [[ "$output" != *"timeout-minutes must be >= 25"* || "$output" != *"got 24"* ]]; then
+            echo "::error::The timeout guard rejected the fixture for an unexpected reason: $output"
+            exit 1
+          fi
+          echo "Timeout guard correctly rejected 24 minutes with the expected finding ✅"
+
   test-govulncheck-main-coverage:
     if: "${{ github.event_name != 'merge_group' && !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
     name: "[Test] Govulncheck - Default-Branch & Allowlist Trigger Coverage"

--- a/.github/workflows/validate-go-project.yaml
+++ b/.github/workflows/validate-go-project.yaml
@@ -461,12 +461,12 @@ jobs:
     # ceiling instead of OOM-killing; timeout-minutes bounds the worst case to a clear,
     # fast failure rather than a hung runner.
     #
-    # 20 (not 15): a cold-cache scan of a large module (no setup-go cache) legitimately
-    # runs ~14 min and a clean run has crossed the old 15-min bound — Actions cancelled
-    # a scan one second after it printed "No blocking vulnerabilities", failing the
-    # required check on a passing result (actions#593). 20 keeps a finite ceiling with
-    # headroom over the observed cold-cache runtime. Guarded by test-govulncheck-timeout.
-    timeout-minutes: 20
+    # 25 (not 20): a cold-cache scan of a large module legitimately takes most of the
+    # previous limit. A KSail main run finished the scan after 17m44s, then setup-go's
+    # cache-save post-step hit the 20-minute ceiling and cancelled an otherwise-passing
+    # required check. 25 keeps a finite ceiling with headroom for both the scan and its
+    # post-job cleanup. Guarded by test-govulncheck-timeout.
+    timeout-minutes: 25
     env:
       # ubuntu-latest provides 16 GiB RAM; leave headroom for the OS, the Go toolchain
       # subprocesses and harden-runner.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## What changed

- Raise the reusable Go vulnerability job's finite timeout from 20 to 25 minutes.
- Raise the contract-test floor to 25 minutes and document the scan plus post-job cleanup phases.

## Why

KSail default-branch run [31209007757](https://github.com/devantler-tech/ksail/actions/runs/31209007757) completed its vulnerability scan successfully after 17m44s. During `actions/setup-go` post-job cleanup, saving the Go cache exceeded the remaining two minutes, so GitHub cancelled the job at the 20-minute ceiling and the aggregate required check turned main red.

The five-minute increase preserves both safety controls: the timeout remains finite and `GOMEMLIMIT` remains `12GiB`.

## Validation

- `bash .github/tests/test-govulncheck-timeout.sh` (failed at 20 before the workflow change, passed at 25 after it)
- `actionlint .github/workflows/validate-go-project.yaml`
- `yamllint .github/workflows/validate-go-project.yaml .github/workflows/ci.yaml`
- `shellcheck .github/tests/test-govulncheck-timeout.sh`
- `git diff --check`