### PR TITLE
ci(tests): declare the currently-patched Go version in go-valid-fixture

### DIFF
--- a/.github/tests/go-valid-fixture/go.mod
+++ b/.github/tests/go-valid-fixture/go.mod
@@ -1,3 +1,3 @@
 module example.com/go-valid-fixture
 
-go 1.26.5
+go 1.26.6


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

No pull request in this repository can merge right now. Eight new Go standard-library advisories were
published against the exact Go version our Go test fixture declares, so the vulnerability scanner
fails, which fails the required checks — on every PR, regardless of what it changes.

`main` looks fine only because nothing has pushed to it since the advisories appeared. The next thing
that merges would turn it red.

### What

Moves the fixture onto the currently-patched Go version. One line.

This keeps the existing design rather than second-guessing it — the fixture pins a patched Go version
on purpose, and the alternative was already tried and abandoned in #492. The cost of that design is a
manual bump whenever Go patches a stdlib advisory, which is what fell behind here; automating that
bump is written up as follow-up on the issue rather than guessed at in this change.

Fixes #946
