### PR TITLE
fix(ci): stop granting id-token: write to pull_request-eligible test jobs

### DIFF
--- a/.github/tests/ci-idtoken-boundary-bad-fixture.yaml
+++ b/.github/tests/ci-idtoken-boundary-bad-fixture.yaml
@@ -1,0 +1,33 @@
+name: Deliberately unsafe OIDC-grant fixture
+
+on:
+  pull_request:
+  push:
+
+permissions: {}
+
+jobs:
+  # The offender. Its predicate MENTIONS the push event, so a guard that merely
+  # searched the condition for `github.event_name == 'push'` would exempt it —
+  # but the leading `true ||` makes the arm dead and the job runs on a
+  # pull_request all the same.
+  unsafe-dead-disjunct:
+    if: "${{ true || github.event_name == 'push' }}"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - run: echo "This job is deliberately eligible for pull_request"
+
+  # Positive control: a genuinely push-only job holding the same grant. The
+  # guard must leave this one alone, so a fixture failure cannot be explained by
+  # the guard rejecting every id-token grant it sees.
+  safe-push-only:
+    if: "${{ github.event_name == 'push' && !startsWith(github.head_ref, 'release-please--') }}"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - run: echo "Trusted ref, already merged"

--- a/.github/tests/ci-idtoken-boundary-mixed-interpolation-fixture.yaml
+++ b/.github/tests/ci-idtoken-boundary-mixed-interpolation-fixture.yaml
@@ -1,0 +1,35 @@
+name: Deliberately unsafe OIDC-grant fixture (mixed interpolation)
+
+on:
+  pull_request:
+  push:
+
+permissions: {}
+
+jobs:
+  # The offender. Its scalar OPENS with the exact push-only conjunct, but text
+  # follows the closing `}}`, so the value is a STRING rather than the
+  # expression's boolean: on a pull_request `${{ … }}` renders `false` and the
+  # scalar becomes `falsetrailing`, which Actions treats as true. A guard that
+  # classifies on the leading conjunct and ignores the suffix exempts a job that
+  # runs on every pull_request.
+  unsafe-mixed-interpolation:
+    if: "${{ github.event_name == 'push' && true }}trailing"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - run: echo "This job is deliberately eligible for pull_request"
+
+  # Positive control: the same predicate as a plain, unsuffixed interpolation,
+  # so a fixture failure cannot be explained by the guard having started
+  # rejecting every conjunctive push-only predicate.
+  safe-push-only:
+    if: "${{ github.event_name == 'push' && !startsWith(github.head_ref, 'release-please--') }}"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - run: echo "Trusted ref, already merged"

--- a/.github/tests/ci-idtoken-boundary-trailing-or-fixture.yaml
+++ b/.github/tests/ci-idtoken-boundary-trailing-or-fixture.yaml
@@ -1,0 +1,35 @@
+name: Deliberately unsafe OIDC-grant fixture (trailing disjunction)
+
+on:
+  pull_request:
+  push:
+
+permissions: {}
+
+jobs:
+  # The offender. Its predicate OPENS with the exact push-only conjunct, so a
+  # guard classifying on the leading conjunct alone exempts it — but `&&` binds
+  # tighter than `||` in GitHub expressions, so this parses as
+  # `(github.event_name == 'push' && false) || true` and is unconditionally
+  # true. The job runs on a pull_request while looking push-only.
+  unsafe-trailing-disjunct:
+    if: "${{ github.event_name == 'push' && false || true }}"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - run: echo "This job is deliberately eligible for pull_request"
+
+  # Positive control: a genuinely push-only job holding the same grant, whose
+  # predicate also carries a `&&`. The guard must leave this one alone, so a
+  # fixture failure cannot be explained by the guard having started rejecting
+  # every conjunctive predicate.
+  safe-push-only:
+    if: "${{ github.event_name == 'push' && !startsWith(github.head_ref, 'release-please--') }}"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - run: echo "Trusted ref, already merged"

