### PR TITLE
ci: stop pipefail SIGPIPE inverting two self-test assertions

### DIFF
--- a/.github/tests/agent-skills-retry-env.sh
+++ b/.github/tests/agent-skills-retry-env.sh
@@ -73,9 +73,14 @@ case "$fwd" in
   *inputs.experimental-rate-limit-retry*) : ;;
   *) echo "::error::setup-agent-skills must forward the experimental-rate-limit-retry input into INPUT_EXPERIMENTAL_RATE_LIMIT_RETRY (got: $fwd)"; exit 1 ;;
 esac
+# Capture, then match in-shell. Under `set -o pipefail`, `<writer> | grep -q` reports
+# the pipeline as failed when grep exits at its first match before the writer has
+# finished writing: the writer takes SIGPIPE (141) and pipefail promotes that to the
+# pipeline status, so a SATISFIED assertion is recorded as a violation.
 # shellcheck disable=SC2016  # match the literal source line, not an expansion
-if ! yq -r '.runs.steps[] | select(.id=="install") | .run' "$ay" \
-  | grep -qF 'source "${GITHUB_ACTION_PATH}/../.scripts/agent-skills-retry-env.sh" "${INPUT_EXPERIMENTAL_RATE_LIMIT_RETRY:-false}"'; then
+src_needle='source "${GITHUB_ACTION_PATH}/../.scripts/agent-skills-retry-env.sh" "${INPUT_EXPERIMENTAL_RATE_LIMIT_RETRY:-false}"'
+install_run="$(yq -r '.runs.steps[] | select(.id=="install") | .run' "$ay")"
+if [[ $install_run != *"$src_needle"* ]]; then
   echo "::error::setup-agent-skills must source agent-skills-retry-env.sh with INPUT_EXPERIMENTAL_RATE_LIMIT_RETRY"
   exit 1
 fi

--- a/.github/tests/gh-skill-install-script.sh
+++ b/.github/tests/gh-skill-install-script.sh
@@ -51,7 +51,8 @@ if [ "$(grep -c '^call:' "$log")" -ne 2 ]; then
   cat "$log"
   exit 1
 fi
-if ! tail -n 1 "$log" | grep -q -- '--force'; then
+last_call="$(tail -n 1 "$log")"
+if [[ $last_call != *"--force"* ]]; then
   echo "::error::expected second gh call to add --force"
   cat "$log"
   exit 1


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

Two of this repo's self-tests assert a condition by piping a command into `grep -q`. Under
`pipefail` that construct can report a **satisfied** assertion as a violation: `grep -q` stops at the
first match, the writer is then killed by the broken pipe, and that write error becomes the
pipeline's result.

The wiring check in `agent-skills-retry-env.sh` hits this. On a developer or agent machine it fails
20 times out of 20 against **correct** wiring, and the error message points at the action's wiring
rather than at the test — so the time goes into hunting a defect that is not there.

To be precise about the blast radius: **CI is not affected and was not red.** The behaviour depends
on the local `grep` implementation, so it bites macOS checkouts and leaves the Linux runners green.
That is why it has survived unnoticed.

### What this changes

Both checks now capture the output first and match it in the shell, so there is no reader that can
kill the writer. No assertion changes meaning: each one was ablated by breaking the behaviour it
guards, and each correctly failed.