### PR TITLE
fix(create-issues-from-todos): pin the scanner image to an immutable digest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -118,6 +118,13 @@ jobs:
             echo "::error::create-issues-from-todos must keep the pinned todo-to-issue container image floor."
             exit 1
           }
+          # The image runs with github.token and the App PROJECTS_SECRET, so a mutable
+          # tag would let an upstream retag execute unreviewed code with those
+          # credentials. Require an immutable digest (devantler-tech/actions#942).
+          grep -Eq 'TODO_TO_ISSUE_IMAGE:[[:space:]]*ghcr\.io/alstr/todo-to-issue-action:v[0-9]+\.[0-9]+\.[0-9]+@sha256:[0-9a-f]{64}$' "$action_file" || {
+            echo "::error::create-issues-from-todos must pin the todo-to-issue image to an immutable @sha256 digest, not a bare tag."
+            exit 1
+          }
 
       - name: 🧪 Run create-issues-from-todos
         uses: ./create-issues-from-todos

--- a/create-issues-from-todos/action.yaml
+++ b/create-issues-from-todos/action.yaml
@@ -70,7 +70,12 @@ runs:
         INPUT_ESCAPE: "true"
         INPUT_NO_STANDARD: "false"
         INPUT_INSERT_ISSUE_URLS: "false"
-        TODO_TO_ISSUE_IMAGE: ghcr.io/alstr/todo-to-issue-action:v5.1.15
+        # Pinned by DIGEST, not by tag: this image runs with `github.token` and the
+        # App `PROJECTS_SECRET`, so a retag of `:v5.1.15` upstream would otherwise
+        # execute unreviewed code with those credentials. The tag is kept in front of
+        # the digest for human-readable version context — Docker resolves the digest.
+        # When raising the floor, update BOTH halves in the same change.
+        TODO_TO_ISSUE_IMAGE: ghcr.io/alstr/todo-to-issue-action:v5.1.15@sha256:a1794cab7e7a0306d6f74dd5249734f2c0b49e47d7549c6cdca4421bced67c9d
       run: |
         retry() { bash "${RUNNER_TEMP}/devantler-actions-retry.sh" "$@"; }
 


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

The to-do scanner runs a third-party container with `github.token` and an App `PROJECTS_SECRET`, but picked the image by a **mutable tag**. A retag upstream would run unreviewed code with those credentials on the next scheduled TODOs run in every consumer repo.

### What

Pins the image to its immutable digest and adds a CI invariant so it cannot regress to a bare tag. The version tag stays in front of the digest for readability; raising the floor now means updating both halves together.

The retry wrapper is deliberately kept — upstream fetches `github/linguist` resources unauthenticated on every run and aborts on any non-200 (#483).

Fixes #942