--- a/.github/tests/ci-idtoken-boundary-writeall-job-fixture.yaml
+++ b/.github/tests/ci-idtoken-boundary-writeall-job-fixture.yaml
@@ -1,0 +1,29 @@
+name: Deliberately unsafe scalar write-all fixture (job scope)
+
+on:
+  pull_request:
+  push:
+
+permissions: {}
+
+jobs:
+  # `write-all` is the scalar shorthand GitHub expands to write on EVERY scope,
+  # id-token included — so this job holds the OIDC grant without the string
+  # "id-token" appearing anywhere. A guard that reads only the map member sees
+  # an empty value here and waves it through.
+  unsafe-scalar-write-all:
+    if: "${{ github.event_name != 'merge_group' }}"
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - run: echo "This job is deliberately eligible for pull_request"
+
+  # Positive control: read-all grants no write on any scope, so the guard must
+  # leave it alone. Without this, a fixture failure could be explained by the
+  # guard rejecting every scalar permissions value it meets.
+  safe-scalar-read-all:
+    if: "${{ github.event_name != 'merge_group' }}"
+    runs-on: ubuntu-latest
+    permissions: read-all
+    steps:
+      - run: echo "No write on any scope"

--- a/.github/tests/ci-idtoken-boundary-writeall-workflow-fixture.yaml
+++ b/.github/tests/ci-idtoken-boundary-writeall-workflow-fixture.yaml
@@ -1,0 +1,17 @@
+name: Deliberately unsafe scalar write-all fixture (workflow scope)
+
+on:
+  pull_request:
+  push:
+
+# At workflow scope the shorthand is inherited by every job that does not
+# override it, so no job needs a permissions block at all for the OIDC grant to
+# reach a pull_request-eligible job.
+permissions: write-all
+
+jobs:
+  inherits-the-grant:
+    if: "${{ github.event_name != 'merge_group' }}"
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Inherits write-all from the workflow"

--- a/.github/tests/test-ci-idtoken-boundary-blocks.sh
+++ b/.github/tests/test-ci-idtoken-boundary-blocks.sh
@@ -7,7 +7,9 @@
 #   2. the scalar `write-all` shorthand at JOB scope, which grants id-token
 #      without the string ever appearing;
 #   3. the same shorthand at WORKFLOW scope, inherited by a job that declares no
-#      permissions at all.
+#      permissions at all;
+#   4. a trailing top-level `||`, which short-circuits past a correct leading
+#      push-only conjunct because `&&` binds tighter than `||`.
 #
 # Each fixture also carries a job the guard must NOT flag (a genuinely push-only
 # job, or `read-all`), so a failure here can never be explained by the guard
@@ -55,6 +57,9 @@ check "$dir/ci-idtoken-boundary-writeall-job-fixture.yaml" \
 
 check "$dir/ci-idtoken-boundary-writeall-workflow-fixture.yaml" \
   "workflow-level permissions grant id-token: write"
+
+check "$dir/ci-idtoken-boundary-trailing-or-fixture.yaml" \
+  "pull_request-eligible jobs grant id-token: write to PR-editable workflows: unsafe-trailing-disjunct"
 
 if [[ "$status" -eq 0 ]]; then
   echo "PASS: OIDC boundary guard blocks every known fail-open shape"

--- a/.github/tests/test-ci-idtoken-boundary-blocks.sh
+++ b/.github/tests/test-ci-idtoken-boundary-blocks.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Failing-input counterpart to test-ci-idtoken-boundary.sh. The fixture's offender
+# names the push event inside a dead OR arm, so substring matching must not let it
+# masquerade as a push-only job. The fixture's second job IS push-only and holds
+# the same grant, so the expected message also proves the guard exempts it rather
+# than rejecting every id-token grant it encounters.
+
+set -euo pipefail
+
+guard="${1:-.github/tests/test-ci-idtoken-boundary.sh}"
+fixture="${2:-.github/tests/ci-idtoken-boundary-bad-fixture.yaml}"
+expected="pull_request-eligible jobs grant id-token: write to PR-editable workflows: unsafe-dead-disjunct"
+
+if [[ ! -f "$fixture" ]]; then
+  echo "::error::fixture $fixture is missing — the negative test cannot prove the gate bites"
+  exit 1
+fi
+
+out="$(bash "$guard" "$fixture" 2>&1)" && rc=0 || rc=$?
+
+if [[ "$rc" -eq 0 ]]; then
+  echo "::error file=$fixture::the guard PASSED a deliberately-bad fixture — it has stopped biting"
+  exit 1
+fi
+
+if ! grep -qF "$expected" <<<"$out"; then
+  echo "::error file=$fixture::the guard failed for the wrong reason; expected: $expected"
+  while IFS= read -r line; do echo "    got: $line"; done <<<"$out"
+  exit 1
+fi
+
+echo "PASS: OIDC boundary guard blocks a misleading event disjunct and exempts the push-only job"

--- a/.github/tests/test-ci-idtoken-boundary-blocks.sh
+++ b/.github/tests/test-ci-idtoken-boundary-blocks.sh
@@ -9,7 +9,9 @@
 #   3. the same shorthand at WORKFLOW scope, inherited by a job that declares no
 #      permissions at all;
 #   4. a trailing top-level `||`, which short-circuits past a correct leading
-#      push-only conjunct because `&&` binds tighter than `||`.
+#      push-only conjunct because `&&` binds tighter than `||`;
+#   5. text after the closing `}}`, which makes the scalar a non-empty STRING
+#      rather than the expression's boolean, so the job runs on every event.
 #
 # Each fixture also carries a job the guard must NOT flag (a genuinely push-only
 # job, or `read-all`), so a failure here can never be explained by the guard
@@ -22,8 +24,20 @@ dir="${2:-.github/tests}"
 
 status=0
 
+# The offender list is reported space-separated on one line, so `$expected`
+# remains a prefix of the output even when the guard also names the fixture's
+# positive control. Matching the expected string alone therefore accepts
+# `unsafe-scalar-write-all safe-scalar-read-all` — an indiscriminate guard the
+# positive controls exist to catch. Each control is named here and asserted
+# ABSENT, which is what makes the header's claim above true.
 check() {
-  local fixture=$1 expected=$2 out rc=0
+  local fixture=$1 expected=$2
+  shift 2
+  # bash 3.2 (the macOS system shell agents run this under) treats `("$@")` and
+  # `"${arr[@]}"` as unbound when empty, so the no-control case is guarded
+  # rather than expanded.
+  local controls=() out rc=0 control
+  if (($# > 0)); then controls=("$@"); fi
 
   if [[ ! -f "$fixture" ]]; then
     echo "::error::fixture $fixture is missing — the negative test cannot prove the gate bites"
@@ -46,20 +60,38 @@ check() {
     return
   fi
 
+  for control in ${controls[@]+"${controls[@]}"}; do
+    if grep -qF "$control" <<<"$out"; then
+      echo "::error file=$fixture::the guard also flagged positive control $control — it has become indiscriminate"
+      while IFS= read -r line; do echo "    got: $line"; done <<<"$out"
+      status=1
+      return
+    fi
+  done
+
   echo "PASS: $(basename "$fixture")"
 }
 
 check "$dir/ci-idtoken-boundary-bad-fixture.yaml" \
-  "pull_request-eligible jobs grant id-token: write to PR-editable workflows: unsafe-dead-disjunct"
+  "pull_request-eligible jobs grant id-token: write to PR-editable workflows: unsafe-dead-disjunct" \
+  safe-push-only
 
 check "$dir/ci-idtoken-boundary-writeall-job-fixture.yaml" \
-  "pull_request-eligible jobs grant id-token: write to PR-editable workflows: unsafe-scalar-write-all"
+  "pull_request-eligible jobs grant id-token: write to PR-editable workflows: unsafe-scalar-write-all" \
+  safe-scalar-read-all
 
+# The workflow-scope fixture fails before any job is classified, so it carries
+# no positive control to assert absent.
 check "$dir/ci-idtoken-boundary-writeall-workflow-fixture.yaml" \
   "workflow-level permissions grant id-token: write"
 
 check "$dir/ci-idtoken-boundary-trailing-or-fixture.yaml" \
-  "pull_request-eligible jobs grant id-token: write to PR-editable workflows: unsafe-trailing-disjunct"
+  "pull_request-eligible jobs grant id-token: write to PR-editable workflows: unsafe-trailing-disjunct" \
+  safe-push-only
+
+check "$dir/ci-idtoken-boundary-mixed-interpolation-fixture.yaml" \
+  "pull_request-eligible jobs grant id-token: write to PR-editable workflows: unsafe-mixed-interpolation" \
+  safe-push-only
 
 if [[ "$status" -eq 0 ]]; then
   echo "PASS: OIDC boundary guard blocks every known fail-open shape"

--- a/.github/tests/test-ci-idtoken-boundary-blocks.sh
+++ b/.github/tests/test-ci-idtoken-boundary-blocks.sh
@@ -1,32 +1,62 @@
 #!/usr/bin/env bash
-# Failing-input counterpart to test-ci-idtoken-boundary.sh. The fixture's offender
-# names the push event inside a dead OR arm, so substring matching must not let it
-# masquerade as a push-only job. The fixture's second job IS push-only and holds
-# the same grant, so the expected message also proves the guard exempts it rather
-# than rejecting every id-token grant it encounters.
+# Failing-input counterpart to test-ci-idtoken-boundary.sh. One case per way the
+# guard has been observed to fail open:
+#
+#   1. a dead OR arm naming the push event, so substring matching must not read
+#      the job as push-only;
+#   2. the scalar `write-all` shorthand at JOB scope, which grants id-token
+#      without the string ever appearing;
+#   3. the same shorthand at WORKFLOW scope, inherited by a job that declares no
+#      permissions at all.
+#
+# Each fixture also carries a job the guard must NOT flag (a genuinely push-only
+# job, or `read-all`), so a failure here can never be explained by the guard
+# having become indiscriminate.
 
 set -euo pipefail
 
 guard="${1:-.github/tests/test-ci-idtoken-boundary.sh}"
-fixture="${2:-.github/tests/ci-idtoken-boundary-bad-fixture.yaml}"
-expected="pull_request-eligible jobs grant id-token: write to PR-editable workflows: unsafe-dead-disjunct"
+dir="${2:-.github/tests}"
 
-if [[ ! -f "$fixture" ]]; then
-  echo "::error::fixture $fixture is missing — the negative test cannot prove the gate bites"
-  exit 1
+status=0
+
+check() {
+  local fixture=$1 expected=$2 out rc=0
+
+  if [[ ! -f "$fixture" ]]; then
+    echo "::error::fixture $fixture is missing — the negative test cannot prove the gate bites"
+    status=1
+    return
+  fi
+
+  out="$(bash "$guard" "$fixture" 2>&1)" && rc=0 || rc=$?
+
+  if [[ "$rc" -eq 0 ]]; then
+    echo "::error file=$fixture::the guard PASSED a deliberately-bad fixture — it has stopped biting"
+    status=1
+    return
+  fi
+
+  if ! grep -qF "$expected" <<<"$out"; then
+    echo "::error file=$fixture::the guard failed for the wrong reason; expected: $expected"
+    while IFS= read -r line; do echo "    got: $line"; done <<<"$out"
+    status=1
+    return
+  fi
+
+  echo "PASS: $(basename "$fixture")"
+}
+
+check "$dir/ci-idtoken-boundary-bad-fixture.yaml" \
+  "pull_request-eligible jobs grant id-token: write to PR-editable workflows: unsafe-dead-disjunct"
+
+check "$dir/ci-idtoken-boundary-writeall-job-fixture.yaml" \
+  "pull_request-eligible jobs grant id-token: write to PR-editable workflows: unsafe-scalar-write-all"
+
+check "$dir/ci-idtoken-boundary-writeall-workflow-fixture.yaml" \
+  "workflow-level permissions grant id-token: write"
+
+if [[ "$status" -eq 0 ]]; then
+  echo "PASS: OIDC boundary guard blocks every known fail-open shape"
 fi
-
-out="$(bash "$guard" "$fixture" 2>&1)" && rc=0 || rc=$?
-
-if [[ "$rc" -eq 0 ]]; then
-  echo "::error file=$fixture::the guard PASSED a deliberately-bad fixture — it has stopped biting"
-  exit 1
-fi
-
-if ! grep -qF "$expected" <<<"$out"; then
-  echo "::error file=$fixture::the guard failed for the wrong reason; expected: $expected"
-  while IFS= read -r line; do echo "    got: $line"; done <<<"$out"
-  exit 1
-fi
-
-echo "PASS: OIDC boundary guard blocks a misleading event disjunct and exempts the push-only job"
+exit "$status"

--- a/.github/tests/test-ci-idtoken-boundary.sh
+++ b/.github/tests/test-ci-idtoken-boundary.sh
@@ -25,6 +25,33 @@ grants_id_token() {
   return 1
 }
 
+# `&&` binds tighter than `||`, so `<push-check> && false || true` parses as
+# `(<push-check> && false) || true` — true on a pull_request however the
+# predicate opens. A leading push-only conjunct therefore proves nothing once a
+# top-level disjunction follows it, and classifying on that conjunct alone is a
+# fail-open. Only a disjunction the leading conjunct cannot bypass counts:
+# `||` inside parentheses is a sub-expression the conjunct still gates, and one
+# inside a single-quoted literal is not an operator at all. Doubled quotes are
+# GitHub's escape for a literal quote and toggle in pairs, so tracking the
+# string state alone reads them correctly.
+has_top_level_or() {
+  local expr=$1 i ch depth=0 in_str=0
+  for ((i = 0; i < ${#expr}; i++)); do
+    ch="${expr:i:1}"
+    if ((in_str)); then
+      [[ "$ch" == "'" ]] && in_str=0
+      continue
+    fi
+    case "$ch" in
+      "'") in_str=1 ;;
+      '(') ((depth++)) ;;
+      ')') ((depth > 0)) && ((depth--)) ;;
+      '|') [[ "${expr:i+1:1}" == '|' ]] && ((depth == 0)) && return 0 ;;
+    esac
+  done
+  return 1
+}
+
 # A workflow-level grant is inherited by every job that does not override it, so
 # it would defeat the per-job check below.
 root_tag="$(yq -r '.permissions | tag' "$ci")"
@@ -47,16 +74,19 @@ while IFS= read -r entry; do
   # Only a push-only job is exempt: its ref has already merged, so the workspace
   # is trusted. Classify on the LEADING top-level conjunct, matching
   # test-ci-merge-group-isolation.sh — a predicate that merely mentions the event
-  # elsewhere (`true || github.event_name == 'push'`) still runs on a pull_request.
-  # Anything unrecognised, including a job with no predicate, is treated as
-  # pull_request-eligible, so this fails closed.
+  # elsewhere (`true || github.event_name == 'push'`) still runs on a pull_request
+  # — and require that no top-level disjunction follows it, which would otherwise
+  # short-circuit past that conjunct entirely. Anything unrecognised, including a
+  # job with no predicate, is treated as pull_request-eligible, so this fails
+  # closed.
   compact_condition="$(
     sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//' <<<"$condition"
   )"
   expression="${compact_condition#\$\{\{}"
   expression="${expression#"${expression%%[![:space:]]*}"}"
   if [[ "$expression" == "github.event_name == 'push' &&"* ||
-    "$expression" == "github.event_name == 'push' }}"* ]]; then
+    "$expression" == "github.event_name == 'push' }}"* ]] &&
+    ! has_top_level_or "$expression"; then
     continue
   fi
 

--- a/.github/tests/test-ci-idtoken-boundary.sh
+++ b/.github/tests/test-ci-idtoken-boundary.sh
@@ -82,10 +82,21 @@ while IFS= read -r entry; do
   compact_condition="$(
     sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//' <<<"$condition"
   )"
-  expression="${compact_condition#\$\{\{}"
+  # Only a scalar that is EXACTLY one interpolation carries the expression's
+  # boolean. `${{ <expr> }}<suffix>` is a string: on a pull_request the
+  # interpolation renders `false` and the scalar becomes `falsesuffix`, which
+  # Actions evaluates as true — so a suffixed predicate runs on every event
+  # however push-only its expression looks. The closing `}}` must therefore be
+  # the first one and must end the scalar; anything else is left unrecognised
+  # and stays pull_request-eligible.
+  body="${compact_condition#\$\{\{}"
+  expression="${body%%\}\}*}"
+  [[ "${body#"$expression"}" == '}}' ]] || expression=''
   expression="${expression#"${expression%%[![:space:]]*}"}"
-  if [[ "$expression" == "github.event_name == 'push' &&"* ||
-    "$expression" == "github.event_name == 'push' }}"* ]] &&
+  expression="${expression%"${expression##*[![:space:]]}"}"
+  if [[ -n "$expression" ]] &&
+    [[ "$expression" == "github.event_name == 'push' &&"* ||
+    "$expression" == "github.event_name == 'push'" ]] &&
     ! has_top_level_or "$expression"; then
     continue
   fi

--- a/.github/tests/test-ci-idtoken-boundary.sh
+++ b/.github/tests/test-ci-idtoken-boundary.sh
@@ -14,19 +14,35 @@ fail() {
   exit 1
 }
 
+# `permissions:` is either a MAP of scopes or the scalar shorthand `write-all`,
+# which GitHub expands to write on every scope — id-token included. Reading only
+# the map member returns empty for the scalar, so the shorthand would sail past
+# a map-only check. Both shapes are resolved here and at job level below.
+grants_id_token() {
+  local tag=$1 raw=$2 member=$3
+  [[ "$tag" == '!!str' && "$raw" == 'write-all' ]] && return 0
+  [[ "$member" == 'write' ]] && return 0
+  return 1
+}
+
 # A workflow-level grant is inherited by every job that does not override it, so
 # it would defeat the per-job check below.
+root_tag="$(yq -r '.permissions | tag' "$ci")"
+root_raw="$(yq -r '.permissions | tostring' "$ci")"
 root_idtoken="$(yq -r '.permissions."id-token" // ""' "$ci")"
-[[ "$root_idtoken" == "write" ]] &&
+if grants_id_token "$root_tag" "$root_raw" "$root_idtoken"; then
   fail "workflow-level permissions grant id-token: write, which pull_request-eligible jobs inherit"
+fi
 
 offenders=()
 while IFS= read -r entry; do
   job="$(yq -r '.job' <<<"$entry")"
   condition="$(yq -r '.condition' <<<"$entry")"
   idtoken="$(yq -r '.idtoken' <<<"$entry")"
+  ptag="$(yq -r '.ptag' <<<"$entry")"
+  praw="$(yq -r '.praw' <<<"$entry")"
 
-  [[ "$idtoken" == "write" ]] || continue
+  grants_id_token "$ptag" "$praw" "$idtoken" || continue
 
   # Only a push-only job is exempt: its ref has already merged, so the workspace
   # is trusted. Classify on the LEADING top-level conjunct, matching
@@ -47,7 +63,7 @@ while IFS= read -r entry; do
   offenders+=("$job")
 done < <(
   yq -o=json -I=0 \
-    '.jobs | to_entries[] | {"job": .key, "condition": (.value.if // ""), "idtoken": (.value.permissions."id-token" // "")}' \
+    '.jobs | to_entries[] | {"job": .key, "condition": (.value.if // ""), "idtoken": (.value.permissions."id-token" // ""), "ptag": (.value.permissions | tag), "praw": (.value.permissions | tostring)}' \
     "$ci"
 )
 

--- a/.github/tests/test-ci-idtoken-boundary.sh
+++ b/.github/tests/test-ci-idtoken-boundary.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Guards this file's header rule for OIDC specifically: a job that can run on a
+# pull_request checks out a PR-controlled workspace, including the local reusable
+# workflows it calls, so granting it id-token: write lets a PR mint a real OIDC
+# token. A called workflow gating its publish job on `if: ${{ !inputs.dry-run }}`
+# is not a boundary — it is a property of the very file the PR may edit.
+
+set -euo pipefail
+
+ci="${1:-.github/workflows/ci.yaml}"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+# A workflow-level grant is inherited by every job that does not override it, so
+# it would defeat the per-job check below.
+root_idtoken="$(yq -r '.permissions."id-token" // ""' "$ci")"
+[[ "$root_idtoken" == "write" ]] &&
+  fail "workflow-level permissions grant id-token: write, which pull_request-eligible jobs inherit"
+
+offenders=()
+while IFS= read -r entry; do
+  job="$(yq -r '.job' <<<"$entry")"
+  condition="$(yq -r '.condition' <<<"$entry")"
+  idtoken="$(yq -r '.idtoken' <<<"$entry")"
+
+  [[ "$idtoken" == "write" ]] || continue
+
+  # Only a push-only job is exempt: its ref has already merged, so the workspace
+  # is trusted. Classify on the LEADING top-level conjunct, matching
+  # test-ci-merge-group-isolation.sh — a predicate that merely mentions the event
+  # elsewhere (`true || github.event_name == 'push'`) still runs on a pull_request.
+  # Anything unrecognised, including a job with no predicate, is treated as
+  # pull_request-eligible, so this fails closed.
+  compact_condition="$(
+    sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//' <<<"$condition"
+  )"
+  expression="${compact_condition#\$\{\{}"
+  expression="${expression#"${expression%%[![:space:]]*}"}"
+  if [[ "$expression" == "github.event_name == 'push' &&"* ||
+    "$expression" == "github.event_name == 'push' }}"* ]]; then
+    continue
+  fi
+
+  offenders+=("$job")
+done < <(
+  yq -o=json -I=0 \
+    '.jobs | to_entries[] | {"job": .key, "condition": (.value.if // ""), "idtoken": (.value.permissions."id-token" // "")}' \
+    "$ci"
+)
+
+if ((${#offenders[@]} > 0)); then
+  fail "pull_request-eligible jobs grant id-token: write to PR-editable workflows: ${offenders[*]}"
+fi
+
+echo "PASS: id-token: write is confined to push-only jobs"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2289,15 +2289,26 @@ jobs:
         run: bash .github/tests/test-create-release-config.sh
 
   test-deploy-github-pages:
-    if: "${{ github.event_name != 'merge_group' && !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
+    if: "${{ github.event_name == 'push' && !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
     name: "[Test] Deploy GitHub Pages - Dry Run"
     uses: ./.github/workflows/deploy-github-pages.yaml
-    # No id-token: write. On a pull_request this job's workspace — including
-    # deploy-github-pages.yaml itself — is PR-controlled, so the grant would let a
-    # PR mint a real OIDC token. The dry-run reaches no job that uses one.
+    # PUSH-ONLY, deliberately, like test-publish-caller-pin-live below. This job
+    # holds id-token: write, and on a pull_request the workspace it would hand to
+    # deploy-github-pages.yaml is PR-controlled — a PR that adds an ungated job to
+    # that called workflow inherits the grant and can mint a real OIDC token.
+    #
+    # The grant cannot simply be dropped instead: a called workflow's job declares
+    # its own permissions, and GitHub validates them against the caller's grant when
+    # the run STARTS, before the `if: ${{ !inputs.dry-run }}` gate skips the job. A
+    # caller granting less than the called job declares fails the whole workflow at
+    # startup, so restricting the event is the available fix.
+    #
+    # The trade-off is the one the live-OIDC job already accepts: these dry-runs
+    # surface a regression after merge rather than on the PR.
     permissions:
       contents: read
       pages: write
+      id-token: write
     with:
       dry-run: true
 
@@ -2312,14 +2323,15 @@ jobs:
       dry-run: true
 
   test-publish-app:
-    if: "${{ github.event_name != 'merge_group' && !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
+    if: "${{ github.event_name == 'push' && !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
     name: "[Test] Publish App - Dry Run"
     uses: ./.github/workflows/publish-app.yaml
-    # No id-token: write — see test-deploy-github-pages. The signing step lives in
-    # publish-app.yaml's publish job, which the dry-run skips.
+    # PUSH-ONLY — see test-deploy-github-pages for why the grant cannot just be
+    # dropped. The signing step lives in publish-app.yaml's publish job.
     permissions:
       contents: read
       packages: write
+      id-token: write
     with:
       app-name: app
       dry-run: true
@@ -2329,14 +2341,15 @@ jobs:
       # below.
 
   test-publish-app-caller-pin:
-    if: "${{ github.event_name != 'merge_group' && !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
+    if: "${{ github.event_name == 'push' && !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
     name: "[Test] Publish App - Dry Run (caller-pin enabled)"
     uses: ./.github/workflows/publish-app.yaml
-    # No id-token: write — see test-deploy-github-pages. This job is a schema
-    # check; the guard it covers runs in the skipped publish job.
+    # PUSH-ONLY — see test-deploy-github-pages. This job is a schema check; the
+    # guard it covers runs in the skipped publish job.
     permissions:
       contents: read
       packages: write
+      id-token: write
     with:
       app-name: app
       dry-run: true
@@ -2417,27 +2430,29 @@ jobs:
           echo "guard correctly rejected $RESOLVED_REF ✅"
 
   test-publish-manifests:
-    if: "${{ github.event_name != 'merge_group' && !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
+    if: "${{ github.event_name == 'push' && !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
     name: "[Test] Publish Manifests - Dry Run"
     uses: ./.github/workflows/publish-manifests.yaml
-    # No id-token: write — see test-deploy-github-pages. The signing step lives in
-    # publish-manifests.yaml's publish job, which the dry-run skips.
+    # PUSH-ONLY — see test-deploy-github-pages for why the grant cannot just be
+    # dropped. The signing step lives in publish-manifests.yaml's publish job.
     permissions:
       contents: read
       packages: write
+      id-token: write
     with:
       dry-run: true
       # Default-off half, as above: enable-caller-pin is deliberately omitted.
 
   test-publish-manifests-caller-pin:
-    if: "${{ github.event_name != 'merge_group' && !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
+    if: "${{ github.event_name == 'push' && !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
     name: "[Test] Publish Manifests - Dry Run (caller-pin enabled)"
     uses: ./.github/workflows/publish-manifests.yaml
-    # No id-token: write — see test-deploy-github-pages. This job is a schema
-    # check; the guard it covers runs in the skipped publish job.
+    # PUSH-ONLY — see test-deploy-github-pages. This job is a schema check; the
+    # guard it covers runs in the skipped publish job.
     permissions:
       contents: read
       packages: write
+      id-token: write
     with:
       dry-run: true
       # Enabled half. publish-manifests.yaml's publish-manifests job is gated on

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1913,6 +1913,14 @@ jobs:
         shell: bash
         run: bash .github/tests/test-ci-merge-group-isolation-blocks.sh
 
+      - name: 🔐 Check OIDC grants stay off pull_request-eligible jobs
+        shell: bash
+        run: bash .github/tests/test-ci-idtoken-boundary.sh
+
+      - name: 🔐 Check OIDC boundary guard blocks unsafe input
+        shell: bash
+        run: bash .github/tests/test-ci-idtoken-boundary-blocks.sh
+
       - name: 🔒 Check required status gate stays workspace-independent
         shell: bash
         run: bash .github/tests/test-ci-required-checks-boundary.sh
@@ -2284,10 +2292,12 @@ jobs:
     if: "${{ github.event_name != 'merge_group' && !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
     name: "[Test] Deploy GitHub Pages - Dry Run"
     uses: ./.github/workflows/deploy-github-pages.yaml
+    # No id-token: write. On a pull_request this job's workspace — including
+    # deploy-github-pages.yaml itself — is PR-controlled, so the grant would let a
+    # PR mint a real OIDC token. The dry-run reaches no job that uses one.
     permissions:
       contents: read
       pages: write
-      id-token: write
     with:
       dry-run: true
 
@@ -2305,10 +2315,11 @@ jobs:
     if: "${{ github.event_name != 'merge_group' && !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
     name: "[Test] Publish App - Dry Run"
     uses: ./.github/workflows/publish-app.yaml
+    # No id-token: write — see test-deploy-github-pages. The signing step lives in
+    # publish-app.yaml's publish job, which the dry-run skips.
     permissions:
       contents: read
       packages: write
-      id-token: write
     with:
       app-name: app
       dry-run: true
@@ -2321,10 +2332,11 @@ jobs:
     if: "${{ github.event_name != 'merge_group' && !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
     name: "[Test] Publish App - Dry Run (caller-pin enabled)"
     uses: ./.github/workflows/publish-app.yaml
+    # No id-token: write — see test-deploy-github-pages. This job is a schema
+    # check; the guard it covers runs in the skipped publish job.
     permissions:
       contents: read
       packages: write
-      id-token: write
     with:
       app-name: app
       dry-run: true
@@ -2408,10 +2420,11 @@ jobs:
     if: "${{ github.event_name != 'merge_group' && !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
     name: "[Test] Publish Manifests - Dry Run"
     uses: ./.github/workflows/publish-manifests.yaml
+    # No id-token: write — see test-deploy-github-pages. The signing step lives in
+    # publish-manifests.yaml's publish job, which the dry-run skips.
     permissions:
       contents: read
       packages: write
-      id-token: write
     with:
       dry-run: true
       # Default-off half, as above: enable-caller-pin is deliberately omitted.
@@ -2420,10 +2433,11 @@ jobs:
     if: "${{ github.event_name != 'merge_group' && !startsWith(github.head_ref, 'release-please--') && !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
     name: "[Test] Publish Manifests - Dry Run (caller-pin enabled)"
     uses: ./.github/workflows/publish-manifests.yaml
+    # No id-token: write — see test-deploy-github-pages. This job is a schema
+    # check; the guard it covers runs in the skipped publish job.
     permissions:
       contents: read
       packages: write
-      id-token: write
     with:
       dry-run: true
       # Enabled half. publish-manifests.yaml's publish-manifests job is gated on


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

Five CI test jobs handed the OIDC signing permission (`id-token: write`) to workflows that a pull
request is able to edit. Nothing enforced the boundary — the jobs were safe only because the
publish steps they call happen to be switched off during a dry run, which is a property of the very
file a PR can change. A pull request that added an ungated step could therefore mint a real signing
token. This was demonstrated in an earlier PR, not theorised.

The issue was filed against three jobs; two more have appeared since, which is the argument for a
guard rather than a one-off cleanup.

### What this changes

The five jobs now run only after merge, so a pull request never hands the signing permission to a
workflow it can edit. A new check fails CI if any pull-request-eligible job gains that permission,
so this cannot come back.

The first approach was simply to drop the permission, which the issue preferred. That turned out not
to be available: GitHub checks a called workflow's declared permissions against the caller's grant
when the run starts, before the dry-run switch skips the job, so the workflow failed to start at all.
Restricting when the jobs run reaches the same end.

**Trade-off worth knowing:** these five dry-run tests now report a regression after merge instead of
on the pull request. That is the same trade the existing live-OIDC test already makes, and the
signing behaviour they cover stays covered by the checks that do run on PRs.

Fixes #867
